### PR TITLE
Improve tablet responsiveness

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { CSSProperties } from "react";
 import { Playfair_Display, Inter, Bebas_Neue } from "next/font/google";
 import "./globals.css";
@@ -26,6 +26,11 @@ const buttonFont = Bebas_Neue({
 });
 
 export const revalidate = 300;
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
 
 export async function generateMetadata(): Promise<Metadata> {
   const settings = await siteSettings();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,12 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    screens: {
+      sm: "640px",
+      md: "1024px",
+      lg: "1280px",
+      xl: "1536px",
+    },
     extend: {
       colors: {
         // Project brand palette. Prefer these colors in components over Tailwind defaults.


### PR DESCRIPTION
## Summary
- ensure responsive viewport scaling
- treat widths under 1024px as mobile with updated Tailwind breakpoints

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bccc17ebd4832c9d1ed527a25ceb16