### PR TITLE
Collapse navigation earlier to avoid overlap

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -34,7 +34,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
         >
           {siteTitle}
         </Link>
-        <nav className="absolute left-1/2 -translate-x-1/2 hidden items-center gap-6 text-sm font-medium md:flex">
+        <nav className="absolute left-1/2 -translate-x-1/2 hidden items-center gap-6 text-sm font-medium lg:flex">
           <Link
             href="/"
             className={linkClasses(pathname === "/")}
@@ -143,7 +143,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
         </nav>
 
         <button
-          className="ml-auto text-[var(--brand-accent)] hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)] md:hidden"
+          className="ml-auto text-[var(--brand-accent)] hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)] lg:hidden"
           aria-label="Open menu"
           onClick={() => mobileMenuRef.current?.open()}
         >

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -37,7 +37,7 @@ function MobileMenuInner({ nav }: MobileMenuProps, ref: React.Ref<MobileMenuHand
 
   return (
     <Transition show={open} as={Fragment}>
-      <Dialog as="div" className="md:hidden" onClose={handleClose}>
+      <Dialog as="div" className="lg:hidden" onClose={handleClose}>
         <Transition.Child
           as={Fragment}
           enter="transition-opacity ease-linear duration-200"


### PR DESCRIPTION
## Summary
- Show desktop navigation only on large screens to prevent menu overlap
- Hide mobile menu only on large screens to match new collapse point

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0f63146d8832c849e86ad1ed2ef2f