### PR TITLE
feat: add logo hover effect

### DIFF
--- a/app/utilities.css
+++ b/app/utilities.css
@@ -36,22 +36,6 @@
     background-color: var(--brand-overlay-muted);
   }
 
-  .logo-hover {
-    @apply transition-all;
-    display: inline-block;
-    color: var(--brand-accent);
-    -webkit-text-fill-color: var(--brand-accent);
-    filter: drop-shadow(0 0 0 transparent);
-  }
-  .logo-hover:hover,
-  .logo-hover:focus {
-    background: none !important;
-    color: var(--brand-alt) !important;
-    -webkit-text-fill-color: var(--brand-alt) !important;
-    animation: none !important;
-    filter: drop-shadow(0 0 4px color-mix(in oklab, var(--brand-alt) 60%, transparent))
-      drop-shadow(0 0 8px color-mix(in oklab, var(--brand-alt) 40%, transparent));
-  }
 }
 
 @layer utilities {
@@ -258,6 +242,42 @@
     animation: shimmer-sweep 12s linear infinite;
   }
 
+  /* Cancel shimmer on hover for opted elements */
+  .no-shimmer-on-hover:hover,
+  .no-shimmer-on-hover:focus,
+  .no-shimmer-on-hover:active {
+    background-image: none !important;
+    -webkit-background-clip: border-box !important;
+    background-clip: border-box !important;
+    color: var(--brand-alt) !important;
+    -webkit-text-fill-color: var(--brand-alt) !important;
+  }
+
+  /* Soft pulsing glow for prominent titles */
+  @keyframes text-glow-pulse {
+    0%, 100% {
+      text-shadow:
+        0 0 0 transparent,
+        0 0 0 transparent;
+    }
+    50% {
+      text-shadow:
+        0 0 6px color-mix(in oklab, var(--brand-accent) 70%, transparent),
+        0 0 14px color-mix(in oklab, var(--brand-accent) 55%, transparent);
+    }
+  }
+  .glow-text {
+    animation: text-glow-pulse 2400ms ease-in-out infinite;
+    will-change: text-shadow, filter;
+  }
+  /* Hover-only variant for glow */
+  .glow-text-hover:hover,
+  .glow-text-hover:focus,
+  .glow-text-hover:active {
+    animation: text-glow-pulse 4200ms ease-in-out infinite;
+    will-change: text-shadow, filter;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .animate-marquee,
     .animate-marquee-single,
@@ -274,7 +294,9 @@
     .annc-border-glow::after,
     .border-glow,
     .shimmer-text,
-    .shimmer-text-slow {
+    .shimmer-text-slow,
+    .glow-text,
+    .glow-text-hover {
       animation: none;
       opacity: 1 !important;
       transform: none !important;
@@ -285,4 +307,5 @@
     }
   }
 }
+
 

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -35,6 +35,20 @@
     @apply pointer-events-none absolute inset-0;
     background-color: var(--brand-overlay-muted);
   }
+
+  .logo-hover {
+    @apply transition-all;
+    filter: drop-shadow(0 0 0 transparent);
+  }
+  .logo-hover:hover,
+  .logo-hover:focus {
+    background-image: none;
+    color: var(--brand-alt);
+    -webkit-text-fill-color: var(--brand-alt);
+    animation: none;
+    filter: drop-shadow(0 0 4px color-mix(in oklab, var(--brand-alt) 60%, transparent))
+      drop-shadow(0 0 8px color-mix(in oklab, var(--brand-alt) 40%, transparent));
+  }
 }
 
 @layer utilities {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -30,7 +30,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
       <div className="max-w-site relative flex h-16 items-center px-4">
         <Link
           href="/"
-          className="logo-hover font-bold shimmer-text-slow"
+          className="font-bold inline-block shimmer-text-slow glow-text-hover no-shimmer-on-hover transition-transform duration-200 hover:no-underline focus:no-underline hover:scale-110 focus:scale-110"
         >
           {siteTitle}
         </Link>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -23,7 +23,10 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
   return (
     <header className="sticky top-0 z-50 border-b border-[var(--brand-border)] bg-[var(--brand-surface)]">
       <div className="max-w-site relative flex h-16 items-center px-4">
-        <Link href="/" className="font-bold shimmer-text-slow text-[var(--brand-accent)] hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)]">
+        <Link
+          href="/"
+          className="logo-hover font-bold shimmer-text-slow text-[var(--brand-accent)]"
+        >
           {siteTitle}
         </Link>
         <nav className="absolute left-1/2 -translate-x-1/2 hidden items-center gap-6 text-sm font-medium md:flex">


### PR DESCRIPTION
## Summary
- add reusable `logo-hover` class with glow and color shift
- apply new hover effect to header logo

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac83d9524c832cb52c0b85af5b1d76