### PR TITLE
Add announcement banner and Google Maps block

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,24 @@
+import AnnouncementBanner from "../components/AnnouncementBanner";
+import MapBlock from "../components/MapBlock";
+
 export default function Page() {
-  return <h1 className="text-2xl font-semibold">Home</h1>;
+  const message =
+    "Pop-up Workshop: SUPER DOES IT NEED TO BE ENVEN LOGNER WTF LONG TO ENFORCE MARQUEE SCROLLING LOL Build with Next.js — Sat, Aug 23, 2025, 2:00–4:00 PM PT · Venue: 123 Market St, San Francisco, CA 94103 · RSVP now";
+  const address = "123 Market St, San Francisco, CA 94103";
+
+  return (
+    <main className="space-y-6">
+      <AnnouncementBanner message={message} />
+      <section className="p-4">
+        <h1 className="text-2xl font-semibold">Home</h1>
+        <div className="mt-4">
+          <h2 className="text-lg font-medium">Event Location</h2>
+          <MapBlock address={address} />
+          <p className="text-sm text-gray-600">
+            Open in Maps: <a className="underline" href={`https://maps.google.com/?q=${encodeURIComponent(address)}`}>Google Maps</a>
+          </p>
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -19,3 +19,27 @@
     @apply pointer-events-none absolute inset-0 bg-black/30 dark:bg-black/60;
   }
 }
