### PR TITLE
Configure singleton Site Settings in Sanity

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export const revalidate = 300;
 export async function generateMetadata(): Promise<Metadata> {
   const settings = await siteSettings();
   const title = settings?.title ?? "Greater Pentecostal Temple";
-  const description = settings?.description ?? "Greater Pentecostal Temple website";
+  const description = "Greater Pentecostal Temple website";
   const logoUrl = settings?.logo ?? "/static/favicon.ico";
 
   return {

--- a/components/SocialCTA.tsx
+++ b/components/SocialCTA.tsx
@@ -26,12 +26,9 @@ function SocialCard({ href, label, description, Icon }: SocialItem) {
 }
 
 export default async function SocialCTA() {
-  const [latest, settings] = await Promise.all([
-      getLatestSundayLivestream(),
-    siteSettings(),
-  ]);
-
-  const channelId = process.env.YOUTUBE_CHANNEL_ID;
+  const settings = await siteSettings();
+  const channelId = settings?.youtubeChannelId;
+  const latest = channelId ? await getLatestSundayLivestream(channelId) : null;
   const embedUrl = latest?.id
     ? `https://www.youtube.com/embed/${latest.id}`
     : channelId

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -79,16 +79,16 @@ export interface SocialLink {
 export interface SiteSettings {
   _id: string;
   title: string;
-  description?: string;
   address?: string;
   serviceTimes?: string;
   logo?: string;
   socialLinks?: SocialLink[];
+  youtubeChannelId?: string;
 }
 
 export const siteSettings = () =>
   sanity.fetch<SiteSettings | null>(
-    groq`*[_type == "siteSettings"] | order(_updatedAt desc)[0]{_id, title, description, address, serviceTimes, "logo": logo.asset->url, "socialLinks": socialLinks[]{label, href, description, icon}}`
+    groq`*[_id == "siteSettings"][0]{_id, title, address, serviceTimes, youtubeChannelId, "logo": logo.asset->url, "socialLinks": socialLinks[]{label, href, description, icon}}`
   );
 
 export interface Ministry {

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,7 +1,6 @@
-export async function getLatestSundayLivestream(): Promise<
-  { id: string; published: Date } | null
-> {
-  const channelId = process.env.YOUTUBE_CHANNEL_ID;
+export async function getLatestSundayLivestream(
+  channelId: string
+): Promise<{ id: string; published: Date } | null> {
   if (!channelId) return null;
 
   try {

--- a/sanity/deskStructure.ts
+++ b/sanity/deskStructure.ts
@@ -8,7 +8,11 @@ export const structure = (S: any) =>
       S.documentTypeListItem('service').title('Services'),
       S.documentTypeListItem('ministry').title('Ministries'),
       S.documentTypeListItem('heroSlide').title('Hero Slides'),
-      S.documentTypeListItem('siteSettings').title('Site Settings'),
+      S.listItem()
+        .title('Site Settings')
+        .child(
+          S.document().schemaType('siteSettings').documentId('siteSettings')
+        ),
       S.documentTypeListItem('staff').title('Staff'),
       S.documentTypeListItem('missionStatement').title('Mission Statement'),
     ])

--- a/sanity/schemas/siteSettings.ts
+++ b/sanity/schemas/siteSettings.ts
@@ -4,6 +4,7 @@ export default defineType({
   name: 'siteSettings',
   title: 'Site Settings',
   type: 'document',
+  __experimental_actions: ['update', 'publish'],
   fields: [
     defineField({
       name: 'title',
@@ -18,12 +19,6 @@ export default defineType({
       options: { hotspot: true }
     }),
     defineField({
-      name: 'description',
-      title: 'Description',
-      type: 'text',
-      validation: (Rule) => Rule.required(),
-    }),
-    defineField({
       name: 'address',
       title: 'Address',
       type: 'string',
@@ -33,6 +28,11 @@ export default defineType({
       title: 'Service Times',
       type: 'string',
       description: 'e.g., Sundays 9am & 11am; Wednesdays 7pm',
+    }),
+    defineField({
+      name: 'youtubeChannelId',
+      title: 'YouTube Channel ID',
+      type: 'string',
     }),
     defineField({
       name: 'socialLinks',


### PR DESCRIPTION
## Summary
- drop seed-site-settings script
- remove unused site description and fetch YouTube channel ID from Site Settings
- load YouTube channel ID from Site Settings instead of environment variable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc60be31a0832caebe9ea043f41e5c