### PR TITLE
Enable About menu hover dropdown

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -69,13 +69,22 @@ export default function Header() {
           <Link href="/" className="hover:underline">
             Home
           </Link>
-          <div className="relative">
+          <div
+            className="relative"
+            onMouseEnter={() => setAboutOpen(true)}
+            onMouseLeave={() => setAboutOpen(false)}
+            onFocus={() => setAboutOpen(true)}
+            onBlur={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                setAboutOpen(false);
+              }
+            }}
+          >
             <button
               type="button"
               className="hover:underline"
               aria-haspopup="menu"
               aria-expanded={aboutOpen}
-              onClick={() => setAboutOpen((o) => !o)}
             >
               About
             </button>


### PR DESCRIPTION
## Summary
- open About submenu on hover and focus, hide when pointer/focus leaves

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: requires manual ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68a29fdccb28832c9661826af5505c1d