### PR TITLE
refactor: apply brand color palette

### DIFF
--- a/app/contact/prayer-requests/page.tsx
+++ b/app/contact/prayer-requests/page.tsx
@@ -1,11 +1,18 @@
 import Link from "next/link";
+
+// Back link uses brand colors from tailwind.config.js.
 export const metadata = { title: "Prayer Requests" };
 export default function Page() {
   return (
     <div>
       <h1 className="text-2xl font-semibold">Prayer Requests</h1>
       <p className="mt-2 text-sm text-gray-600">
-        <Link href="/contact" className="text-blue-700 hover:underline">Back to Contact</Link>
+        <Link
+          href="/contact"
+          className="text-brand-purple hover:underline hover:text-brand-purpleLt active:text-brand-purpleLt"
+        >
+          Back to Contact
+        </Link>
       </p>
     </div>
   );

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -2,8 +2,9 @@
 
 @layer components {
   .btn-primary {
-    @apply rounded-md bg-blue-600 px-4 py-2 font-medium text-white transition-colors;
-    @apply hover:bg-blue-700;
+    /* Uses brand colors defined in tailwind.config.js */
+    @apply rounded-md bg-brand-purple px-4 py-2 font-medium text-white transition-colors;
+    @apply hover:bg-brand-purpleLt active:bg-brand-purpleLt;
   }
 
   .btn-ghost {

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 
+// Styled with the brand color palette defined in tailwind.config.js.
+
 type AnnouncementBannerProps = {
   message: string;
 };
@@ -31,7 +33,7 @@ export default function AnnouncementBanner({
   }
 
   return (
-    <div className="relative overflow-hidden rounded-md bg-indigo-600 px-4 py-3 pr-4 text-center text-sm text-white">
+    <div className="relative overflow-hidden rounded-md bg-brand-purple px-4 py-3 pr-4 text-center text-sm text-white">
       <div className="mr-4 overflow-hidden">
         <div className="inline-flex animate-marquee whitespace-nowrap [--marquee-gap:6rem]">
           <span className="pr-[var(--marquee-gap)]">{message}</span>
@@ -41,7 +43,7 @@ export default function AnnouncementBanner({
 
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute right-8 top-0 h-full w-10 bg-gradient-to-l from-indigo-600 to-indigo-600/0"
+        className="pointer-events-none absolute right-8 top-0 h-full w-10 bg-gradient-to-l from-brand-purple to-brand-purple/0"
       />
 
       <button

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -2,6 +2,8 @@ import Image from "next/image";
 import Link from "next/link";
 import type { CSSProperties } from "react";
 
+// Links use the brand palette defined in tailwind.config.js.
+
 export type Event = {
   title: string;
   date: string;
@@ -57,7 +59,7 @@ export function EventCard({
         {event.href && (
           <Link
             href={event.href}
-            className="mt-4 text-sm font-medium text-blue-600 hover:underline"
+            className="mt-4 text-sm font-medium text-brand-purple hover:underline hover:text-brand-purpleLt active:text-brand-purpleLt"
           >
             Learn more
           </Link>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+// Footer links reference the brand palette defined in tailwind.config.js.
+
 export type SiteSettings = {
   address: string;
   serviceTimes: string;
@@ -41,27 +43,27 @@ export default async function Footer() {
             <h4 className="mb-3 font-semibold text-white">Quick Links</h4>
             <ul className="space-y-1">
               <li>
-                <Link className="text-indigo-200 hover:underline" href="/visit">
+                <Link className="text-brand-purpleLt hover:underline hover:text-brand-purple active:text-brand-purple" href="/visit">
                   Visit
                 </Link>
               </li>
               <li>
-                <Link className="text-indigo-200 hover:underline" href="/events">
+                <Link className="text-brand-purpleLt hover:underline hover:text-brand-purple active:text-brand-purple" href="/events">
                   Events
                 </Link>
               </li>
               <li>
-                <Link className="text-indigo-200 hover:underline" href="/livestreams">
+                <Link className="text-brand-purpleLt hover:underline hover:text-brand-purple active:text-brand-purple" href="/livestreams">
                   Livestreams
                 </Link>
               </li>
               <li>
-                <Link className="text-indigo-200 hover:underline" href="/ministries">
+                <Link className="text-brand-purpleLt hover:underline hover:text-brand-purple active:text-brand-purple" href="/ministries">
                   Ministries
                 </Link>
               </li>
               <li>
-                <Link className="text-indigo-200 hover:underline" href="/giving">
+                <Link className="text-brand-purpleLt hover:underline hover:text-brand-purple active:text-brand-purple" href="/giving">
                   Giving
                 </Link>
               </li>

--- a/components/MinistryCard.tsx
+++ b/components/MinistryCard.tsx
@@ -2,6 +2,8 @@ import Image from "next/image";
 import Link from "next/link";
 import type { CSSProperties } from "react";
 
+// Link colors follow the brand palette in tailwind.config.js.
+
 export type Ministry = {
   name: string;
   description: string;
@@ -49,7 +51,7 @@ export function MinistryCard({
         {ministry.href && (
           <Link
             href={ministry.href}
-            className="mt-4 text-sm font-medium text-blue-600 hover:underline"
+            className="mt-4 text-sm font-medium text-brand-purple hover:underline hover:text-brand-purpleLt active:text-brand-purpleLt"
           >
             Learn more
           </Link>

--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+// Quick action buttons use the brand color palette defined in tailwind.config.js.
 export type QuickAction = {
   label: string;
   href: string;
@@ -12,7 +13,7 @@ export default function QuickActions({ actions }: { actions: QuickAction[] }) {
         <Link
           key={action.href}
           href={action.href}
-          className="rounded bg-indigo-600 px-4 py-2 text-center font-medium text-white hover:bg-indigo-700"
+          className="rounded bg-brand-purple px-4 py-2 text-center font-medium text-white hover:bg-brand-purpleLt active:bg-brand-purpleLt"
         >
           {action.label}
         </Link>

--- a/components/SermonCard.tsx
+++ b/components/SermonCard.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import type { CSSProperties } from "react";
 
+// Action links use brand colors from tailwind.config.js.
+
 export type Sermon = {
   title: string;
   date?: string;
@@ -55,7 +57,7 @@ export function SermonCard({
             {sermon.audioUrl && (
               <a
                 href={sermon.audioUrl}
-                className="text-sm font-medium text-blue-600 hover:underline"
+                className="text-sm font-medium text-brand-purple hover:underline hover:text-brand-purpleLt active:text-brand-purpleLt"
               >
                 Listen
               </a>
@@ -64,7 +66,7 @@ export function SermonCard({
             {sermon.href && (
               <Link
                 href={sermon.href}
-                className="text-sm font-medium text-blue-600 hover:underline"
+                className="text-sm font-medium text-brand-purple hover:underline hover:text-brand-purpleLt active:text-brand-purpleLt"
               >
                 Details
               </Link>

--- a/components/StaffCard.tsx
+++ b/components/StaffCard.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import type { CSSProperties } from "react";
 
+// Email link uses brand colors defined in tailwind.config.js.
+
 export type Staff = {
   name: string;
   role: string;
@@ -46,7 +48,7 @@ export function StaffCard({
         {staff.email && (
           <a
             href={`mailto:${staff.email}`}
-            className="mt-2 block text-sm font-medium text-blue-600 hover:underline"
+            className="mt-2 block text-sm font-medium text-brand-purple hover:underline hover:text-brand-purpleLt active:text-brand-purpleLt"
           >
             {staff.email}
           </a>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        // Project brand palette. Prefer these colors in components over Tailwind defaults.
         brand: {
           purple: "#5C30A6",
           purpleLt: "#B19CD9",


### PR DESCRIPTION
## Summary
- use brand color palette across components and utilities
- ensure hover/active styles use matching brand shades
- document brand palette in Tailwind config for future work

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6838cae2c832cbb0fc08ee1c05a3f