### PR TITLE
Fetch Vimeo credentials from Sanity settings

### DIFF
--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -99,11 +99,13 @@ export interface SiteSettings {
   logo?: string;
   socialLinks?: SocialLink[];
   youtubeChannelId?: string;
+  vimeoUserId?: string;
+  vimeoAccessToken?: string;
 }
 
 export const siteSettings = () =>
   sanity.fetch<SiteSettings | null>(
-    groq`*[_id == "siteSettings"][0]{_id, title, address, serviceTimes, youtubeChannelId, "logo": logo.asset->url, "socialLinks": socialLinks[]{label, href, description, icon}}`
+    groq`*[_id == "siteSettings"][0]{_id, title, address, serviceTimes, youtubeChannelId, vimeoUserId, vimeoAccessToken, "logo": logo.asset->url, "socialLinks": socialLinks[]{label, href, description, icon}}`
   );
 
 export interface Ministry {

--- a/sanity/schemas/siteSettings.ts
+++ b/sanity/schemas/siteSettings.ts
@@ -35,6 +35,16 @@ export default defineType({
       type: 'string',
     }),
     defineField({
+      name: 'vimeoUserId',
+      title: 'Vimeo User ID',
+      type: 'string',
+    }),
+    defineField({
+      name: 'vimeoAccessToken',
+      title: 'Vimeo Access Token',
+      type: 'string',
+    }),
+    defineField({
       name: 'socialLinks',
       title: 'Social Links',
       type: 'array',


### PR DESCRIPTION
## Summary
- add Vimeo user ID and access token fields to Sanity site settings schema and query
- retrieve Vimeo credentials from site settings in Vimeo API helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc69e97028832c9ef292f3fab7c15b