### PR TITLE
Filter home page livestream to service days

### DIFF
--- a/components/SocialCTA.tsx
+++ b/components/SocialCTA.tsx
@@ -10,21 +10,23 @@ type SocialItem = {
   Icon: (props: SVGProps<SVGSVGElement>) => JSX.Element;
 };
 
-const DAY_MAP: Record<string, number> = {
-  sunday: 0,
-  monday: 1,
-  tuesday: 2,
-  wednesday: 3,
-  thursday: 4,
-  friday: 5,
-  saturday: 6,
+const DAY_ALIASES: Record<number, string[]> = {
+  0: ["sunday", "sun"],
+  1: ["monday", "mon"],
+  2: ["tuesday", "tue"],
+  3: ["wednesday", "wed"],
+  4: ["thursday", "thu"],
+  5: ["friday", "fri"],
+  6: ["saturday", "sat"],
 };
 
 function extractServiceDays(serviceTimes?: string): number[] {
   const lower = (serviceTimes ?? "").toLowerCase();
   const days = new Set<number>();
-  for (const [name, value] of Object.entries(DAY_MAP)) {
-    if (lower.includes(name)) days.add(value);
+  for (const [value, aliases] of Object.entries(DAY_ALIASES)) {
+    if (aliases.some((name) => lower.includes(name))) {
+      days.add(Number(value));
+    }
   }
   return Array.from(days);
 }
@@ -52,11 +54,7 @@ export default async function SocialCTA() {
     channelId && serviceDays.length > 0
       ? await getLatestLivestream(channelId, serviceDays)
       : null;
-  const embedUrl = latest?.id
-    ? `https://www.youtube.com/embed/${latest.id}`
-    : channelId
-    ? `https://www.youtube.com/embed/live_stream?channel=${channelId}`
-    : null;
+  const embedUrl = latest ? `https://www.youtube.com/embed/${latest.id}` : null;
 
   const socials: SocialItem[] = (settings?.socialLinks ?? [])
     .map(({ label, href, description = "", icon }) => {

--- a/components/SocialCTA.tsx
+++ b/components/SocialCTA.tsx
@@ -54,8 +54,11 @@ export default async function SocialCTA() {
     channelId && serviceDays.length > 0
       ? await getLatestLivestream(channelId, serviceDays)
       : null;
+  const origin = process.env.NEXT_PUBLIC_SITE_URL
+    ? `&origin=${encodeURIComponent(process.env.NEXT_PUBLIC_SITE_URL)}`
+    : "";
   const embedUrl = latest
-    ? `https://www.youtube.com/embed/${latest.id}?playsinline=1`
+    ? `https://www.youtube-nocookie.com/embed/${latest.id}?rel=0&playsinline=1${origin}`
     : null;
 
   const socials: SocialItem[] = (settings?.socialLinks ?? [])
@@ -90,10 +93,11 @@ export default async function SocialCTA() {
             )}
             <iframe
               src={embedUrl}
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               allowFullScreen
-              referrerPolicy="origin"
+              referrerPolicy="strict-origin-when-cross-origin"
               className="h-full w-full"
+              title="Latest livestream"
             />
           </div>
         )}

--- a/components/SocialCTA.tsx
+++ b/components/SocialCTA.tsx
@@ -54,7 +54,9 @@ export default async function SocialCTA() {
     channelId && serviceDays.length > 0
       ? await getLatestLivestream(channelId, serviceDays)
       : null;
-  const embedUrl = latest ? `https://www.youtube.com/embed/${latest.id}` : null;
+  const embedUrl = latest
+    ? `https://www.youtube.com/embed/${latest.id}?playsinline=1`
+    : null;
 
   const socials: SocialItem[] = (settings?.socialLinks ?? [])
     .map(({ label, href, description = "", icon }) => {
@@ -90,6 +92,7 @@ export default async function SocialCTA() {
               src={embedUrl}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
+              referrerPolicy="origin"
               className="h-full w-full"
             />
           </div>

--- a/components/SocialCTA.tsx
+++ b/components/SocialCTA.tsx
@@ -50,16 +50,38 @@ export default async function SocialCTA() {
   const settings = await siteSettings();
   const channelId = settings?.youtubeChannelId;
   const serviceDays = extractServiceDays(settings?.serviceTimes);
+
+  try {
+    // eslint-disable-next-line no-console
+    console.log('[SocialCTA] settings', {
+      channelId,
+      serviceTimes: settings?.serviceTimes,
+      serviceDays,
+      siteUrl: process.env.NEXT_PUBLIC_SITE_URL || null,
+    });
+  } catch {}
+
   const latest =
     channelId && serviceDays.length > 0
       ? await getLatestLivestream(channelId, serviceDays)
       : null;
+
   const origin = process.env.NEXT_PUBLIC_SITE_URL
     ? `&origin=${encodeURIComponent(process.env.NEXT_PUBLIC_SITE_URL)}`
     : "";
   const embedUrl = latest
     ? `https://www.youtube-nocookie.com/embed/${latest.id}?rel=0&playsinline=1${origin}`
     : null;
+
+  try {
+    // eslint-disable-next-line no-console
+    console.log('[SocialCTA] latestLivestream', {
+      found: Boolean(latest),
+      id: latest?.id || null,
+      publishedISO: latest?.published?.toISOString?.() || null,
+      embedUrl,
+    });
+  } catch {}
 
   const socials: SocialItem[] = (settings?.socialLinks ?? [])
     .map(({ label, href, description = "", icon }) => {
@@ -80,7 +102,7 @@ export default async function SocialCTA() {
             <SocialCard key={s.label} {...s} />
           ))}
         </div>
-        {embedUrl && (
+        {embedUrl ? (
           <div className="order-1 relative aspect-video w-full overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-bg)] md:order-2">
             {latest && (
               <div className="absolute left-2 top-2 rounded bg-[var(--brand-primary)]/80 px-2 py-1 text-sm font-semibold text-[var(--brand-primary-contrast)]">
@@ -88,6 +110,7 @@ export default async function SocialCTA() {
                   month: "long",
                   day: "numeric",
                   year: "numeric",
+                  timeZone: process.env.TZ || "America/Chicago",
                 })}
               </div>
             )}
@@ -100,6 +123,34 @@ export default async function SocialCTA() {
               title="Latest livestream"
             />
           </div>
+        ) : (
+          channelId ? (
+            <a
+              href={`https://www.youtube.com/channel/${channelId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="order-1 relative aspect-video w-full overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] md:order-2 flex items-center justify-center group transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface)_85%,white_15%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)]"
+              aria-label="Visit our YouTube channel"
+            >
+              {settings?.logo && (
+                // Background logo watermark
+                <img
+                  src={settings.logo}
+                  alt=""
+                  aria-hidden="true"
+                  className="pointer-events-none select-none absolute left-1/2 top-1/2 z-0 -translate-x-1/2 -translate-y-1/2 h-2/3 w-2/3 opacity-10 object-contain transition-opacity duration-300 group-hover:opacity-15"
+                />
+              )}
+              <div className="relative z-10 flex flex-col items-center gap-3">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-12 w-12 text-[var(--brand-accent)] drop-shadow-sm transition-transform group-hover:scale-105 group-hover:text-[var(--brand-primary-contrast)]" fill="currentColor">
+                  <path d="M23.5 6.2a4 4 0 0 0-2.8-2.8C18.9 3 12 3 12 3s-6.9 0-8.7.4A4 4 0 0 0 .5 6.2 41.3 41.3 0 0 0 0 12a41.3 41.3 0 0 0 .5 5.8 4 4 0 0 0 2.8 2.8C5.1 21 12 21 12 21s6.9 0 8.7-.4a4 4 0 0 0 2.8-2.8A41.3 41.3 0 0 0 24 12a41.3 41.3 0 0 0-.5-5.8zM9.6 15.5V8.5L15.8 12l-6.2 3.5z"/>
+                </svg>
+                <div className="text-center">
+                  <h3 className="text-base font-semibold text-[var(--brand-accent)] group-hover:text-[var(--brand-primary-contrast)]">Watch on YouTube</h3>
+                </div>
+              </div>
+            </a>
+          ) : null
         )}
         <div className="order-3 grid h-full grid-rows-2 gap-4 md:order-3">
           {right.map((s) => (

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -23,7 +23,7 @@ export async function getLatestLivestream(
       const published = new Date(dateMatch[1]);
       if (
         isNaN(published.getTime()) ||
-        !serviceDays.includes(published.getUTCDay())
+        !serviceDays.includes(published.getDay())
       )
         continue;
 

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,12 +1,13 @@
-export async function getLatestSundayLivestream(
-  channelId: string
+export async function getLatestLivestream(
+  channelId: string,
+  serviceDays: number[],
 ): Promise<{ id: string; published: Date } | null> {
-  if (!channelId) return null;
+  if (!channelId || serviceDays.length === 0) return null;
 
   try {
     const res = await fetch(
       `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`,
-      { next: { revalidate: 60 } }
+      { next: { revalidate: 60 } },
     );
     if (!res.ok) return null;
     const text = await res.text();
@@ -20,7 +21,11 @@ export async function getLatestSundayLivestream(
       if (!idMatch || !dateMatch) continue;
 
       const published = new Date(dateMatch[1]);
-      if (isNaN(published.getTime()) || published.getUTCDay() !== 0) continue;
+      if (
+        isNaN(published.getTime()) ||
+        !serviceDays.includes(published.getUTCDay())
+      )
+        continue;
 
       if (!latest || published.getTime() > latest.published.getTime()) {
         latest = { id: idMatch[1], published };

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -2,45 +2,171 @@ function convertTZ(date: Date, timeZone: string): Date {
   return new Date(date.toLocaleString("en-US", { timeZone }));
 }
 
+function rfc3339(date: Date) {
+  return date.toISOString();
+}
+
+export type LatestLivestream = { id: string; published: Date };
+
 export async function getLatestLivestream(
   channelId: string,
   serviceDays: number[],
-  timeZone =
-    process.env.SERVICE_TIMEZONE || process.env.TZ || "America/New_York",
-): Promise<{ id: string; published: Date } | null> {
+  timeZone = process.env.TZ || "America/Chicago",
+): Promise<LatestLivestream | null> {
   const apiKey = process.env.YOUTUBE_API_KEY;
   if (!channelId || serviceDays.length === 0 || !apiKey) return null;
 
   try {
-    const url = new URL("https://www.googleapis.com/youtube/v3/search");
-    url.searchParams.set("key", apiKey);
-    url.searchParams.set("channelId", channelId);
-    url.searchParams.set("part", "snippet");
-    url.searchParams.set("eventType", "completed");
-    url.searchParams.set("type", "video");
-    url.searchParams.set("order", "date");
-    url.searchParams.set("maxResults", "10");
+    // Build Search API request (fixed 14-day lookback)
+    const lookbackDays = 14;
+    const publishedAfter = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
 
-    const res = await fetch(url, { next: { revalidate: 60 } });
-    if (!res.ok) return null;
+    const searchUrl = new URL("https://www.googleapis.com/youtube/v3/search");
+    searchUrl.searchParams.set("key", apiKey);
+    searchUrl.searchParams.set("channelId", channelId);
+    searchUrl.searchParams.set("part", "snippet");
+    searchUrl.searchParams.set("eventType", "completed");
+    searchUrl.searchParams.set("type", "video");
+    searchUrl.searchParams.set("order", "date");
+    searchUrl.searchParams.set("maxResults", "50");
+    searchUrl.searchParams.set("publishedAfter", rfc3339(publishedAfter));
+
+    try {
+      // eslint-disable-next-line no-console
+      console.log("[YouTube][latestLivestream][request]", {
+        channelId,
+        serviceDays,
+        timeZone,
+        lookbackDays,
+        url: searchUrl.toString(),
+      });
+    } catch {}
+
+    const res = await fetch(searchUrl, { next: { revalidate: 60 } });
+    if (!res.ok) {
+      try {
+        // eslint-disable-next-line no-console
+        console.error("[YouTube][latestLivestream][httpError]", {
+          status: res.status,
+          statusText: res.statusText,
+        });
+      } catch {}
+      return null;
+    }
     const data = await res.json();
 
-    for (const item of data.items ?? []) {
-      const published = convertTZ(
-        new Date(item?.snippet?.publishedAt ?? 0),
-        timeZone,
-      );
-      if (
-        isNaN(published.getTime()) ||
-        !serviceDays.includes(published.getDay())
-      )
-        continue;
+    const ids: string[] = (data?.items ?? [])
+      .map((it: any) => it?.id?.videoId)
+      .filter(Boolean);
 
-      return { id: item.id.videoId, published };
+    try {
+      // eslint-disable-next-line no-console
+      console.log("[YouTube][latestLivestream][response] items", {
+        count: Array.isArray(data?.items) ? data.items.length : 0,
+        idsCount: ids.length,
+      });
+    } catch {}
+
+    if (ids.length === 0) {
+      try {
+        // eslint-disable-next-line no-console
+        console.warn("[YouTube][latestLivestream] No search results");
+      } catch {}
+      return null;
     }
 
+    // Fetch accurate livestream details for start time
+    const vidsUrl = new URL("https://www.googleapis.com/youtube/v3/videos");
+    vidsUrl.searchParams.set("key", apiKey);
+    vidsUrl.searchParams.set("part", "liveStreamingDetails,snippet");
+    vidsUrl.searchParams.set("id", ids.join(","));
+
+    try {
+      // eslint-disable-next-line no-console
+      console.log("[YouTube][videos.list][request]", {
+        ids: ids.slice(0, 10).join(",") + (ids.length > 10 ? ",…" : ""),
+        url: vidsUrl.toString().slice(0, 200) + "…",
+      });
+    } catch {}
+
+    const vidsRes = await fetch(vidsUrl, { next: { revalidate: 60 } });
+    if (!vidsRes.ok) {
+      try {
+        // eslint-disable-next-line no-console
+        console.error("[YouTube][videos.list][httpError]", {
+          status: vidsRes.status,
+          statusText: vidsRes.statusText,
+        });
+      } catch {}
+      return null;
+    }
+
+    const vidsData = await vidsRes.json();
+    const items: any[] = Array.isArray(vidsData?.items) ? vidsData.items : [];
+
+    type Candidate = { id: string; startLocal: Date };
+    const candidates: Candidate[] = [];
+
+    for (const v of items) {
+      const id = v?.id as string | undefined;
+      const live = v?.liveStreamingDetails;
+      const snip = v?.snippet;
+
+      const rawStart = live?.actualStartTime || live?.scheduledStartTime || live?.actualEndTime || snip?.publishedAt || null;
+      const start = rawStart ? new Date(rawStart) : null;
+      const startLocal = start ? convertTZ(start, timeZone) : null;
+      const weekday = startLocal && !isNaN(startLocal.getTime()) ? startLocal.getDay() : NaN;
+      const included = !!startLocal && !isNaN(weekday) && serviceDays.includes(weekday);
+
+      try {
+        // eslint-disable-next-line no-console
+        console.log("[YouTube][videos.list][inspect]", {
+          id,
+          title: snip?.title,
+          actualStartTime: live?.actualStartTime || null,
+          scheduledStartTime: live?.scheduledStartTime || null,
+          actualEndTime: live?.actualEndTime || null,
+          fallbackPublishedAt: snip?.publishedAt || null,
+          startLocalISO: startLocal && !isNaN(startLocal.getTime()) ? startLocal.toISOString() : null,
+          weekday,
+          included,
+        });
+      } catch {}
+
+      if (id && startLocal && included) {
+        candidates.push({ id, startLocal });
+      }
+    }
+
+    candidates.sort((a, b) => b.startLocal.getTime() - a.startLocal.getTime());
+    const chosen = candidates[0];
+
+    if (chosen) {
+      try {
+        // eslint-disable-next-line no-console
+        console.log("[YouTube][latestLivestream][selected]", {
+          videoId: chosen.id,
+          dateISO: chosen.startLocal.toISOString(),
+        });
+      } catch {}
+      return { id: chosen.id, published: chosen.startLocal };
+    }
+
+    try {
+      // eslint-disable-next-line no-console
+      console.warn("[YouTube][latestLivestream] No matching items for serviceDays", {
+        serviceDays,
+        timeZone,
+        publishedAfter: publishedAfter.toISOString(),
+      });
+    } catch {}
+
     return null;
-  } catch {
+  } catch (e) {
+    try {
+      // eslint-disable-next-line no-console
+      console.error("[YouTube][latestLivestream][exception]", String(e));
+    } catch {}
     return null;
   }
 }

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,6 +1,11 @@
+function convertTZ(date: Date, timeZone: string): Date {
+  return new Date(date.toLocaleString("en-US", { timeZone }));
+}
+
 export async function getLatestLivestream(
   channelId: string,
   serviceDays: number[],
+  timeZone = process.env.SERVICE_TIMEZONE || process.env.TZ || "America/New_York",
 ): Promise<{ id: string; published: Date } | null> {
   if (!channelId || serviceDays.length === 0) return null;
 
@@ -20,7 +25,7 @@ export async function getLatestLivestream(
       const dateMatch = entry.match(/<published>(.+?)<\/published>/);
       if (!idMatch || !dateMatch) continue;
 
-      const published = new Date(dateMatch[1]);
+      const published = convertTZ(new Date(dateMatch[1]), timeZone);
       if (
         isNaN(published.getTime()) ||
         !serviceDays.includes(published.getDay())


### PR DESCRIPTION
## Summary
- fetch latest YouTube video only if published on a configured service day
- parse service days from `serviceTimes` and use that video on the home page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcd4cb4af8832cad4a4f1571d34f94