### PR TITLE
Remove Plan a Visit button from header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -110,12 +110,6 @@ export default function Header() {
               {item.label}
             </Link>
           ))}
-          <Link
-            href="/visit"
-            className="rounded bg-indigo-600 px-3 py-2 font-semibold text-white hover:bg-indigo-700"
-          >
-            Plan a Visit
-          </Link>
         </nav>
         <button
           className="md:hidden"
@@ -199,12 +193,6 @@ export default function Header() {
               {item.label}
             </Link>
           ))}
-          <Link
-            href="/visit"
-            className="rounded bg-indigo-600 px-3 py-2 font-semibold text-white hover:bg-indigo-700"
-          >
-            Plan a Visit
-          </Link>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- remove Plan a Visit button from desktop and mobile header navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive prompt to configure ESLint)


------
https://chatgpt.com/codex/tasks/task_e_68a3b0e8f31c832ca816b8717c4d830e