### PR TITLE
Enable browser dark mode detection

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
 }
 
 body {


### PR DESCRIPTION
## Summary
- support dark mode detection by allowing both light and dark color schemes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6893643b0832ca6c299157757e680