### PR TITLE
feat: add inactivity nudges to CTA buttons

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,10 +4,12 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRef, useState } from "react";
 import MobileMenu, { MobileMenuHandle } from "./MobileMenu";
+import useInactivityNudge from "@/lib/useInactivityNudge";
 
 export default function Header({ initialTitle }: { initialTitle?: string }) {
   const pathname = usePathname();
   const mobileMenuRef = useRef<MobileMenuHandle>(null);
+  const givingRef = useRef<HTMLAnchorElement>(null);
   const [siteTitle] = useState(initialTitle ?? "Example Church");
 
   const nav = [
@@ -16,6 +18,8 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
     { href: "/livestreams", label: "Livestreams" },
     { href: "/giving", label: "Giving" },
   ];
+
+  useInactivityNudge(givingRef);
 
   const linkClasses = (active: boolean) =>
     `${active ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)]`;
@@ -127,6 +131,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
               href={item.href}
               className={linkClasses(pathname.startsWith(item.href))}
               aria-current={pathname.startsWith(item.href) ? "page" : undefined}
+              ref={item.href === "/giving" ? givingRef : undefined}
             >
               {item.label}
             </Link>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
+import { useRef } from "react";
+import useInactivityNudge from "@/lib/useInactivityNudge";
 
 export type HeroProps = {
   headline: string;
@@ -19,6 +23,8 @@ export default function Hero({
   backgroundImage,
   backgroundGradient,
 }: HeroProps) {
+  const ctaRef = useRef<HTMLAnchorElement>(null);
+  useInactivityNudge(ctaRef);
   return (
     <section className="relative isolate overflow-hidden">
       {backgroundImage && (
@@ -40,6 +46,7 @@ export default function Hero({
         {subline && <p className="mt-4 text-lg">{subline}</p>}
         {cta && (
           <Link
+            ref={ctaRef}
             href={cta.href}
             className="mt-8 inline-block rounded-md border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-6 py-2 font-medium text-[var(--brand-primary-contrast)] shadow-sm hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)]"
           >

--- a/lib/useInactivityNudge.ts
+++ b/lib/useInactivityNudge.ts
@@ -1,0 +1,34 @@
+import { RefObject, useEffect } from "react";
+
+export default function useInactivityNudge(
+  ref: RefObject<HTMLElement>,
+  delay = 5000
+) {
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const start = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        element.classList.add("animate-pulse");
+      }, delay);
+    };
+
+    const reset = () => {
+      element.classList.remove("animate-pulse");
+      start();
+    };
+
+    start();
+    const events = ["mousemove", "keydown", "scroll", "touchstart"];
+    events.forEach((evt) => window.addEventListener(evt, reset));
+
+    return () => {
+      clearTimeout(timeout);
+      events.forEach((evt) => window.removeEventListener(evt, reset));
+    };
+  }, [ref, delay]);
+}


### PR DESCRIPTION
## Summary
- add hook to pulse elements after user inactivity
- trigger gentle pulse on header Giving link and hero CTA buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9e5151c00832c9a411fde8bc333e2