### PR TITLE
Refresh site data regularly

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import Footer from "@/components/Footer";
 import AnnouncementBanner from "@/components/AnnouncementBanner";
 import BannerAnchor from "@/components/BannerAnchor";
 import { siteSettings, announcementLatest } from "@/lib/queries";
+import AutoRefresh from "@/components/AutoRefresh";
 
 const headerFont = Playfair_Display({
   subsets: ["latin"],
@@ -63,6 +64,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         className="flex min-h-screen flex-col"
         style={{ "--layout-max-width": maxWidth } as CSSProperties}
       >
+        <AutoRefresh />
         <Header initialTitle={headerTitle} />
         {message && (
           <BannerAnchor gap={0}>

--- a/components/AutoRefresh.tsx
+++ b/components/AutoRefresh.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+export default function AutoRefresh() {
+  const router = useRouter();
+  useEffect(() => {
+    const id = setInterval(() => {
+      router.refresh();
+    }, FIVE_MINUTES);
+    return () => clearInterval(id);
+  }, [router]);
+  return null;
+}
+

--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -9,7 +9,7 @@ const token = process.env.SANITY_READ_TOKEN;
 
 const useCdn = false; // Always disable CDN to ensure fresh data
 
-// Allow cached responses but revalidate after five minutes globally
+// Cache responses for up to five minutes, then revalidate in the background
 const revalidateFetch: typeof globalThis.fetch = (
   url: RequestInfo | URL,
   init?: RequestInit,


### PR DESCRIPTION
## Summary
- fetch Sanity data with five-minute cache revalidation
- auto refresh router every five minutes so pages pull new content

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc5cdfc17c832cbf939fc4f9ea6d32