### PR TITLE
Move contact submenu to end

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -86,6 +86,18 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
             </div>
           </div>
 
+          {nav.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              ref={item.href === "/giving" ? givingRef : undefined}
+              className={`${linkClasses(pathname.startsWith(item.href))} ${item.href === "/giving" && shouldNudgeGiving ? "animate-shake" : ""}`}
+              aria-current={pathname.startsWith(item.href) ? "page" : undefined}
+            >
+              {item.label}
+            </Link>
+          ))}
+
           <div className="relative group">
             <button
               className={`${pathname.startsWith("/contact") ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)] inline-flex items-center gap-1 cursor-pointer focus:outline-none`}
@@ -128,18 +140,6 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
               </Link>
             </div>
           </div>
-
-          {nav.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              ref={item.href === "/giving" ? givingRef : undefined}
-              className={`${linkClasses(pathname.startsWith(item.href))} ${item.href === "/giving" && shouldNudgeGiving ? "animate-shake" : ""}`}
-              aria-current={pathname.startsWith(item.href) ? "page" : undefined}
-            >
-              {item.label}
-            </Link>
-          ))}
         </nav>
 
         <button

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -135,6 +135,18 @@ function MobileMenuInner({ nav }: MobileMenuProps, ref: React.Ref<MobileMenuHand
                     </div>
                   )}
                 </Disclosure>
+                {nav.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={linkClasses(pathname.startsWith(item.href))}
+                    aria-current={pathname.startsWith(item.href) ? "page" : undefined}
+                    onClick={handleClose}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+
                 <Disclosure defaultOpen={pathname.startsWith("/contact")}>
                   {({ open: contactOpen }) => (
                     <div>
@@ -185,17 +197,6 @@ function MobileMenuInner({ nav }: MobileMenuProps, ref: React.Ref<MobileMenuHand
                     </div>
                   )}
                 </Disclosure>
-                {nav.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={linkClasses(pathname.startsWith(item.href))}
-                    aria-current={pathname.startsWith(item.href) ? "page" : undefined}
-                    onClick={handleClose}
-                  >
-                    {item.label}
-                  </Link>
-                ))}
               </nav>
             </Dialog.Panel>
           </Transition.Child>


### PR DESCRIPTION
## Summary
- Rearranged desktop navigation so the contact submenu appears after all other items
- Adjusted mobile menu layout placing the contact section at the bottom of the menu

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bded383b7c832ca23d7e9e3147e335