### PR TITLE
fix: ensure Sanity data is always fresh

### DIFF
--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -15,6 +15,13 @@ const client = createClient({
   apiVersion: '2025-08-01',
   useCdn,
   token,
+  // Ensure all Sanity requests bypass Next.js fetch caching so fresh data is returned
+  fetch: (url, init) =>
+    fetch(url, {
+      ...init,
+      cache: 'no-store',
+      next: { revalidate: 0 },
+    }),
   // If a read token is configured, allow fetching drafts as well (useful for preview and staging)
   perspective: token ? 'previewDrafts' : 'published',
 });


### PR DESCRIPTION
## Summary
- disable Next.js caching for all Sanity requests to prevent stale content

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2c85d818832c8de10f1164595938