### PR TITLE
Hide empty Upcoming Events section on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,24 +17,27 @@ export default async function Page() {
   ]);
 
   const address = settings?.address ?? "";
+  const hasEvents = events.length > 0;
 
   return (
     <div className="w-full space-y-12">
       <Hero slides={slides} />
       <VisitorCTA />
+      {hasEvents && (
+        <section
+          className="w-full opacity-0 animate-fade-in-up"
+          style={{ animationDelay: '0.1s' }}
+        >
+          <h2 className="mb-4 text-xl font-semibold text-[var(--brand-accent)]">Upcoming Events</h2>
+          <EventList events={events} />
+        </section>
+      )}
       <section
         className="w-full opacity-0 animate-fade-in-up"
-        style={{ animationDelay: '0.1s' }}
+        style={{ animationDelay: hasEvents ? '0.2s' : '0.1s' }}
       >
-        <h2 className="mb-4 text-xl font-semibold text-[var(--brand-accent)]">Upcoming Events</h2>
-        <EventList events={events} />
+        <SocialCTA />
       </section>
-        <section
-            className="w-full opacity-0 animate-fade-in-up"
-            style={{ animationDelay: '0.2s' }}
-        >
-            <SocialCTA />
-        </section>
       <MapBlock address={address} />
     </div>
   );


### PR DESCRIPTION
## Summary
- Skip rendering Upcoming Events section when no upcoming events
- Adjust Social CTA animation timing when events are absent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbb8378eb8832c95629ee4befc58a1