### PR TITLE
Enhance homepage text styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,21 +29,21 @@ export default async function Page() {
         className="w-full opacity-0 animate-fade-in-up"
         style={{ animationDelay: '0.1s' }}
       >
-        <h2 className="mb-4 text-xl font-semibold text-[var(--brand-accent)]">Upcoming Events</h2>
+        <h2 className="mb-6 inline-block border-b-2 border-[var(--brand-accent)] pb-1 text-2xl font-semibold headline-style">Upcoming Events</h2>
         <EventList events={events} />
       </section>
       <section
         className="w-full opacity-0 animate-fade-in-up"
         style={{ animationDelay: '0.2s' }}
       >
-        <h2 className="mb-4 text-xl font-semibold text-[var(--brand-accent)]">Recent Sermon</h2>
+        <h2 className="mb-6 inline-block border-b-2 border-[var(--brand-accent)] pb-1 text-2xl font-semibold headline-style">Recent Sermon</h2>
         <SermonList sermons={sermon ? [sermon] : []} />
       </section>
       <section
         className="w-full opacity-0 animate-fade-in-up"
         style={{ animationDelay: '0.3s' }}
       >
-        <h2 className="mb-4 text-xl font-semibold text-[var(--brand-accent)]">Ministry Highlights</h2>
+        <h2 className="mb-6 inline-block border-b-2 border-[var(--brand-accent)] pb-1 text-2xl font-semibold headline-style">Ministry Highlights</h2>
         <div className="grid gap-6 grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]">
           {ministries.map((min) => (
             <MinistryCard key={min._id} ministry={min} />

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -35,6 +35,14 @@
     @apply pointer-events-none absolute inset-0;
     background-color: var(--brand-overlay-muted);
   }
+
+  .headline-style {
+    @apply font-heading tracking-wide text-[var(--brand-accent)] drop-shadow-sm;
+  }
+
+  .body-style {
+    @apply font-body text-[var(--brand-primary-contrast)] drop-shadow-sm;
+  }
 }
 
 @layer utilities {

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -45,7 +45,7 @@ export function EventCard({
         />
       )}
       <div className="flex flex-1 flex-col p-4">
-        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{event.title}</h3>
+        <h3 className="text-lg font-semibold headline-style">{event.title}</h3>
         <p className="mt-1 text-sm text-[var(--brand-muted)]">
           {event.date}
           {event.location ? ` • ${event.location}` : ""}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -83,8 +83,14 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
           )}
           <div className="absolute inset-0 bg-[var(--brand-overlay)] z-10" />
           <div className="relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center text-[var(--brand-fg)]">
-            <h1 className="text-4xl font-bold tracking-tight">{slide.headline}</h1>
-            {slide.subline && <p className="mt-4 text-lg">{slide.subline}</p>}
+            <h1 className="text-4xl md:text-5xl font-extrabold headline-style drop-shadow-md">
+              {slide.headline}
+            </h1>
+            {slide.subline && (
+              <p className="mt-4 text-lg body-style">
+                {slide.subline}
+              </p>
+            )}
             {slide.cta && slide.cta.href && slide.cta.label && (
               <Link
                 ref={ctaRef}

--- a/components/MinistryCard.tsx
+++ b/components/MinistryCard.tsx
@@ -42,7 +42,7 @@ export function MinistryCard({
         />
       )}
       <div className="flex flex-1 flex-col p-4">
-        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{ministry.name}</h3>
+        <h3 className="text-lg font-semibold headline-style">{ministry.name}</h3>
         <p className="mt-2 flex-1 text-sm text-[var(--brand-fg)]/90">
           {ministry.description}
         </p>

--- a/components/SermonCard.tsx
+++ b/components/SermonCard.tsx
@@ -35,7 +35,7 @@ export function SermonCard({
       style={style}
     >
       <div className="flex flex-1 flex-col p-4">
-        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{sermon.title}</h3>
+        <h3 className="text-lg font-semibold headline-style">{sermon.title}</h3>
         <p className="mt-1 text-sm text-[var(--brand-muted)]">
           {sermon.date}
           {sermon.speaker ? ` • ${sermon.speaker}` : ""}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,10 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        heading: ['Georgia', 'serif'],
+        body: ['Arial', 'sans-serif'],
+      },
       colors: {
         // Project brand palette. Prefer these colors in components over Tailwind defaults.
         brand: {


### PR DESCRIPTION
## Summary
- introduce `headline-style` and `body-style` classes for reusable accent typography
- apply shared header style across hero, section headings, and cards
- extend Tailwind config with heading and body font families

## Testing
- `npm test`
- `npm run lint` *(warnings: react-hooks/exhaustive-deps)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2944f534832c8409e91bcf7535dd