### PR TITLE
feat: add logo watermark background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,21 @@ body {
   /* Base typography colors and background driven by tokens */
   background-color: var(--brand-bg);
   color: var(--brand-fg);
+  position: relative;
   @apply antialiased transition-colors;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: var(--watermark-url);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 50vmin;
+  opacity: 0.05;
+  pointer-events: none;
+  z-index: -1;
 }
 
 a {
@@ -34,6 +48,7 @@ img {
 /* Brand color tokens for light and dark modes */
 :root {
   /* Light mode defaults */
+  --watermark-url: url('/static/favicon.svg');
   --brand-primary: #5C30A6; /* purple */
   --brand-primary-contrast: #FFFFFF;
   --brand-accent: #D6AF36; /* gold */
@@ -77,6 +92,7 @@ img {
 
 /* Fallback for environments mis-parsing :root — define tokens on html as well */
 html {
+  --watermark-url: url('/static/favicon.svg');
   --brand-primary: #5C30A6;
   --brand-primary-contrast: #FFFFFF;
   --brand-accent: #D6AF36;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,12 +38,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const headerTitle = settings?.title ?? "Example Church";
   const maxWidth = "90vw";
   const message = announcement?.message ?? "";
+  const watermarkUrl = settings?.logo ?? "/static/favicon.svg";
 
   return (
     <html lang="en">
       <body
         className="flex min-h-screen flex-col"
-        style={{ "--layout-max-width": maxWidth } as CSSProperties}
+        style={{ "--layout-max-width": maxWidth, "--watermark-url": `url(${watermarkUrl})` } as CSSProperties}
       >
         <Header initialTitle={headerTitle} />
         {message && (


### PR DESCRIPTION
## Summary
- overlay low-opacity site logo as centered watermark background via CSS variable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac83ae3570832cbefb7437d57174d5