### PR TITLE
feat: add event timeline view

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,5 +1,5 @@
 import EventsSegmentedTabs, { type EventsShow } from "@/components/EventsSegmentedTabs";
-import EventGallery from "@/components/EventGallery";
+import { EventList } from "@/components/EventList";
 import { eventsAll } from "@/lib/queries";
 import type { Event as SanityEvent } from "@/lib/queries";
 
@@ -38,7 +38,7 @@ export default async function Page({
       <h1 className="text-2xl font-semibold">Events</h1>
       <EventsSegmentedTabs current={show} />
       <section className="w-full">
-        <EventGallery events={events} />
+        <EventList events={events} mode="timeline" />
       </section>
     </div>
   );

--- a/components/EventList.tsx
+++ b/components/EventList.tsx
@@ -1,12 +1,23 @@
 import { Event, EventCard } from "./EventCard";
+import { EventTimeline } from "./EventTimeline";
 
-export function EventList({ events }: { events: Event[] }) {
+export function EventList({
+  events,
+  mode = "grid",
+}: {
+  events: Event[];
+  mode?: "grid" | "timeline";
+}) {
   if (events.length === 0) {
     return (
       <div className="grid gap-6 grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]">
         <p className="col-span-full text-sm text-[var(--brand-muted)]">No events found.</p>
       </div>
     );
+  }
+
+  if (mode === "timeline") {
+    return <EventTimeline events={events} />;
   }
 
   return (
@@ -18,3 +29,4 @@ export function EventList({ events }: { events: Event[] }) {
   );
 }
 
+export { EventTimeline };

--- a/components/EventTimeline.tsx
+++ b/components/EventTimeline.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from "react";
+import type { Event } from "./EventCard";
+
+function TimelineItem({ event }: { event: Event }) {
+  const ref = useRef<HTMLLIElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1 }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  const date = new Date(event.date).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <li
+      ref={ref}
+      className={`relative pl-8 transition-all duration-500 ease-out translate-y-4 opacity-0 ${
+        visible ? "translate-y-0 opacity-100" : ""
+      }`}
+    >
+      <span className="absolute left-0 top-2 h-3 w-3 rounded-full bg-[var(--brand-accent)]" />
+      <h3 className="font-semibold text-[var(--brand-surface-contrast)]">{event.title}</h3>
+      <time className="block text-sm text-[var(--brand-muted)]">{date}</time>
+      {event.description && (
+        <p className="mt-1 text-sm text-[var(--brand-fg)]/90">{event.description}</p>
+      )}
+    </li>
+  );
+}
+
+export function EventTimeline({ events }: { events: Event[] }) {
+  if (events.length === 0) {
+    return (
+      <div className="pl-4">
+        <p className="text-sm text-[var(--brand-muted)]">No events found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="relative space-y-8 pl-4">
+      <span className="absolute left-1 top-0 h-full w-px bg-[var(--brand-border)]" />
+      {events.map(ev => (
+        <TimelineItem key={ev._id} event={ev} />
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add EventTimeline component with intersection observer animations
- allow EventList to render grid or timeline layouts
- render events page using timeline layout instead of a separate timeline route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc591b1f30832cbd21fc579c6c2fb0