### PR TITLE
chore: extend api fetch caching to five minutes

### DIFF
--- a/lib/vimeo.ts
+++ b/lib/vimeo.ts
@@ -31,7 +31,7 @@ export async function getCurrentLivestream(): Promise<VimeoItem | null> {
   const { user, headers } = config
   const res = await fetch(
     `https://api.vimeo.com/users/${user}/videos?filter=live&per_page=1&sort=date&direction=desc&fields=uri,name,link,pictures.sizes.link,live.status,stats.viewers`,
-    { headers, next: { revalidate: 60 } }
+    { headers, next: { revalidate: 300 } }
   )
   if (!res.ok) return null
   const data = await res.json()
@@ -46,7 +46,7 @@ export async function getRecentLivestreams(): Promise<VimeoItem[]> {
   const { user, headers } = config
   const res = await fetch(
     `https://api.vimeo.com/users/${user}/videos?filter=live&per_page=10&sort=date&direction=desc&fields=uri,name,link,pictures.sizes.link,live.status,created_time`,
-    { headers, next: { revalidate: 60 } }
+    { headers, next: { revalidate: 300 } }
   )
   if (!res.ok) return []
   const data = await res.json()

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -42,7 +42,7 @@ export async function getLatestLivestream(
       });
     } catch {}
 
-    const res = await fetch(searchUrl, { next: { revalidate: 60 } });
+    const res = await fetch(searchUrl, { next: { revalidate: 300 } });
     if (!res.ok) {
       try {
         // eslint-disable-next-line no-console
@@ -89,7 +89,7 @@ export async function getLatestLivestream(
       });
     } catch {}
 
-    const vidsRes = await fetch(vidsUrl, { next: { revalidate: 60 } });
+    const vidsRes = await fetch(vidsUrl, { next: { revalidate: 300 } });
     if (!vidsRes.ok) {
       try {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- increase YouTube API request cache duration to five minutes
- increase Vimeo API request cache duration to five minutes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0e28c9824832c93001ec3cac6a157