### PR TITLE
Add animated logo loader

### DIFF
--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -2,7 +2,7 @@ import LogoSpinner from "@/components/LogoSpinner";
 
 export default function Loading() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--brand-bg)]">
       <LogoSpinner />
     </div>
   );

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,9 @@
+import LogoSpinner from "@/components/LogoSpinner";
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <LogoSpinner />
+    </div>
+  );
+}

--- a/components/LogoSpinner.tsx
+++ b/components/LogoSpinner.tsx
@@ -7,7 +7,7 @@ export default async function LogoSpinner() {
 
   return (
     <div className="flex items-center justify-center">
-      <Image src={logoUrl} alt="Logo" width={64} height={64} className="animate-spin" />
+      <Image src={logoUrl} alt="Logo" width={64} height={64} className="animate-spin rounded-full opacity-80" />
     </div>
   );
 }

--- a/components/LogoSpinner.tsx
+++ b/components/LogoSpinner.tsx
@@ -1,0 +1,13 @@
+import Image from "next/image";
+import { siteSettings } from "@/lib/queries";
+
+export default async function LogoSpinner() {
+  const settings = await siteSettings();
+  const logoUrl = settings?.logo ?? "/static/favicon.svg";
+
+  return (
+    <div className="flex items-center justify-center">
+      <Image src={logoUrl} alt="Logo" width={64} height={64} className="animate-spin" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show animated logo while routes load
- fetch logo from SiteSettings instead of static favicon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac83cc7270832cb0bb112f6a0b5653