### PR TITLE
fix: handle touch events for inactivity nudge

### DIFF
--- a/lib/useNudge.ts
+++ b/lib/useNudge.ts
@@ -32,6 +32,8 @@ export function useNudge<T extends HTMLElement>(
     window.addEventListener('scroll', handleActivity);
     window.addEventListener('mousemove', handleActivity);
     window.addEventListener('keydown', handleActivity);
+    window.addEventListener('touchstart', handleActivity);
+    window.addEventListener('touchmove', handleActivity);
 
     reset();
 
@@ -40,6 +42,8 @@ export function useNudge<T extends HTMLElement>(
       window.removeEventListener('scroll', handleActivity);
       window.removeEventListener('mousemove', handleActivity);
       window.removeEventListener('keydown', handleActivity);
+      window.removeEventListener('touchstart', handleActivity);
+      window.removeEventListener('touchmove', handleActivity);
       clearTimeout(timeout);
     };
   }, [ref, delay]);


### PR DESCRIPTION
## Summary
- ensure inactivity nudge responds to touch interactions for mobile users

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af392fb6d8832c98f0776c30b7991b