### PR TITLE
feat: add spiral drop animation for map block

### DIFF
--- a/app/utilities.css
+++ b/app/utilities.css
@@ -179,29 +179,26 @@
     backface-visibility: hidden;
   }
 
-  /* Spiral drop animation for MapBlock container */
-  @keyframes spiralDrop {
+  /* Zoom-in from left with elastic rebound for MapBlock container */
+  @keyframes zoomInLeftElastic {
     0% {
-      transform: translate(-120%, -120%) rotate(-360deg) scale(0.25);
+      transform: translateX(-120%) scale(0.5);
       opacity: 0;
     }
-    25% {
-      transform: translate(-90%, 90%) rotate(-270deg) scale(0.5);
+    60% {
+      transform: translateX(10%) scale(1.05);
       opacity: 1;
     }
-    50% {
-      transform: translate(60%, 60%) rotate(-180deg) scale(0.75);
-    }
-    75% {
-      transform: translate(30%, -30%) rotate(-90deg) scale(0.9);
+    80% {
+      transform: translateX(-5%) scale(0.95);
     }
     100% {
-      transform: translate(0, 0) rotate(0deg) scale(1);
+      transform: translateX(0) scale(1);
       opacity: 1;
     }
   }
-  .animate-spiral-drop {
-    animation: spiralDrop 2000ms linear both;
+  .animate-zoom-in-left-elastic {
+    animation: zoomInLeftElastic 1500ms cubic-bezier(0.22, 1, 0.36, 1) both;
     will-change: transform, opacity;
     backface-visibility: hidden;
   }

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -182,23 +182,23 @@
   /* Spiral drop animation for MapBlock container */
   @keyframes spiralDrop {
     0% {
-      transform: translate(-150%, -150%) rotate(-720deg) scale(0.2);
+      transform: translate(-120%, -120%) rotate(-540deg) scale(0.25);
       opacity: 0;
     }
-    50% {
-      transform: translate(20%, 20%) rotate(-360deg) scale(0.6);
+    40% {
+      transform: translate(15%, 10%) rotate(-270deg) scale(0.55);
       opacity: 1;
     }
-    75% {
-      transform: translate(-10%, 5%) rotate(-180deg) scale(0.85);
+    70% {
+      transform: translate(-5%, 3%) rotate(-90deg) scale(0.85);
     }
     100% {
-      transform: translate(0, 0) rotate(0) scale(1);
+      transform: translate(0, 0) rotate(0deg) scale(1);
       opacity: 1;
     }
   }
   .animate-spiral-drop {
-    animation: spiralDrop 800ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    animation: spiralDrop 2000ms cubic-bezier(0.22, 1, 0.36, 1) both;
     will-change: transform, opacity;
     backface-visibility: hidden;
   }

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -179,28 +179,26 @@
     backface-visibility: hidden;
   }
 
-  /* Slide in from the upper-left and bounce into place */
-  @keyframes mapblock-bounce-in {
+  /* Spiral drop animation for MapBlock container */
+  @keyframes spiralDrop {
     0% {
-      transform: translate(-150%, -80%);
+      transform: translate(-150%, -150%) rotate(-720deg) scale(0.2);
       opacity: 0;
     }
-    60% {
-      transform: translate(8%, 12%);
+    50% {
+      transform: translate(20%, 20%) rotate(-360deg) scale(0.6);
       opacity: 1;
     }
     75% {
-      transform: translate(-4%, -6%);
-    }
-    90% {
-      transform: translate(2%, 3%);
+      transform: translate(-10%, 5%) rotate(-180deg) scale(0.85);
     }
     100% {
-      transform: translate(0, 0);
+      transform: translate(0, 0) rotate(0) scale(1);
+      opacity: 1;
     }
   }
-  .animate-mapblock-bounce-in {
-    animation: mapblock-bounce-in 700ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  .animate-spiral-drop {
+    animation: spiralDrop 800ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
     will-change: transform, opacity;
     backface-visibility: hidden;
   }

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -182,15 +182,18 @@
   /* Spiral drop animation for MapBlock container */
   @keyframes spiralDrop {
     0% {
-      transform: translate(-120%, -120%) rotate(-540deg) scale(0.25);
+      transform: translate(-120%, -120%) rotate(-360deg) scale(0.25);
       opacity: 0;
     }
-    40% {
-      transform: translate(12%, 8%) rotate(-324deg) scale(0.55);
+    25% {
+      transform: translate(-90%, 90%) rotate(-270deg) scale(0.5);
       opacity: 1;
     }
-    70% {
-      transform: translate(3%, 2%) rotate(-162deg) scale(0.85);
+    50% {
+      transform: translate(60%, 60%) rotate(-180deg) scale(0.75);
+    }
+    75% {
+      transform: translate(30%, -30%) rotate(-90deg) scale(0.9);
     }
     100% {
       transform: translate(0, 0) rotate(0deg) scale(1);

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -186,11 +186,11 @@
       opacity: 0;
     }
     40% {
-      transform: translate(15%, 10%) rotate(-270deg) scale(0.55);
+      transform: translate(12%, 8%) rotate(-324deg) scale(0.55);
       opacity: 1;
     }
     70% {
-      transform: translate(-5%, 3%) rotate(-90deg) scale(0.85);
+      transform: translate(3%, 2%) rotate(-162deg) scale(0.85);
     }
     100% {
       transform: translate(0, 0) rotate(0deg) scale(1);
@@ -198,7 +198,7 @@
     }
   }
   .animate-spiral-drop {
-    animation: spiralDrop 2000ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation: spiralDrop 2000ms linear both;
     will-change: transform, opacity;
     backface-visibility: hidden;
   }

--- a/components/MapBlock.tsx
+++ b/components/MapBlock.tsx
@@ -46,7 +46,7 @@ export default function MapBlock({ address, zoom = 15 }: MapBlockProps) {
       el.addEventListener("animationend", onDone, { once: true });
       el.classList.remove("opacity-0");
       // Fallback in case animationend doesn't fire (e.g., prefers-reduced-motion)
-      setTimeout(onDone, 800);
+      setTimeout(onDone, 2000);
     }
 
     const observer = new IntersectionObserver((entries) => {

--- a/components/MapBlock.tsx
+++ b/components/MapBlock.tsx
@@ -42,11 +42,11 @@ export default function MapBlock({ address, zoom = 15 }: MapBlockProps) {
         revealDoneRef.current = true;
         tryBounce();
       };
-      el.classList.add("animate-spiral-drop");
+      el.classList.add("animate-zoom-in-left-elastic");
       el.addEventListener("animationend", onDone, { once: true });
       el.classList.remove("opacity-0");
       // Fallback in case animationend doesn't fire (e.g., prefers-reduced-motion)
-      setTimeout(onDone, 2000);
+      setTimeout(onDone, 1500);
     }
 
     const observer = new IntersectionObserver((entries) => {

--- a/components/MapBlock.tsx
+++ b/components/MapBlock.tsx
@@ -42,9 +42,9 @@ export default function MapBlock({ address, zoom = 15 }: MapBlockProps) {
         revealDoneRef.current = true;
         tryBounce();
       };
-      el.classList.remove("opacity-0");
+      el.classList.add("animate-spiral-drop");
       el.addEventListener("animationend", onDone, { once: true });
-      el.classList.add("animate-mapblock-bounce-in");
+      el.classList.remove("opacity-0");
       // Fallback in case animationend doesn't fire (e.g., prefers-reduced-motion)
       setTimeout(onDone, 800);
     }


### PR DESCRIPTION
## Summary
- animate MapBlock container with new spiralDrop sequence for spinning descent and growth
- remove legacy bounce animation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbc304d204832c88a2af0414410426