### PR TITLE
feat: add content cards

### DIFF
--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,0 +1,48 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export type Event = {
+  title: string;
+  date: string;
+  location?: string;
+  description?: string;
+  image?: string;
+  href?: string;
+};
+
+export function EventCard({ event }: { event: Event }) {
+  return (
+    <div className="card flex h-full flex-col">
+      {event.image && (
+        <Image
+          src={event.image}
+          alt=""
+          width={400}
+          height={192}
+          className="h-48 w-full object-cover"
+        />
+      )}
+      <div className="flex flex-1 flex-col p-4">
+        <h3 className="text-lg font-semibold">{event.title}</h3>
+        <p className="mt-1 text-sm text-gray-600">
+          {event.date}
+          {event.location ? ` • ${event.location}` : ""}
+        </p>
+        {event.description && (
+          <p className="mt-2 flex-1 text-sm text-gray-700">
+            {event.description}
+          </p>
+        )}
+        {event.href && (
+          <Link
+            href={event.href}
+            className="mt-4 text-sm font-medium text-blue-600 hover:underline"
+          >
+            Learn more
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/components/EventList.tsx
+++ b/components/EventList.tsx
@@ -1,0 +1,16 @@
+import { Event, EventCard } from "./EventCard";
+
+export function EventList({ events }: { events: Event[] }) {
+  if (events.length === 0) {
+    return <p className="text-sm text-gray-600">No events found.</p>;
+  }
+
+  return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {events.map((ev) => (
+        <EventCard key={ev.title + ev.date} event={ev} />
+      ))}
+    </div>
+  );
+}
+

--- a/components/MinistryCard.tsx
+++ b/components/MinistryCard.tsx
@@ -1,0 +1,40 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export type Ministry = {
+  name: string;
+  description: string;
+  image?: string;
+  href?: string;
+};
+
+export function MinistryCard({ ministry }: { ministry: Ministry }) {
+  return (
+    <div className="card flex h-full flex-col">
+      {ministry.image && (
+        <Image
+          src={ministry.image}
+          alt=""
+          width={400}
+          height={192}
+          className="h-48 w-full object-cover"
+        />
+      )}
+      <div className="flex flex-1 flex-col p-4">
+        <h3 className="text-lg font-semibold">{ministry.name}</h3>
+        <p className="mt-2 flex-1 text-sm text-gray-700">
+          {ministry.description}
+        </p>
+        {ministry.href && (
+          <Link
+            href={ministry.href}
+            className="mt-4 text-sm font-medium text-blue-600 hover:underline"
+          >
+            Learn more
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/components/SermonCard.tsx
+++ b/components/SermonCard.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+
+export type Sermon = {
+  title: string;
+  date: string;
+  speaker?: string;
+  passage?: string;
+  description?: string;
+  audioUrl?: string;
+  href?: string;
+};
+
+export function SermonCard({ sermon }: { sermon: Sermon }) {
+  return (
+    <div className="card flex h-full flex-col">
+      <div className="flex flex-1 flex-col p-4">
+        <h3 className="text-lg font-semibold">{sermon.title}</h3>
+        <p className="mt-1 text-sm text-gray-600">
+          {sermon.date}
+          {sermon.speaker ? ` • ${sermon.speaker}` : ""}
+        </p>
+        {sermon.passage && (
+          <p className="mt-1 text-sm italic text-gray-600">
+            {sermon.passage}
+          </p>
+        )}
+        {sermon.description && (
+          <p className="mt-2 flex-1 text-sm text-gray-700">
+            {sermon.description}
+          </p>
+        )}
+        {(sermon.audioUrl || sermon.href) && (
+          <div className="mt-4">
+            {sermon.audioUrl && (
+              <a
+                href={sermon.audioUrl}
+                className="text-sm font-medium text-blue-600 hover:underline"
+              >
+                Listen
+              </a>
+            )}
+            {sermon.href && sermon.audioUrl && " • "}
+            {sermon.href && (
+              <Link
+                href={sermon.href}
+                className="text-sm font-medium text-blue-600 hover:underline"
+              >
+                Details
+              </Link>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/components/SermonList.tsx
+++ b/components/SermonList.tsx
@@ -1,0 +1,16 @@
+import { Sermon, SermonCard } from "./SermonCard";
+
+export function SermonList({ sermons }: { sermons: Sermon[] }) {
+  if (sermons.length === 0) {
+    return <p className="text-sm text-gray-600">No sermons found.</p>;
+  }
+
+  return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {sermons.map((sermon) => (
+        <SermonCard key={sermon.title + sermon.date} sermon={sermon} />
+      ))}
+    </div>
+  );
+}
+

--- a/components/StaffCard.tsx
+++ b/components/StaffCard.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image";
+
+export type Staff = {
+  name: string;
+  role: string;
+  email?: string;
+  image?: string;
+};
+
+export function StaffCard({ staff }: { staff: Staff }) {
+  return (
+    <div className="card flex h-full flex-col items-center text-center">
+      {staff.image && (
+        <Image
+          src={staff.image}
+          alt={staff.name}
+          width={400}
+          height={400}
+          className="h-48 w-full object-cover"
+        />
+      )}
+      <div className="p-4">
+        <h3 className="text-lg font-semibold">{staff.name}</h3>
+        <p className="mt-1 text-sm text-gray-600">{staff.role}</p>
+        {staff.email && (
+          <a
+            href={`mailto:${staff.email}`}
+            className="mt-2 block text-sm font-medium text-blue-600 hover:underline"
+          >
+            {staff.email}
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement EventCard/EventList for showcasing events
- add SermonCard/SermonList to display sermons with links
- create StaffCard and MinistryCard components with card styling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3bc59d520832ca520605239dc50eb