### PR TITLE
feat: add logo to site settings

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,29 +1,13 @@
 import Link from "next/link";
-
-export type SiteSettings = {
-  address: string;
-  serviceTimes: string;
-};
-
-async function getSiteSettings(): Promise<SiteSettings> {
-  const url = process.env.NEXT_PUBLIC_CMS_URL
-    ? `${process.env.NEXT_PUBLIC_CMS_URL}/api/site-settings`
-    : null;
-  if (!url) {
-    return {
-      address: "123 Main St, Hometown, ST 12345",
-      serviceTimes: "Sundays 10:00 AM",
-    };
-  }
-  const res = await fetch(url, { next: { revalidate: 60 } });
-  if (!res.ok) {
-    throw new Error("Failed to fetch SiteSettings");
-  }
-  return res.json();
-}
+import Image from "next/image";
+import { siteSettings } from "../lib/queries";
 
 export default async function Footer() {
-  const { address, serviceTimes } = await getSiteSettings();
+  const settings = await siteSettings();
+  const title = settings?.title ?? "Example Church";
+  const logo = settings?.logo;
+  const address = settings?.address ?? "123 Main St, Hometown, ST 12345";
+  const serviceTimes = settings?.serviceTimes ?? "Sundays 10:00 AM";
   const year = new Date().getFullYear();
 
   return (
@@ -31,7 +15,17 @@ export default async function Footer() {
       <div className="mx-auto max-w-5xl px-4 py-8">
         <div className="grid grid-cols-1 gap-8 md:grid-cols-4">
           <div>
-            <h4 className="mb-3 font-semibold text-white">Example Church</h4>
+            {logo ? (
+              <Image
+                src={logo}
+                alt={title}
+                width={120}
+                height={40}
+                className="mb-3"
+              />
+            ) : (
+              <h4 className="mb-3 font-semibold text-white">{title}</h4>
+            )}
             <p>{address}</p>
             <p className="mt-2">
               <strong>Service Times:</strong> {serviceTimes}
@@ -132,7 +126,7 @@ export default async function Footer() {
           </div>
         </div>
         <div className="mt-8 flex flex-col items-center justify-between gap-3 border-t border-gray-700 pt-4 text-sm text-gray-400 md:flex-row">
-          <div>© {year} Example Church</div>
+          <div>© {year} {title}</div>
           <div className="flex gap-3">
             <Link className="hover:underline" href="/privacy">
               Privacy

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname } from "next/navigation";
 
 export default function Header() {
@@ -11,6 +12,8 @@ export default function Header() {
   const [contactOpen, setContactOpen] = useState(false);
   const [mobileAboutOpen, setMobileAboutOpen] = useState(false);
   const [mobileContactOpen, setMobileContactOpen] = useState(false);
+  const [siteTitle, setSiteTitle] = useState("Example Church");
+  const [logo, setLogo] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const aboutTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const contactTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -21,6 +24,21 @@ export default function Header() {
     { href: "/livestreams", label: "Livestreams" },
     { href: "/giving", label: "Giving" },
   ];
+
+  useEffect(() => {
+    const url = process.env.NEXT_PUBLIC_CMS_URL
+      ? `${process.env.NEXT_PUBLIC_CMS_URL}/api/site-settings`
+      : null;
+    if (!url) return;
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data) return;
+        if (data.title) setSiteTitle(data.title);
+        if (data.logo) setLogo(data.logo);
+      })
+      .catch(() => {});
+  }, []);
 
   const handleAboutEnter = () => {
     if (aboutTimeoutRef.current) clearTimeout(aboutTimeoutRef.current);
@@ -86,7 +104,11 @@ export default function Header() {
     <header className="sticky top-0 z-10 border-b border-gray-200 bg-white">
       <div className="relative mx-auto flex h-16 max-w-5xl items-center px-4">
         <Link href="/" className="font-bold text-gray-900">
-          Example Church
+          {logo ? (
+            <Image src={logo} alt={siteTitle} width={120} height={40} />
+          ) : (
+            siteTitle
+          )}
         </Link>
         <nav
           className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 items-center gap-4 text-sm font-medium md:flex"

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -62,11 +62,12 @@ export interface SiteSettings {
   description?: string;
   address?: string;
   serviceTimes?: string;
+  logo?: string;
 }
 
 export const siteSettings = () =>
   sanity.fetch<SiteSettings | null>(
-    groq`*[_type == "siteSettings"][0]{_id, title, description, address, serviceTimes}`
+    groq`*[_type == "siteSettings"][0]{_id, title, description, address, serviceTimes, "logo": logo.asset->url}`
   );
 
 export interface Ministry {

--- a/sanity/schemas/siteSettings.ts
+++ b/sanity/schemas/siteSettings.ts
@@ -12,6 +12,11 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'logo',
+      title: 'Logo',
+      type: 'image',
+    }),
+    defineField({
       name: 'description',
       title: 'Description',
       type: 'text',


### PR DESCRIPTION
## Summary
- add `logo` field to Sanity site settings schema
- query logo URL alongside site settings
- display site logo in header and footer with text fallback

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Configuration must contain `projectId`)*

------
https://chatgpt.com/codex/tasks/task_e_68a68352e108832c8ce6d6c4e9e00be4