### PR TITLE
feat: add Sanity-backed hero slideshow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,10 @@
 import { EventList } from "@/components/EventList";
 import { SermonList } from "@/components/SermonList";
 import { MinistryCard } from "@/components/MinistryCard";
+import Hero from "@/components/Hero";
 import MapBlock from "@/components/MapBlock";
 import {
+  heroSlides,
   eventsUpcoming,
   sermonLatest,
   siteSettings,
@@ -10,7 +12,8 @@ import {
 } from "@/lib/queries";
 
 export default async function Page() {
-  const [events, sermon, settings, ministries] = await Promise.all([
+  const [slides, events, sermon, settings, ministries] = await Promise.all([
+    heroSlides(),
     eventsUpcoming(3),
     sermonLatest(),
     siteSettings(),
@@ -21,6 +24,7 @@ export default async function Page() {
 
   return (
     <div className="w-full space-y-12">
+      <Hero slides={slides} />
       <section
         className="w-full opacity-0 animate-fade-in-up"
         style={{ animationDelay: '0.1s' }}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,61 +1,98 @@
-import Image from "next/image";
-import Link from "next/link";
+'use client';
 
-export type HeroProps = {
-  headline: string;
-  subline?: string;
-  cta?: {
-    label: string;
-    href: string;
-  };
-  backgroundImage?: string;
-  backgroundGradient?: string;
-};
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import type { HeroSlide } from '@/lib/queries';
 
-export default function Hero({
-  headline,
-  subline,
-  cta,
-  backgroundImage,
-  backgroundGradient,
-}: HeroProps) {
+export interface HeroProps {
+  slides: HeroSlide[];
+  intervalMs?: number;
+}
+
+export default function Hero({ slides, intervalMs = 5000 }: HeroProps) {
+  const [index, setIndex] = useState(0);
+  const count = slides.length;
+
+  useEffect(() => {
+    if (count <= 1) return;
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % count);
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [count, intervalMs]);
+
+  const next = () => setIndex((i) => (i + 1) % count);
+  const prev = () => setIndex((i) => (i - 1 + count) % count);
+
   return (
     <section className="relative isolate overflow-hidden">
-      {backgroundImage && (
-        <Image
-          src={backgroundImage}
-          alt=""
-          fill
-          priority
-          className="absolute inset-0 -z-10 h-full w-full object-cover opacity-30"
-        />
-      )}
-      {backgroundGradient && (
-        <div className={`absolute inset-0 -z-10 ${backgroundGradient}`} />
-      )}
-      <div className="absolute inset-0 -z-10 bg-[var(--brand-overlay)]" />
+      {slides.map((slide, i) => (
+        <div
+          key={slide._id}
+          className={`absolute inset-0 transition-opacity duration-700 ${
+            i === index ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
+          {slide.image && (
+            <Image
+              src={slide.image}
+              alt=""
+              fill
+              priority={i === index}
+              className="object-cover"
+            />
+          )}
+          <div className="absolute inset-0 bg-[var(--brand-overlay)]" />
+          <div className="relative flex h-full w-full flex-col items-center justify-center px-4 text-center text-[var(--brand-fg)]">
+            <h1 className="text-4xl font-bold tracking-tight">{slide.headline}</h1>
+            {slide.subline && <p className="mt-4 text-lg">{slide.subline}</p>}
+            {slide.cta && slide.cta.href && slide.cta.label && (
+              <Link
+                href={slide.cta.href}
+                className="mt-8 inline-block rounded-md border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-6 py-2 font-medium text-[var(--brand-primary-contrast)] shadow-sm hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)]"
+              >
+                {slide.cta.label}
+              </Link>
+            )}
+          </div>
+        </div>
+      ))}
 
-      <div className="px-4 py-24 text-center text-[var(--brand-fg)]">
-        <h1 className="text-4xl font-bold tracking-tight opacity-0 animate-fade-in-up">{headline}</h1>
-        {subline && (
-          <p
-            className="mt-4 text-lg opacity-0 animate-fade-in-up"
-            style={{ animationDelay: '0.15s' }}
+      {count > 1 && (
+        <>
+          <button
+            type="button"
+            aria-label="Previous slide"
+            onClick={prev}
+            className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-[color:color-mix(in_oklab,var(--brand-fg)_30%,transparent)] p-2 text-[var(--brand-fg)] hover:bg-[color:color-mix(in_oklab,var(--brand-fg)_50%,transparent)]"
           >
-            {subline}
-          </p>
-        )}
-        {cta && (
-          <Link
-            href={cta.href}
-            className="mt-8 inline-block rounded-md border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-6 py-2 font-medium text-[var(--brand-primary-contrast)] shadow-sm hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)] opacity-0 animate-fade-in-up"
-            style={{ animationDelay: '0.3s' }}
+            ‹
+          </button>
+          <button
+            type="button"
+            aria-label="Next slide"
+            onClick={next}
+            className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-[color:color-mix(in_oklab,var(--brand-fg)_30%,transparent)] p-2 text-[var(--brand-fg)] hover:bg-[color:color-mix(in_oklab,var(--brand-fg)_50%,transparent)]"
           >
-            {cta.label}
-          </Link>
-        )}
-      </div>
+            ›
+          </button>
+          <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 space-x-2">
+            {slides.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setIndex(i)}
+                className={`h-2 w-2 rounded-full ${
+                  i === index
+                    ? 'bg-[var(--brand-fg)]'
+                    : 'bg-[color:color-mix(in_oklab,var(--brand-fg)_50%,transparent)]'
+                }`}
+                aria-label={`Go to slide ${i + 1}`}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </section>
   );
 }
-

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,6 +1,28 @@
 import groq from 'groq';
 import {sanity} from './sanity';
 
+export interface HeroSlide {
+  _id: string;
+  headline: string;
+  subline?: string;
+  cta?: {
+    label?: string;
+    href?: string;
+  };
+  image?: string;
+}
+
+export const heroSlides = () =>
+  sanity.fetch<HeroSlide[]>(
+    groq`*[_type == "heroSlide"] | order(_createdAt asc){
+      _id,
+      headline,
+      subline,
+      "cta": cta{label, href},
+      "image": backgroundImage.asset->url
+    }`
+  );
+
 export interface Event {
   _id: string;
   title: string;

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -11,6 +11,7 @@ import service from './sanity/schemas/service'
 import siteSettings from './sanity/schemas/siteSettings'
 import staff from './sanity/schemas/staff'
 import ministry from './sanity/schemas/ministry'
+import heroSlide from './sanity/schemas/heroSlide'
 
 // Desk structure
 import {structure} from './sanity/deskStructure'
@@ -22,7 +23,7 @@ export default defineConfig({
     projectId: import.meta.env.SANITY_STUDIO_PROJECT_ID,
     dataset: import.meta.env.SANITY_STUDIO_DATASET,
     schema: {
-        types: [announcement, event, sermon, service, siteSettings, staff, ministry],
+        types: [announcement, event, sermon, service, siteSettings, staff, ministry, heroSlide],
     },
     plugins: [
         structureTool({

--- a/sanity/deskStructure.ts
+++ b/sanity/deskStructure.ts
@@ -8,6 +8,7 @@ export const structure = (S: any) =>
       S.documentTypeListItem('sermon').title('Sermons'),
       S.documentTypeListItem('service').title('Services'),
       S.documentTypeListItem('ministry').title('Ministries'),
+      S.documentTypeListItem('heroSlide').title('Hero Slides'),
       S.documentTypeListItem('siteSettings').title('Site Settings'),
       S.documentTypeListItem('staff').title('Staff'),
     ])

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -5,6 +5,7 @@ import service from './schemas/service';
 import staff from './schemas/staff';
 import siteSettings from './schemas/siteSettings';
 import ministry from './schemas/ministry';
+import heroSlide from './schemas/heroSlide';
 
 export const schemaTypes = [
   announcement,
@@ -14,4 +15,5 @@ export const schemaTypes = [
   staff,
   siteSettings,
   ministry,
+  heroSlide,
 ];

--- a/sanity/schemas/heroSlide.ts
+++ b/sanity/schemas/heroSlide.ts
@@ -1,0 +1,43 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'heroSlide',
+  title: 'Hero Slide',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'headline',
+      title: 'Headline',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'subline',
+      title: 'Subline',
+      type: 'string',
+    }),
+    defineField({
+      name: 'cta',
+      title: 'Call To Action',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'label',
+          title: 'Label',
+          type: 'string',
+        }),
+        defineField({
+          name: 'href',
+          title: 'URL',
+          type: 'url',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'backgroundImage',
+      title: 'Background Image',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- add `heroSlide` schema and wire it into Sanity Studio
- implement Sanity-backed hero slideshow with autoplay and controls
- render slideshow on home page via new `heroSlides` query

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abb0f99bcc832c890e611ff91d1dcd