### PR TITLE
feat: nudge CTA buttons after inactivity

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import type { HeroSlide } from '@/lib/queries';
+import useNudge from '@/lib/useNudge';
 
 export interface HeroProps {
   slides: HeroSlide[];
@@ -13,6 +14,8 @@ export interface HeroProps {
 export default function Hero({ slides, intervalMs = 8000 }: HeroProps) {
   const [index, setIndex] = useState(0);
   const count = slides.length;
+  const ctaRef = useRef<HTMLAnchorElement>(null);
+  const shouldNudge = useNudge(ctaRef);
 
   useEffect(() => {
     if (count <= 1) return;
@@ -51,10 +54,11 @@ export default function Hero({ slides, intervalMs = 8000 }: HeroProps) {
             {slide.subline && <p className="mt-4 text-lg">{slide.subline}</p>}
             {slide.cta && slide.cta.href && slide.cta.label && (
               <Link
+                ref={ctaRef}
                 href={slide.cta.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="mt-8 inline-block rounded-md border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-6 py-2 font-medium text-[var(--brand-primary-contrast)] shadow-sm hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)]"
+                className={`mt-8 inline-block rounded-md border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-6 py-2 font-medium text-[var(--brand-primary-contrast)] shadow-sm hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)] ${shouldNudge ? 'animate-pulse' : ''}`}
               >
                 {slide.cta.label}
               </Link>

--- a/lib/useNudge.ts
+++ b/lib/useNudge.ts
@@ -1,0 +1,50 @@
+import { RefObject, useEffect, useState } from 'react';
+
+export function useNudge<T extends HTMLElement>(
+  ref: RefObject<T>,
+  delay = 5000
+) {
+  const [shouldNudge, setShouldNudge] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    let timeout: ReturnType<typeof setTimeout>;
+    let inView = false;
+
+    const reset = () => {
+      clearTimeout(timeout);
+      setShouldNudge(false);
+      if (inView) {
+        timeout = setTimeout(() => setShouldNudge(true), delay);
+      }
+    };
+
+    const observer = new IntersectionObserver(([entry]) => {
+      inView = entry.isIntersecting;
+      reset();
+    });
+
+    observer.observe(el);
+
+    const handleActivity = () => reset();
+    window.addEventListener('scroll', handleActivity);
+    window.addEventListener('mousemove', handleActivity);
+    window.addEventListener('keydown', handleActivity);
+
+    reset();
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('scroll', handleActivity);
+      window.removeEventListener('mousemove', handleActivity);
+      window.removeEventListener('keydown', handleActivity);
+      clearTimeout(timeout);
+    };
+  }, [ref, delay]);
+
+  return shouldNudge;
+}
+
+export default useNudge;


### PR DESCRIPTION
## Summary
- add reusable `useNudge` hook to trigger animation after inactivity
- gently pulse Hero call-to-action button when user is idle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac8301988c832cb8bb04f13fba24c5