### PR TITLE
Slow map block bounce animation

### DIFF
--- a/app/utilities.css
+++ b/app/utilities.css
@@ -182,28 +182,28 @@
   /* Slide in from the upper-left and bounce into place */
   @keyframes mapblock-bounce-in {
     0% {
-      transform: translate(-150%, 0);
+      transform: translate(-140%, -80%);
       opacity: 0;
     }
-    30% {
-      transform: translate(-60%, -50%);
+    35% {
+      transform: translate(-80%, 55%);
       opacity: 1;
     }
-    50% {
-      transform: translate(-20%, 0);
+    55% {
+      transform: translate(-30%, -20%);
     }
     70% {
-      transform: translate(-8%, -25%);
+      transform: translate(-10%, 10%);
     }
     85% {
-      transform: translate(-3%, 0);
+      transform: translate(-4%, -4%);
     }
     100% {
       transform: translate(0, 0);
     }
   }
   .animate-mapblock-bounce-in {
-    animation: mapblock-bounce-in 900ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    animation: mapblock-bounce-in 1200ms cubic-bezier(0.4, 0, 0.2, 1) both;
     will-change: transform, opacity;
     backface-visibility: hidden;
   }

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -182,25 +182,28 @@
   /* Slide in from the upper-left and bounce into place */
   @keyframes mapblock-bounce-in {
     0% {
-      transform: translate(-150%, -80%);
+      transform: translate(-150%, 0);
       opacity: 0;
     }
-    60% {
-      transform: translate(8%, 12%);
+    30% {
+      transform: translate(-60%, -50%);
       opacity: 1;
     }
-    75% {
-      transform: translate(-4%, -6%);
+    50% {
+      transform: translate(-20%, 0);
     }
-    90% {
-      transform: translate(2%, 3%);
+    70% {
+      transform: translate(-8%, -25%);
+    }
+    85% {
+      transform: translate(-3%, 0);
     }
     100% {
       transform: translate(0, 0);
     }
   }
   .animate-mapblock-bounce-in {
-    animation: mapblock-bounce-in 700ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    animation: mapblock-bounce-in 900ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
     will-change: transform, opacity;
     backface-visibility: hidden;
   }

--- a/components/MapBlock.tsx
+++ b/components/MapBlock.tsx
@@ -46,7 +46,7 @@ export default function MapBlock({ address, zoom = 15 }: MapBlockProps) {
       el.addEventListener("animationend", onDone, { once: true });
       el.classList.add("animate-mapblock-bounce-in");
       // Fallback in case animationend doesn't fire (e.g., prefers-reduced-motion)
-      setTimeout(onDone, 800);
+      setTimeout(onDone, 1000);
     }
 
     const observer = new IntersectionObserver((entries) => {

--- a/components/MapBlock.tsx
+++ b/components/MapBlock.tsx
@@ -46,7 +46,7 @@ export default function MapBlock({ address, zoom = 15 }: MapBlockProps) {
       el.addEventListener("animationend", onDone, { once: true });
       el.classList.add("animate-mapblock-bounce-in");
       // Fallback in case animationend doesn't fire (e.g., prefers-reduced-motion)
-      setTimeout(onDone, 1000);
+      setTimeout(onDone, 1500);
     }
 
     const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
## Summary
- make MapBlock bounce in more slowly with arching vertical hops from the left
- extend animation fallback timing for slower bounce-in

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbb8228c9c832c9f5260668bfc9677