### PR TITLE
Implement event listing and detail pages

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -1,0 +1,108 @@
+import Image from "next/image";
+import Script from "next/script";
+import { notFound } from "next/navigation";
+import { eventBySlug } from "@/lib/queries";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const event = await eventBySlug(params.slug);
+  return { title: event?.title ?? "Event" };
+}
+
+export default async function Page({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const event = await eventBySlug(params.slug);
+  if (!event) notFound();
+
+  const start = new Date(event.date);
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
+  const formatICS = (d: Date) => d.toISOString().replace(/[-:]|\.\d{3}/g, "");
+  const calendar = `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+    event.title,
+  )}&dates=${formatICS(start)}/${formatICS(end)}&details=${encodeURIComponent(
+    event.description,
+  )}${
+    event.location ? `&location=${encodeURIComponent(event.location)}` : ""
+  }`;
+  const directions = event.location
+    ? `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
+        event.location,
+      )}`
+    : null;
+
+  const formattedDate = start.toLocaleString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  return (
+    <div className="space-y-4">
+      {event.image && (
+        <Image
+          src={event.image}
+          alt=""
+          width={1200}
+          height={600}
+          className="h-64 w-full rounded object-cover"
+        />
+      )}
+      <h1 className="text-2xl font-semibold">{event.title}</h1>
+      <p className="text-sm text-gray-600">
+        {formattedDate}
+        {event.location ? ` • ${event.location}` : ""}
+      </p>
+      <p className="text-sm text-gray-700">{event.description}</p>
+      <div className="flex gap-4 text-sm">
+        <a
+          href={calendar}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Add to calendar
+        </a>
+        {directions && (
+          <a
+            href={directions}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            Get directions
+          </a>
+        )}
+      </div>
+      <Script
+        id="event-jsonld"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Event",
+            name: event.title,
+            startDate: event.date,
+            description: event.description,
+            image: event.image ? [event.image] : undefined,
+            location: event.location
+              ? {
+                  "@type": "Place",
+                  name: event.location,
+                  address: event.location,
+                }
+              : undefined,
+            url: `/events/${event.slug}`,
+          }),
+        }}
+      />
+    </div>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,4 +1,61 @@
+import Link from "next/link";
+import { EventList } from "@/components/EventList";
+import { eventsAll } from "@/lib/queries";
+
 export const metadata = { title: "Events" };
-export default function Page() {
-  return <h1 className="text-2xl font-semibold">Events</h1>;
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams?: { show?: string };
+}) {
+  const show = searchParams?.show ?? "upcoming";
+  const allEvents = await eventsAll();
+  const now = new Date();
+  const events = allEvents
+    .filter((ev) => {
+      const d = new Date(ev.date);
+      if (show === "past") return d < now;
+      if (show === "all") return true;
+      return d >= now;
+    })
+    .map((ev) => ({
+      title: ev.title,
+      date: new Date(ev.date).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      }),
+      description: ev.description,
+      location: ev.location,
+      image: ev.image,
+      href: ev.slug ? `/events/${ev.slug}` : undefined,
+    }));
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Events</h1>
+      <div className="flex gap-4 text-sm">
+        <Link
+          href="/events?show=upcoming"
+          className={show === "upcoming" ? "font-semibold" : ""}
+        >
+          Upcoming
+        </Link>
+        <Link
+          href="/events?show=past"
+          className={show === "past" ? "font-semibold" : ""}
+        >
+          Past
+        </Link>
+        <Link
+          href="/events?show=all"
+          className={show === "all" ? "font-semibold" : ""}
+        >
+          All
+        </Link>
+      </div>
+      <EventList events={events} />
+    </div>
+  );
 }

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -6,12 +6,26 @@ export interface Event {
   title: string;
   date: string;
   description: string;
+  location?: string;
+  image?: string;
+  slug?: string;
 }
 
 export const eventsUpcoming = (limit: number) =>
   sanity.fetch<Event[]>(
-    groq`*[_type == "event" && date >= now()] | order(date asc)[0...$limit]{_id, title, date, description}`,
+    groq`*[_type == "event" && date >= now()] | order(date asc)[0...$limit]{_id, title, date, description, location, "image": image.asset->url, "slug": slug.current}`,
     {limit}
+  );
+
+export const eventsAll = () =>
+  sanity.fetch<Event[]>(
+    groq`*[_type == "event"] | order(date asc){_id, title, date, description, location, "image": image.asset->url, "slug": slug.current}`
+  );
+
+export const eventBySlug = (slug: string) =>
+  sanity.fetch<Event | null>(
+    groq`*[_type == "event" && slug.current == $slug][0]{_id, title, date, description, location, "image": image.asset->url, "slug": slug.current}`,
+    { slug }
   );
 
 export interface Sermon {


### PR DESCRIPTION
## Summary
- add events listing with optional past/upcoming filters
- create event detail page with hero, calendar link, directions, and JSON-LD schema
- extend event queries to support slugs and fetch all events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a682b15f68832ca9bac99fad8909c6