### PR TITLE
feat: add hero slideshow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,15 +11,17 @@ import {
   sermonLatest,
   siteSettings,
   ministriesHighlights,
+  heroSlides,
 } from "@/lib/queries";
 
 export default async function Page() {
-  const [announcement, events, sermon, settings, ministries] = await Promise.all([
+  const [announcement, events, sermon, settings, ministries, slides] = await Promise.all([
     announcementLatest(),
     eventsUpcoming(3),
     sermonLatest(),
     siteSettings(),
     ministriesHighlights(3),
+    heroSlides(),
   ]);
 
   const actions = [
@@ -29,13 +31,11 @@ export default async function Page() {
     { label: "Giving", href: "/giving" },
   ];
 
-  const headline = settings?.title ?? "Welcome";
-  const subline = settings?.description ?? "";
   const address = settings?.address ?? "";
 
   return (
     <div className="space-y-12">
-      <Hero headline={headline} subline={subline} backgroundImage={settings?.logo} />
+      {slides.length > 0 && <Hero slides={slides} />}
       <QuickActions actions={actions} />
       {announcement && <AnnouncementBanner message={announcement.message} />}
       <section>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,53 +1,96 @@
-import Image from "next/image";
-import Link from "next/link";
+'use client';
 
-export type HeroProps = {
-  headline: string;
-  subline?: string;
-  cta?: {
-    label: string;
-    href: string;
-  };
-  backgroundImage?: string;
-  backgroundGradient?: string;
-};
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import type { HeroSlide } from '@/lib/queries';
 
-export default function Hero({
-  headline,
-  subline,
-  cta,
-  backgroundImage,
-  backgroundGradient,
-}: HeroProps) {
+export interface HeroProps {
+  slides: HeroSlide[];
+  autoInterval?: number;
+}
+
+export default function Hero({ slides, autoInterval = 5000 }: HeroProps) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (slides.length <= 1) return;
+    const id = setInterval(() => setIndex((i) => (i + 1) % slides.length), autoInterval);
+    return () => clearInterval(id);
+  }, [slides.length, autoInterval]);
+
+  if (!slides.length) return null;
+
+  const prev = () => setIndex((i) => (i - 1 + slides.length) % slides.length);
+  const next = () => setIndex((i) => (i + 1) % slides.length);
+
   return (
     <section className="relative isolate overflow-hidden">
-      {backgroundImage && (
-        <Image
-          src={backgroundImage}
-          alt=""
-          fill
-          priority
-          className="absolute inset-0 -z-10 h-full w-full object-cover opacity-30"
-        />
-      )}
-      {backgroundGradient && (
-        <div className={`absolute inset-0 -z-10 ${backgroundGradient}`} />
-      )}
-      <div className="absolute inset-0 -z-10 bg-[var(--brand-overlay)]" />
-
-      <div className="mx-auto max-w-5xl px-4 py-24 text-center text-[var(--brand-fg)]">
-        <h1 className="text-4xl font-bold tracking-tight">{headline}</h1>
-        {subline && <p className="mt-4 text-lg">{subline}</p>}
-        {cta && (
-          <Link
-            href={cta.href}
-            className="mt-8 inline-block rounded-md border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-6 py-2 font-medium text-[var(--brand-primary-contrast)] shadow-sm hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)]"
+      {slides.map((slide, i) => (
+        <div
+          key={slide._id}
+          className={`absolute inset-0 transition-opacity duration-700 ease-in-out ${i === index ? 'opacity-100' : 'opacity-0'}`}
+        >
+          <Image
+            src={slide.image}
+            alt=""
+            fill
+            priority={i === index}
+            className="object-cover"
+          />
+          <div className="absolute inset-0 bg-[var(--brand-overlay)]" />
+          <div className="relative mx-auto max-w-5xl px-4 py-24 text-center text-[var(--brand-fg)]">
+            {slide.headline && <h1 className="text-4xl font-bold tracking-tight">{slide.headline}</h1>}
+            {slide.subline && <p className="mt-4 text-lg">{slide.subline}</p>}
+            {slide.cta?.href && slide.cta?.label && (
+              <Link
+                href={slide.cta.href}
+                className="mt-8 inline-block rounded-md border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-6 py-2 font-medium text-[var(--brand-primary-contrast)] shadow-sm hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)]"
+              >
+                {slide.cta.label}
+              </Link>
+            )}
+          </div>
+        </div>
+      ))}
+      {slides.length > 1 && (
+        <>
+          <button
+            type="button"
+            onClick={prev}
+            className="absolute left-4 top-1/2 z-10 -translate-y-1/2 rounded-full bg-[var(--brand-overlay)] p-2 text-[var(--brand-fg)] hover:bg-[color:color-mix(in_oklab,var(--brand-overlay)_85%,white_15%)]"
+            aria-label="Previous slide"
           >
-            {cta.label}
-          </Link>
-        )}
-      </div>
+            <svg viewBox="0 0 24 24" className="h-6 w-6">
+              <path
+                d="M15 18l-6-6 6-6"
+                stroke="currentColor"
+                strokeWidth="2"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            className="absolute right-4 top-1/2 z-10 -translate-y-1/2 rounded-full bg-[var(--brand-overlay)] p-2 text-[var(--brand-fg)] hover:bg-[color:color-mix(in_oklab,var(--brand-overlay)_85%,white_15%)]"
+            aria-label="Next slide"
+          >
+            <svg viewBox="0 0 24 24" className="h-6 w-6">
+              <path
+                d="M9 6l6 6-6 6"
+                stroke="currentColor"
+                strokeWidth="2"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </>
+      )}
     </section>
   );
 }
-

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -65,6 +65,22 @@ export const announcementLatest = () =>
     groq`*[_type == "announcement"] | order(publishedAt desc)[0]{_id, title, "message": body, publishedAt}`
   );
 
+export interface HeroSlide {
+  _id: string;
+  image: string;
+  headline?: string;
+  subline?: string;
+  cta?: {
+    label?: string;
+    href?: string;
+  };
+}
+
+export const heroSlides = () =>
+  sanity.fetch<HeroSlide[]>(
+    groq`*[_type == "heroSlide"] | order(_createdAt asc){_id, "image": image.asset->url, headline, subline, cta{label, href}}`
+  );
+
 export interface SiteSettings {
   _id: string;
   title: string;

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -11,6 +11,7 @@ import service from './sanity/schemas/service'
 import siteSettings from './sanity/schemas/siteSettings'
 import staff from './sanity/schemas/staff'
 import ministry from './sanity/schemas/ministry'
+import heroSlide from './sanity/schemas/heroSlide'
 
 // Desk structure
 import {structure} from './sanity/deskStructure'
@@ -22,7 +23,7 @@ export default defineConfig({
     projectId: import.meta.env.SANITY_STUDIO_PROJECT_ID,
     dataset: import.meta.env.SANITY_STUDIO_DATASET,
     schema: {
-        types: [announcement, event, sermon, service, siteSettings, staff, ministry],
+        types: [announcement, event, sermon, service, siteSettings, staff, ministry, heroSlide],
     },
     plugins: [
         structureTool({

--- a/sanity/deskStructure.ts
+++ b/sanity/deskStructure.ts
@@ -10,4 +10,5 @@ export const structure = (S: any) =>
       S.documentTypeListItem('ministry').title('Ministries'),
       S.documentTypeListItem('siteSettings').title('Site Settings'),
       S.documentTypeListItem('staff').title('Staff'),
+      S.documentTypeListItem('heroSlide').title('Hero Slides'),
     ])

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -5,6 +5,7 @@ import service from './schemas/service';
 import staff from './schemas/staff';
 import siteSettings from './schemas/siteSettings';
 import ministry from './schemas/ministry';
+import heroSlide from './schemas/heroSlide';
 
 export const schemaTypes = [
   announcement,
@@ -14,4 +15,5 @@ export const schemaTypes = [
   staff,
   siteSettings,
   ministry,
+  heroSlide,
 ];

--- a/sanity/schemas/heroSlide.ts
+++ b/sanity/schemas/heroSlide.ts
@@ -1,0 +1,35 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'heroSlide',
+  title: 'Hero Slide',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'headline',
+      title: 'Headline',
+      type: 'string',
+    }),
+    defineField({
+      name: 'subline',
+      title: 'Subline',
+      type: 'string',
+    }),
+    defineField({
+      name: 'cta',
+      title: 'Call to Action',
+      type: 'object',
+      fields: [
+        defineField({ name: 'label', title: 'Label', type: 'string' }),
+        defineField({ name: 'href', title: 'Link', type: 'url' }),
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- add `heroSlide` schema and wire it into Sanity Studio
- build animated Hero slideshow component with autoplay and navigation
- fetch slides from Sanity and render Hero only when data exists

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a949a50cb8832c85595b73f19946ba