### PR TITLE
feat: open external links in new tab

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -96,6 +96,8 @@ export default async function Footer() {
                 <li key={label}>
                   <a
                     href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     aria-label={label}
                     className="rounded text-[var(--brand-muted)] hover:text-[var(--brand-alt)] focus-visible:text-[var(--brand-alt)] focus-visible:ring-1 focus-visible:ring-[var(--brand-alt)]"
                   >

--- a/components/SocialCTA.tsx
+++ b/components/SocialCTA.tsx
@@ -14,6 +14,8 @@ function SocialCard({ href, label, description, Icon }: SocialItem) {
   return (
     <a
       href={href}
+      target="_blank"
+      rel="noopener noreferrer"
       className="group flex h-full flex-col items-center justify-center gap-2 rounded-full border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 text-center transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface)_85%,white_15%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)]"
     >
       <Icon className="h-8 w-8 text-[var(--brand-accent)] transition-all group-hover:scale-105 group-hover:text-[var(--brand-primary-contrast)]" />

--- a/components/StaffCard.tsx
+++ b/components/StaffCard.tsx
@@ -48,6 +48,8 @@ export function StaffCard({
         {staff.email && (
           <a
             href={`mailto:${staff.email}`}
+            target="_blank"
+            rel="noopener noreferrer"
             className="mt-2 block text-sm font-medium text-[var(--brand-accent)] hover:underline hover:text-[var(--brand-primary-contrast)]"
           >
             {staff.email}


### PR DESCRIPTION
## Summary
- ensure footer social links open in a new tab
- add target and rel attributes to SocialCTA items and staff email links

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc6b3ca90832c86ad7527b465e3a0