### PR TITLE
Add Google Analytics plugin to Sanity studio

### DIFF
--- a/config/google-analytics-plugin.json
+++ b/config/google-analytics-plugin.json
@@ -1,0 +1,4 @@
+{
+  "clientId": "YOUR_GOOGLE_CLIENT_ID",
+  "views": "ga:YOUR_VIEW_ID"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sanity": "^3.99.0",
+        "sanity-plugin-google-analytics": "^0.2.6",
         "styled-components": "^6.1.19"
       },
       "devDependencies": {
@@ -5970,20 +5971,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@sanity/types": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.5.0.tgz",
-      "integrity": "sha512-Q26ySIMLdGQnKn3qIoNy0c3fr2g0TYFeJQ1ypnNiJG2O7VmGXUjDT8pMVONMbZ6jlBXEmIgVE/ex/GGrRUndUg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sanity/client": "^7.8.2",
-        "@sanity/media-library-types": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "18 || 19"
-      }
-    },
     "node_modules/@sanity/ui": {
       "version": "2.16.12",
       "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.16.12.tgz",
@@ -9876,7 +9863,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -13666,7 +13653,7 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -15858,6 +15845,18 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
     },
+    "node_modules/react-debounce-render": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-debounce-render/-/react-debounce-render-5.0.0.tgz",
+      "integrity": "sha512-3u4oUcZ1i9bOtENfnHW5f2x74b+01teKG24+NbuKSklCQhknWq/euyYiBnuRFhyJdaniVmtNqtLL66+2jCHXLw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "peerDependencies": {
+        "react": ">= 15"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -15900,6 +15899,20 @@
         }
       }
     },
+    "node_modules/react-google-charts": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-3.0.15.tgz",
+      "integrity": "sha512-78s5xOQOJvL+jIewrWQZEHtlVk+5Yh4zZy+ODA1on1o1FaRjKWXxoo4n4JQl1XuqkF/A9NWque3KqM6pMggjzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-load-script": "^0.0.6"
+      },
+      "peerDependencies": {
+        "prop-types": ">=15",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
     "node_modules/react-i18next": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.0.2.tgz",
@@ -15922,12 +15935,16 @@
         }
       }
     },
-    "node_modules/react-is": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
-      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+    "node_modules/react-load-script": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/react-load-script/-/react-load-script-0.0.6.tgz",
+      "integrity": "sha512-aRGxDGP9VoLxcsaYvKWIW+LRrMOzz2eEcubTS4NvQPPugjk2VvMhow0wWTkSl7RxookomD1MwcP4l5UStg5ShQ==",
+      "deprecated": "abandoned and unmaintained",
       "license": "MIT",
-      "peer": true
+      "peerDependencies": {
+        "prop-types": ">=15",
+        "react": ">=0.14.9"
+      }
     },
     "node_modules/react-refractor": {
       "version": "2.2.0",
@@ -16825,6 +16842,24 @@
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "styled-components": "^6.1.15"
+      }
+    },
+    "node_modules/sanity-plugin-google-analytics": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-google-analytics/-/sanity-plugin-google-analytics-0.2.6.tgz",
+      "integrity": "sha512-Y1TuvkwPG+QbLv1kMMpffVzJOhseOez1zE8A781JaYFGqjGRlpUEeTNGJxDWAYaYKregpE0gaBEDTvoGbwxfVQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "react-debounce-render": "^5.0.0",
+        "react-google-charts": "^3.0.15"
+      },
+      "peerDependencies": {
+        "@sanity/base": ">= 0.135.x",
+        "@sanity/client": ">= 0.135.x",
+        "@sanity/components": ">= 0.135.x",
+        "@sanity/core": ">= 0.135.x",
+        "react": "^16.2.0"
       }
     },
     "node_modules/sanity/node_modules/@sanity/types": {
@@ -18275,7 +18310,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "^3.99.0",
+    "sanity-plugin-google-analytics": "^0.2.6",
     "styled-components": "^6.1.19"
   },
   "devDependencies": {

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -2,6 +2,7 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
+import googleAnalytics from 'sanity-plugin-google-analytics'
 
 // Schemas
 import announcement from './sanity/schemas/announcement'
@@ -30,6 +31,7 @@ export default defineConfig({
             defaultDocumentNode,
         }),
         visionTool(),
+        googleAnalytics,
     ],
     // Hide the Vision tool for non-admin users (e.g., editors)
     // currentUser is available in the context when using a function form of `tools`


### PR DESCRIPTION
## Summary
- install and configure `sanity-plugin-google-analytics`
- expose Google Analytics credentials via config file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcb78c0618832ca465dceb16558a1d