### PR TITLE
Remove background logo and update loading animation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,7 +53,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const headerTitle = settings?.title ?? "Greater Pentecostal Temple";
   const maxWidth = "90vw";
   const message = announcement?.message ?? "";
-  const watermarkUrl = settings?.logo ?? "/static/favicon.svg";
 
   return (
     <html
@@ -62,7 +61,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     >
       <body
         className="flex min-h-screen flex-col"
-        style={{ "--layout-max-width": maxWidth, "--watermark-url": `url(${watermarkUrl})` } as CSSProperties}
+        style={{ "--layout-max-width": maxWidth } as CSSProperties}
       >
         <Header initialTitle={headerTitle} />
         {message && (

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -106,13 +106,24 @@
   @keyframes logo-pulse {
     0%, 100% {
       opacity: 0.75;
+      transform: scale(1);
+    }
+    25% {
+      opacity: 0.6;
+      transform: scale(1.1);
     }
     50% {
       opacity: 0.5;
+      transform: scale(1);
+    }
+    75% {
+      opacity: 0.6;
+      transform: scale(0.9);
     }
   }
   .animate-logo-pulse {
-    animation: logo-pulse 1500ms ease-in-out infinite;
+    animation: logo-pulse 800ms ease-in-out infinite;
+    will-change: opacity, transform;
   }
 
   /* Fade-in animations */

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -102,6 +102,19 @@
     will-change: box-shadow;
   }
 
+  /* Logo loading pulse */
+  @keyframes logo-pulse {
+    0%, 100% {
+      opacity: 0.75;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+  .animate-logo-pulse {
+    animation: logo-pulse 1500ms ease-in-out infinite;
+  }
+
   /* Fade-in animations */
   @keyframes fade-in-up {
     0% {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -28,7 +28,7 @@ export default async function Footer() {
 
           <div>
             <h4 className="mb-2 font-semibold text-[var(--brand-surface-contrast)]">Service Times</h4>
-            <div className="space-y-0.5">
+            <div className="space-y-0.5 text-[var(--brand-accent)] dark:text-[var(--brand-fg)]">
               {serviceTimes
                 .split(/[,;\n|]+/)
                 .map((s) => s.trim())

--- a/components/LogoSpinner.tsx
+++ b/components/LogoSpinner.tsx
@@ -7,7 +7,7 @@ export default async function LogoSpinner() {
 
   return (
     <div className="flex items-center justify-center">
-      <Image src={logoUrl} alt="Logo" width={64} height={64} className="animate-spin rounded-full opacity-80" />
+      <Image src={logoUrl} alt="Logo" width={64} height={64} className="animate-logo-pulse rounded-full" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove watermark logo from site background
- highlight footer service times in accent color for light mode
- replace spinning logo with pulsing transparent loader

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bba64cfec4832c8a932701a2bfbe1a