### PR TITLE
feat: add brand typography

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,7 +9,20 @@ body {
   background-color: var(--brand-bg);
   color: var(--brand-fg);
   position: relative;
-  @apply antialiased transition-colors;
+  @apply font-body antialiased transition-colors;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply font-header;
+}
+
+button {
+  @apply font-button;
 }
 
 body::before {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { CSSProperties } from "react";
+import { Playfair_Display, Inter, Bebas_Neue } from "next/font/google";
 import "./globals.css";
 import "./utilities.css";
 import Header from "@/components/Header";
@@ -7,6 +8,20 @@ import Footer from "@/components/Footer";
 import AnnouncementBanner from "@/components/AnnouncementBanner";
 import BannerAnchor from "@/components/BannerAnchor";
 import { siteSettings, announcementLatest } from "@/lib/queries";
+
+const headerFont = Playfair_Display({
+  subsets: ["latin"],
+  variable: "--font-header",
+});
+const bodyFont = Inter({
+  subsets: ["latin"],
+  variable: "--font-body",
+});
+const buttonFont = Bebas_Neue({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-button",
+});
 
 export const revalidate = 0;
 
@@ -41,7 +56,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const watermarkUrl = settings?.logo ?? "/static/favicon.svg";
 
   return (
-    <html lang="en">
+    <html
+      lang="en"
+      className={`${headerFont.variable} ${bodyFont.variable} ${buttonFont.variable}`}
+    >
       <body
         className="flex min-h-screen flex-col"
         style={{ "--layout-max-width": maxWidth, "--watermark-url": `url(${watermarkUrl})` } as CSSProperties}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -26,7 +26,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
     `${active ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)]`;
 
   return (
-    <header className="sticky top-0 z-50 border-b border-[var(--brand-border)] bg-[var(--brand-surface)]">
+    <header className="font-header sticky top-0 z-50 border-b border-[var(--brand-border)] bg-[var(--brand-surface)]">
       <div className="max-w-site relative flex h-16 items-center px-4">
         <Link
           href="/"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,11 @@ module.exports = {
           950: "#404040",
         },
       },
+      fontFamily: {
+        header: ["var(--font-header)", "serif"],
+        body: ["var(--font-body)", "sans-serif"],
+        button: ["var(--font-button)", "sans-serif"],
+      },
       keyframes: {
         marquee: {
           "0%": { transform: "translateX(100%)" },


### PR DESCRIPTION
## Summary
- add Playfair Display, Inter, and Bebas Neue fonts
- wire font variables into Tailwind and apply to body text, headers, and buttons
- style header component with new typography

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af3db8c98c832cb5655e8c8ee17ee6