### PR TITLE
feat: add background styling for events and announcements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,13 @@ export default async function Page() {
     <div className="space-y-12">
       <Hero headline={headline} subline={subline} />
       <QuickActions actions={actions} />
-      {announcement && <AnnouncementBanner message={announcement.message} />}
+      {announcement && (
+        <AnnouncementBanner
+          message={announcement.message}
+          backgroundColor={announcement.backgroundColor}
+          backgroundImage={announcement.backgroundImage}
+        />
+      )}
       <section>
         <h2 className="mb-4 text-xl font-semibold">Upcoming Events</h2>
         <EventList events={events} />

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { CSSProperties } from "react";
 
 type AnnouncementBannerProps = {
   message: string;
+  backgroundColor?: string;
+  backgroundImage?: string;
 };
 
 export default function AnnouncementBanner({
   message,
+  backgroundColor,
+  backgroundImage,
 }: AnnouncementBannerProps) {
   const [dismissed, setDismissed] = useState(false);
 
@@ -30,8 +35,25 @@ export default function AnnouncementBanner({
     return null;
   }
 
+  const style: CSSProperties = {};
+  if (backgroundImage) {
+    style.backgroundImage = `url(${backgroundImage})`;
+    style.backgroundSize = "cover";
+    style.backgroundPosition = "center";
+  }
+  if (backgroundColor) {
+    style.backgroundColor = backgroundColor;
+  }
+
+  const gradientStyle: CSSProperties = {
+    background: `linear-gradient(to left, ${backgroundColor ?? "#4f46e5"}, transparent)`,
+  };
+
   return (
-    <div className="relative overflow-hidden rounded-md bg-indigo-600 px-4 py-3 pr-4 text-center text-sm text-white">
+    <div
+      className="relative overflow-hidden rounded-md px-4 py-3 pr-4 text-center text-sm text-white"
+      style={style}
+    >
       <div className="mr-4 overflow-hidden">
         <div className="inline-flex animate-marquee whitespace-nowrap [--marquee-gap:6rem]">
           <span className="pr-[var(--marquee-gap)]">{message}</span>
@@ -41,7 +63,8 @@ export default function AnnouncementBanner({
 
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute right-8 top-0 h-full w-10 bg-gradient-to-l from-indigo-600 to-indigo-600/0"
+        className="pointer-events-none absolute right-8 top-0 h-full w-10"
+        style={gradientStyle}
       />
 
       <button

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -9,25 +9,23 @@ export type Event = {
   description?: string;
   image?: string;
   href?: string;
+  backgroundImage?: string;
+  backgroundColor?: string;
 };
 
 export function EventCard({
   event,
-  backgroundImage,
-  backgroundColor,
 }: {
   event: Event;
-  backgroundImage?: string;
-  backgroundColor?: string;
 }) {
   const style: CSSProperties = {};
-  if (backgroundImage) {
-    style.backgroundImage = `url(${backgroundImage})`;
+  if (event.backgroundImage) {
+    style.backgroundImage = `url(${event.backgroundImage})`;
     style.backgroundSize = "cover";
     style.backgroundPosition = "center";
   }
-  if (backgroundColor) {
-    style.backgroundColor = backgroundColor;
+  if (event.backgroundColor) {
+    style.backgroundColor = event.backgroundColor;
   }
   return (
     <div

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -6,11 +6,13 @@ export interface Event {
   title: string;
   date: string;
   description: string;
+  backgroundColor?: string;
+  backgroundImage?: string;
 }
 
 export const eventsUpcoming = (limit: number) =>
   sanity.fetch<Event[]>(
-    groq`*[_type == "event" && date >= now()] | order(date asc)[0...$limit]{_id, title, date, description}`,
+    groq`*[_type == "event" && date >= now()] | order(date asc)[0...$limit]{_id, title, date, description, backgroundColor, "backgroundImage": backgroundImage.asset->url}`,
     {limit}
   );
 
@@ -49,11 +51,13 @@ export interface Announcement {
   title: string;
   message: string;
   publishedAt: string;
+  backgroundColor?: string;
+  backgroundImage?: string;
 }
 
 export const announcementLatest = () =>
   sanity.fetch<Announcement | null>(
-    groq`*[_type == "announcement"] | order(publishedAt desc)[0]{_id, title, "message": body, publishedAt}`
+    groq`*[_type == "announcement"] | order(publishedAt desc)[0]{_id, title, "message": body, publishedAt, backgroundColor, "backgroundImage": backgroundImage.asset->url}`
   );
 
 export interface SiteSettings {

--- a/sanity/schemas/announcement.ts
+++ b/sanity/schemas/announcement.ts
@@ -23,5 +23,15 @@ export default defineType({
       type: 'text',
       validation: (Rule) => Rule.required(),
     }),
+    defineField({
+      name: 'backgroundColor',
+      title: 'Background Color',
+      type: 'string',
+    }),
+    defineField({
+      name: 'backgroundImage',
+      title: 'Background Image',
+      type: 'image',
+    }),
   ],
 });

--- a/sanity/schemas/event.ts
+++ b/sanity/schemas/event.ts
@@ -23,5 +23,15 @@ export default defineType({
       type: 'text',
       validation: (Rule) => Rule.required(),
     }),
+    defineField({
+      name: 'backgroundColor',
+      title: 'Background Color',
+      type: 'string',
+    }),
+    defineField({
+      name: 'backgroundImage',
+      title: 'Background Image',
+      type: 'image',
+    }),
   ],
 });


### PR DESCRIPTION
## Summary
- allow CMS editors to set background color or image for events and announcements
- query new style fields from Sanity and plumb them through components
- style EventCard and AnnouncementBanner using the provided background fields

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Configuration must contain `projectId`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6835b75e4832c9083e952ddd32969