+
+@layer utilities {
+  /* Marquee starts on-screen and loops seamlessly with duplicated content */
+  @keyframes marquee {
+    0% {
+      transform: translateX(0);
+    }
+    100% {
+      transform: translateX(-50%);
+    }
+  }
+
+  .animate-marquee {
+    animation: marquee 20s linear infinite;
+    will-change: transform;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-marquee {
+      animation-duration: 0.01ms;
+      animation-iteration-count: 1;
+    }
+  }
+}

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -31,8 +31,8 @@ export default function AnnouncementBanner({
   }
 
   return (
-    <div className="relative bg-indigo-600 px-4 py-2 text-center text-sm text-white">
-      <span>{message}</span>
+    <div className="relative rounded-md bg-indigo-600 px-4 py-3 pr-10 text-center text-sm text-white">
+      <p className="overflow-x-auto whitespace-nowrap">{message}</p>
       <button
         type="button"
         aria-label="Dismiss announcement"

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -15,7 +15,7 @@ export default function AnnouncementBanner({
     if (typeof window === "undefined") return;
     const stored = localStorage.getItem("announcement-dismissed");
     if (stored === "true") {
-      setDismissed(true);
+      // setDismissed(true);
     }
   }, []);
 
@@ -31,12 +31,23 @@ export default function AnnouncementBanner({
   }
 
   return (
-    <div className="relative overflow-hidden rounded-md bg-indigo-600 px-4 py-3 pr-10 text-center text-sm text-white">
-      <p className="inline-block whitespace-nowrap animate-marquee">{message}</p>
+    <div className="relative overflow-hidden rounded-md bg-indigo-600 px-4 py-3 pr-4 text-center text-sm text-white">
+      <div className="mr-4 overflow-hidden">
+        <div className="inline-flex animate-marquee whitespace-nowrap [--marquee-gap:6rem]">
+          <span className="pr-[var(--marquee-gap)]">{message}</span>
+          <span className="pr-[var(--marquee-gap)]">{message}</span>
+        </div>
+      </div>
+
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute right-8 top-0 h-full w-10 bg-gradient-to-l from-indigo-600 to-indigo-600/0"
+      />
+
       <button
         type="button"
         aria-label="Dismiss announcement"
-        className="absolute right-2 top-1/2 -translate-y-1/2 text-xl leading-none"
+        className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer text-xl leading-none z-10"
         onClick={handleDismiss}
       >
         ×

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type AnnouncementBannerProps = {
+  message: string;
+};
+
+export default function AnnouncementBanner({
+  message,
+}: AnnouncementBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("announcement-dismissed");
+    if (stored === "true") {
+      setDismissed(true);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("announcement-dismissed", "true");
+    }
+  };
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <div className="relative bg-indigo-600 px-4 py-2 text-center text-sm text-white">
+      <span>{message}</span>
+      <button
+        type="button"
+        aria-label="Dismiss announcement"
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-xl leading-none"
+        onClick={handleDismiss}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -31,8 +31,8 @@ export default function AnnouncementBanner({
   }
 
   return (
-    <div className="relative rounded-md bg-indigo-600 px-4 py-3 pr-10 text-center text-sm text-white">
-      <p className="overflow-x-auto whitespace-nowrap">{message}</p>
+    <div className="relative overflow-hidden rounded-md bg-indigo-600 px-4 py-3 pr-10 text-center text-sm text-white">
+      <p className="inline-block whitespace-nowrap animate-marquee">{message}</p>
       <button
         type="button"
         aria-label="Dismiss announcement"

--- a/components/MapBlock.tsx
+++ b/components/MapBlock.tsx
@@ -8,10 +8,11 @@ export default function MapBlock({
   address = "123 Main St, Hometown, ST 12345",
 }: MapBlockProps) {
   const query = encodeURIComponent(address);
-  const hasKey = Boolean(process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY);
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY;
+  const hasKey = Boolean(apiKey);
   const staticMapUrl = hasKey
-    ? `https://maps.googleapis.com/maps/api/staticmap?center=${query}&zoom=15&size=600x300&markers=${query}&key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY}`
-    : "https://via.placeholder.com/600x300.png?text=Map+Unavailable";
+    ? `https://maps.googleapis.com/maps/api/staticmap?center=${query}&zoom=15&size=600x300&markers=${query}&key=${apiKey}`
+    : "/map-placeholder.svg";
   const mapLink = `https://www.google.com/maps/search/?api=1&query=${query}`;
 
   return (

--- a/components/MapBlock.tsx
+++ b/components/MapBlock.tsx
@@ -8,11 +8,10 @@ export default function MapBlock({
   address = "123 Main St, Hometown, ST 12345",
 }: MapBlockProps) {
   const query = encodeURIComponent(address);
-  const staticMapUrl =
-    `https://maps.googleapis.com/maps/api/staticmap?center=${query}&zoom=15&size=600x300&markers=${query}` +
-    (process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY
-      ? `&key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY}`
-      : "");
+  const hasKey = Boolean(process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY);
+  const staticMapUrl = hasKey
+    ? `https://maps.googleapis.com/maps/api/staticmap?center=${query}&zoom=15&size=600x300&markers=${query}&key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY}`
+    : "https://via.placeholder.com/600x300.png?text=Map+Unavailable";
   const mapLink = `https://www.google.com/maps/search/?api=1&query=${query}`;
 
   return (
@@ -29,6 +28,7 @@ export default function MapBlock({
           width={600}
           height={300}
           className="h-auto w-full"
+          unoptimized={!hasKey}
         />
       </a>
     </div>

--- a/components/MapBlock.tsx
+++ b/components/MapBlock.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image";
+
+type MapBlockProps = {
+  address?: string;
+};
+
+export default function MapBlock({
+  address = "123 Main St, Hometown, ST 12345",
+}: MapBlockProps) {
+  const query = encodeURIComponent(address);
+  const staticMapUrl =
+    `https://maps.googleapis.com/maps/api/staticmap?center=${query}&zoom=15&size=600x300&markers=${query}` +
+    (process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY
+      ? `&key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY}`
+      : "");
+  const mapLink = `https://www.google.com/maps/search/?api=1&query=${query}`;
+
+  return (
+    <div className="my-6">
+      <a
+        href={mapLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block"
+      >
+        <Image
+          src={staticMapUrl}
+          alt={`Map showing ${address}`}
+          width={600}
+          height={300}
+          className="h-auto w-full"
+        />
+      </a>
+    </div>
+  );
+}
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "maps.googleapis.com",
+        pathname: "/maps/api/**",
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,11 @@ const nextConfig = {
         hostname: "maps.googleapis.com",
         pathname: "/maps/api/**",
       },
+      {
+        protocol: "https",
+        hostname: "via.placeholder.com",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -8,11 +8,6 @@ const nextConfig = {
         hostname: "maps.googleapis.com",
         pathname: "/maps/api/**",
       },
-      {
-        protocol: "https",
-        hostname: "via.placeholder.com",
-        pathname: "/**",
-      },
     ],
   },
 };

--- a/public/map-placeholder.svg
+++ b/public/map-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="600" height="300" fill="#e5e7eb" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#6b7280" font-size="24">Map Unavailable</text>
+</svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,15 @@ module.exports = {
           950: "#404040",
         },
       },
+      keyframes: {
+        marquee: {
+          "0%": { transform: "translateX(100%)" },
+          "100%": { transform: "translateX(-100%)" },
+        },
+      },
+      animation: {
+        marquee: "marquee 15s linear infinite",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add dismissible `AnnouncementBanner` component
- add `MapBlock` with static Google Map and link
- allow remote Google Maps images in Next.js config

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3bc509e38832cabd4cdf61cd5f63f