### PR TITLE
feat: add ministries page with dynamic content

### DIFF
--- a/app/ministries/page.tsx
+++ b/app/ministries/page.tsx
@@ -1,4 +1,25 @@
+import { MinistryCard } from "@/components/MinistryCard";
+import { ministriesAll, type Ministry } from "../../lib/queries";
+
 export const metadata = { title: "Ministries" };
-export default function Page() {
-  return <h1 className="text-2xl font-semibold">Ministries</h1>;
+
+export default async function Page() {
+  const ministries: Ministry[] = await ministriesAll();
+  return (
+    <div className="space-y-8">
+      <section>
+        <h1 className="text-2xl font-semibold">Ministries</h1>
+        <p className="mt-4 text-gray-700">
+          Explore ways to grow and serve through the ministries of our church.
+        </p>
+      </section>
+      <section>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {ministries.map((ministry) => (
+            <MinistryCard key={ministry._id} ministry={ministry} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/app/ministries/page.tsx
+++ b/app/ministries/page.tsx
@@ -2,6 +2,7 @@ import { MinistryCard } from "@/components/MinistryCard";
 import { ministriesAll, type Ministry } from "../../lib/queries";
 
 export const metadata = { title: "Ministries" };
+export const revalidate = 0;
 
 export default async function Page() {
   const ministries: Ministry[] = await ministriesAll();

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -82,3 +82,8 @@ export const ministriesHighlights = (limit: number) =>
     {limit}
   );
 
+export const ministriesAll = () =>
+  sanity.fetch<Ministry[]>(
+    groq`*[_type == "ministry"] | order(name asc){_id, name, description, "image": image.asset->url}`
+  );
+

--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,11 @@ const nextConfig = {
         hostname: "maps.googleapis.com",
         pathname: "/maps/api/**",
       },
+      {
+        protocol: "https",
+        hostname: "cdn.sanity.io",
+        pathname: "/images/**",
+      },
     ],
   },
 };

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -4,6 +4,7 @@ import sermon from './schemas/sermon';
 import service from './schemas/service';
 import staff from './schemas/staff';
 import siteSettings from './schemas/siteSettings';
+import ministry from './schemas/ministry';
 
 export const schemaTypes = [
   announcement,
@@ -12,4 +13,5 @@ export const schemaTypes = [
   service,
   staff,
   siteSettings,
+  ministry,
 ];


### PR DESCRIPTION
## Summary
- fetch ministries from Sanity and render dynamically
- add query helper to retrieve all ministries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a682b2949c832cbfdf006659e317b2