### PR TITLE
Fix event list key to display multiple events

### DIFF
--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 
 export type Event = {
+  _id: string;
   title: string;
   date: string;
   location?: string;

--- a/components/EventList.tsx
+++ b/components/EventList.tsx
@@ -8,7 +8,7 @@ export function EventList({ events }: { events: Event[] }) {
   return (
     <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {events.map((ev) => (
-        <EventCard key={ev.title + ev.date} event={ev} />
+        <EventCard key={ev._id} event={ev} />
       ))}
     </div>
   );

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -8,11 +8,13 @@ export interface Event {
   description: string;
 }
 
-export const eventsUpcoming = (limit: number) =>
-  sanity.fetch<Event[]>(
-    groq`*[_type == "event" && date >= now()] | order(date asc)[0...$limit]{_id, title, date, description}`,
-    {limit}
+export const eventsUpcoming = (limit: number) => {
+  const now = new Date().toISOString();
+  return sanity.fetch<Event[]>(
+    groq`*[_type == "event" && date >= $now] | order(date asc)[0...$limit]{_id, title, date, description}`,
+    { limit, now }
   );
+}
 
 export interface Sermon {
   _id: string;


### PR DESCRIPTION
## Summary
- include `_id` in event type
- use stable `_id` key when rendering events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a683269684832c861430796726a208