### PR TITLE
feat: enhance livestream page with live badge and countdown

### DIFF
--- a/app/livestreams/page.tsx
+++ b/app/livestreams/page.tsx
@@ -1,22 +1,46 @@
 import Image from "next/image";
 import { getCurrentLivestream, getRecentLivestreams } from "@/lib/vimeo";
+import { serviceNext } from "@/lib/queries";
+import Countdown from "@/components/Countdown";
 
 export const metadata = { title: "Livestreams" };
 
 export default async function Page() {
-  const [current, recent] = await Promise.all([
+  const [current, recent, next] = await Promise.all([
     getCurrentLivestream(),
     getRecentLivestreams(),
+    serviceNext(),
   ]);
+  const live = current?.live?.status === "streaming";
   return (
     <div>
       {current && (
-        <div className="relative mb-8 aspect-video w-full overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-bg)]">
-          <iframe
-            src={`https://player.vimeo.com/video/${current.id}`}
-            allow="fullscreen; picture-in-picture"
-            className="h-full w-full"
-          />
+        <>
+          <div className="mb-2 flex items-center gap-2 text-[var(--brand-fg)]">
+            <h1 className="text-2xl font-bold">{current.name}</h1>
+            {live && (
+              <span className="rounded bg-[var(--brand-accent)] px-2 py-0.5 text-xs font-semibold uppercase text-[var(--brand-ink)]">
+                Live
+              </span>
+            )}
+            {typeof current.stats?.viewers === "number" && (
+              <span className="text-sm font-medium">
+                {current.stats.viewers} watching
+              </span>
+            )}
+          </div>
+          <div className="relative mb-8 aspect-video w-full overflow-hidden rounded-lg bg-gradient-to-r from-brand-purple to-brand-gold p-[2px]">
+            <iframe
+              src={`https://player.vimeo.com/video/${current.id}`}
+              allow="fullscreen; picture-in-picture"
+              className="h-full w-full rounded-md"
+            />
+          </div>
+        </>
+      )}
+      {!live && next && (
+        <div className="mb-8">
+          <Countdown target={new Date(next.date)} />
         </div>
       )}
       {recent.length > 0 && (

--- a/components/Countdown.tsx
+++ b/components/Countdown.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Props {
+  target: Date;
+}
+
+export default function Countdown({ target }: Props) {
+  const [remaining, setRemaining] = useState(target.getTime() - Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRemaining(target.getTime() - Date.now());
+    }, 1000);
+    return () => clearInterval(id);
+  }, [target]);
+
+  if (remaining <= 0) return null;
+
+  const days = Math.floor(remaining / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((remaining / (1000 * 60 * 60)) % 24);
+  const minutes = Math.floor((remaining / (1000 * 60)) % 60);
+  const seconds = Math.floor((remaining / 1000) % 60);
+
+  return (
+    <div className="text-center text-lg font-semibold text-[var(--brand-fg)]">
+      {days > 0 && `${days}d `}
+      {String(hours).padStart(2, '0')}:{String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')} until next stream
+    </div>
+  );
+}
+

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -45,6 +45,21 @@ export const eventsAll = () =>
     groq`*[_type == "event"] | order(date asc){_id, title, date, description, location, "image": image.asset->url}`
   );
 
+export interface Service {
+  _id: string;
+  title: string;
+  date: string;
+  description?: string;
+}
+
+export const serviceNext = () => {
+  const now = new Date().toISOString();
+  return sanity.fetch<Service | null>(
+    groq`*[_type == "service" && date >= $now] | order(date asc)[0]{_id, title, date, description}`,
+    { now }
+  );
+};
+
 export interface Staff {
   _id: string;
   name: string;

--- a/lib/vimeo.ts
+++ b/lib/vimeo.ts
@@ -3,6 +3,8 @@ export type VimeoVideo = {
   name: string
   link: string
   pictures?: { sizes: { link: string }[] }
+  live?: { status?: string }
+  stats?: { viewers?: number }
 }
 
 export type VimeoItem = VimeoVideo & { id: string }
@@ -21,7 +23,7 @@ function idFromUri(uri: string) {
 export async function getCurrentLivestream(): Promise<VimeoItem | null> {
   if (!user || !token) return null
   const res = await fetch(
-    `https://api.vimeo.com/users/${user}/videos?filter=live&per_page=1&sort=date&direction=desc`,
+    `https://api.vimeo.com/users/${user}/videos?filter=live&per_page=1&sort=date&direction=desc&fields=uri,name,link,pictures.sizes.link,live.status,stats.viewers`,
     { headers, next: { revalidate: 60 } }
   )
   if (!res.ok) return null
@@ -34,7 +36,7 @@ export async function getCurrentLivestream(): Promise<VimeoItem | null> {
 export async function getRecentLivestreams(): Promise<VimeoItem[]> {
   if (!user || !token) return []
   const res = await fetch(
-    `https://api.vimeo.com/users/${user}/videos?filter=live&per_page=10&sort=date&direction=desc`,
+    `https://api.vimeo.com/users/${user}/videos?filter=live&per_page=10&sort=date&direction=desc&fields=uri,name,link,pictures.sizes.link`,
     { headers, next: { revalidate: 60 } }
   )
   if (!res.ok) return []


### PR DESCRIPTION
## Summary
- show livestream title with optional Live badge and viewer count
- wrap stream iframe with branded gradient border
- add upcoming service countdown when stream offline

## Testing
- `npm test`
- `npm run lint` *(fails: Warning: React Hook useEffect has a missing dependency and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a29f84c832c86552b66245ab5d6