### PR TITLE
feat: add staff photos to ministries

### DIFF
--- a/app/ministries/page.tsx
+++ b/app/ministries/page.tsx
@@ -15,7 +15,7 @@ export default async function Page() {
         </p>
       </section>
       <section>
-        <div className="w-full grid gap-8 grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]">
+        <div className="w-full grid gap-8 grid-cols-[repeat(auto-fit,minmax(22rem,1fr))]">
           {ministries.map((ministry) => (
             <MinistryCard key={ministry._id} ministry={ministry} />
           ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,7 +44,7 @@ export default async function Page() {
         style={{ animationDelay: '0.3s' }}
       >
         <h2 className="mb-4 text-xl font-semibold text-[var(--brand-accent)]">Ministry Highlights</h2>
-        <div className="grid gap-6 grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]">
+        <div className="grid gap-6 grid-cols-[repeat(auto-fit,minmax(22rem,1fr))]">
           {ministries.map((min) => (
             <MinistryCard key={min._id} ministry={min} />
           ))}

--- a/components/MinistryCard.tsx
+++ b/components/MinistryCard.tsx
@@ -5,7 +5,6 @@ import type { CSSProperties } from "react";
 export type Ministry = {
   name: string;
   description: string;
-  image?: string;
   staffImage?: string;
   href?: string;
 };
@@ -30,42 +29,37 @@ export function MinistryCard({
   }
   return (
     <div
-      className="card relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-within:-translate-y-1 focus-within:-rotate-1 focus-within:scale-[1.02] focus-within:shadow-lg"
+      className="card relative flex h-full transform overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-within:-translate-y-1 focus-within:-rotate-1 focus-within:scale-[1.02] focus-within:shadow-lg"
       style={style}
     >
-      {ministry.image && (
-        <Image
-          src={ministry.image}
-          alt=""
-          width={400}
-          height={192}
-          className="h-48 w-full object-cover"
-        />
-      )}
-      <div className="flex flex-1 flex-col p-4">
-        <div className="flex items-center gap-4">
-          {ministry.staffImage && (
+      <div className="flex w-full flex-col md:flex-row md:items-start">
+        {ministry.staffImage && (
+          <div className="shrink-0 p-4 md:pr-0 md:pl-4 md:pt-4 md:pb-4">
             <Image
               src={ministry.staffImage}
               alt=""
-              width={80}
-              height={80}
-              className="h-20 w-20 rounded-full object-cover"
+              width={96}
+              height={96}
+              className="h-16 w-16 rounded-full object-cover md:h-24 md:w-24"
             />
-          )}
-          <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{ministry.name}</h3>
-        </div>
-        <p className="mt-2 flex-1 text-sm text-[var(--brand-fg)]/90">
-          {ministry.description}
-        </p>
-        {ministry.href && (
-          <Link
-            href={ministry.href}
-            className="relative mt-4 inline-block rounded px-1 py-0.5 text-sm font-medium text-[var(--brand-accent)] transition-colors hover:underline hover:text-[var(--brand-primary-contrast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] active:bg-[var(--brand-accent)]/20"
-          >
-            Learn more
-          </Link>
+          </div>
         )}
+        <div className="flex min-w-0 flex-1 p-4">
+          <div className="flex w-full flex-col">
+            <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{ministry.name}</h3>
+            <p className="mt-2 text-sm leading-relaxed text-[var(--brand-fg)]/90">
+              {ministry.description}
+            </p>
+            {ministry.href && (
+              <Link
+                href={ministry.href}
+                className="relative mt-4 inline-block self-start rounded px-1 py-0.5 text-sm font-medium text-[var(--brand-accent)] transition-colors hover:underline hover:text-[var(--brand-primary-contrast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] active:bg-[var(--brand-accent)]/20"
+              >
+                Learn more
+              </Link>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/components/MinistryCard.tsx
+++ b/components/MinistryCard.tsx
@@ -6,6 +6,7 @@ export type Ministry = {
   name: string;
   description: string;
   image?: string;
+  staffImage?: string;
   href?: string;
 };
 
@@ -42,7 +43,18 @@ export function MinistryCard({
         />
       )}
       <div className="flex flex-1 flex-col p-4">
-        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{ministry.name}</h3>
+        <div className="flex items-center gap-4">
+          {ministry.staffImage && (
+            <Image
+              src={ministry.staffImage}
+              alt=""
+              width={80}
+              height={80}
+              className="h-20 w-20 rounded-full object-cover"
+            />
+          )}
+          <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{ministry.name}</h3>
+        </div>
         <p className="mt-2 flex-1 text-sm text-[var(--brand-fg)]/90">
           {ministry.description}
         </p>

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -129,17 +129,18 @@ export interface Ministry {
   name: string;
   description: string;
   image?: string;
+  staffImage?: string;
 }
 
 export const ministriesHighlights = (limit: number) =>
   sanity.fetch<Ministry[]>(
-    groq`*[_type == "ministry"] | order(_createdAt desc)[0...$limit]{_id, name, description, "image": image.asset->url}`,
+    groq`*[_type == "ministry"] | order(_createdAt desc)[0...$limit]{_id, name, description, "image": image.asset->url, "staffImage": staffImage.asset->url}`,
     {limit}
   );
 
 export const ministriesAll = () =>
   sanity.fetch<Ministry[]>(
-    groq`*[_type == "ministry"] | order(name asc){_id, name, description, "image": image.asset->url}`
+    groq`*[_type == "ministry"] | order(name asc){_id, name, description, "image": image.asset->url, "staffImage": staffImage.asset->url}`
   );
 
 export interface MissionStatement {

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -128,19 +128,18 @@ export interface Ministry {
   _id: string;
   name: string;
   description: string;
-  image?: string;
   staffImage?: string;
 }
 
 export const ministriesHighlights = (limit: number) =>
   sanity.fetch<Ministry[]>(
-    groq`*[_type == "ministry"] | order(_createdAt desc)[0...$limit]{_id, name, description, "image": image.asset->url, "staffImage": staffImage.asset->url}`,
+    groq`*[_type == "ministry"] | order(_createdAt desc)[0...$limit]{_id, name, description, "staffImage": staffImage.asset->url}`,
     {limit}
   );
 
 export const ministriesAll = () =>
   sanity.fetch<Ministry[]>(
-    groq`*[_type == "ministry"] | order(name asc){_id, name, description, "image": image.asset->url, "staffImage": staffImage.asset->url}`
+    groq`*[_type == "ministry"] | order(name asc){_id, name, description, "staffImage": staffImage.asset->url}`
   );
 
 export interface MissionStatement {

--- a/sanity/schemas/ministry.ts
+++ b/sanity/schemas/ministry.ts
@@ -18,12 +18,6 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
-      name: 'image',
-      title: 'Image',
-      type: 'image',
-      options: { hotspot: true },
-    }),
-    defineField({
       name: 'staffImage',
       title: 'Staff Image',
       type: 'image',

--- a/sanity/schemas/ministry.ts
+++ b/sanity/schemas/ministry.ts
@@ -23,5 +23,11 @@ export default defineType({
       type: 'image',
       options: { hotspot: true },
     }),
+    defineField({
+      name: 'staffImage',
+      title: 'Staff Image',
+      type: 'image',
+      options: { hotspot: true },
+    }),
   ],
 });


### PR DESCRIPTION
## Summary
- allow ministries to include staff images
- surface staff photos on ministry cards

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3e801bd8832cb650597a883b62d0