### PR TITLE
Limit event card underlines to Learn more link

### DIFF
--- a/components/EventCalendar.tsx
+++ b/components/EventCalendar.tsx
@@ -81,7 +81,7 @@ export default function EventCalendar({ events }: { events: CalendarEvent[] }) {
                   .map((ev) => (
                     <div
                       key={ev.id}
-                      className="mt-1 rounded bg-[var(--brand-accent)]/20 p-0.5"
+                      className="mt-1 rounded bg-[var(--brand-accent)]/20 p-0.5 no-underline"
                     >
                       {ev.title}
                     </div>

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -49,20 +49,30 @@ export function EventCard({
         />
       )}
       <div className="flex flex-1 flex-col p-4">
-        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{event.title}</h3>
-        <p className={`mt-1 text-sm ${dateClassName ?? 'text-[var(--brand-muted)]'}`}>
+        <h3 className="text-lg font-semibold no-underline text-[var(--brand-surface-contrast)]">
+          {event.title}
+        </h3>
+        <p
+          className={`mt-1 text-sm no-underline ${
+            dateClassName ?? "text-[var(--brand-muted)]"
+          }`}
+        >
           {event.date}
           {event.location ? ` • ${event.location}` : ""}
         </p>
         {event.description && (
-          <p className={`mt-2 flex-1 text-sm ${descriptionClassName ?? 'text-[var(--brand-fg)]'}`}>
+          <p
+            className={`mt-2 flex-1 text-sm no-underline ${
+              descriptionClassName ?? "text-[var(--brand-fg)]"
+            }`}
+          >
             {event.description}
           </p>
         )}
         {event.href && (
           <Link
             href={event.href}
-            className="relative mt-4 inline-block rounded px-1 py-0.5 text-sm font-medium text-[var(--brand-accent)] transition-colors hover:underline hover:text-[var(--brand-primary-contrast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] active:bg-[var(--brand-accent)]/20"
+            className="relative mt-4 inline-block rounded px-1 py-0.5 text-sm font-medium text-[var(--brand-accent)] underline transition-colors hover:text-[var(--brand-primary-contrast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] active:bg-[var(--brand-accent)]/20"
           >
             Learn more
           </Link>

--- a/components/EventTimeline.tsx
+++ b/components/EventTimeline.tsx
@@ -86,15 +86,15 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
                 className="mb-4 w-full rounded object-cover"
               />
             )}
-            <h3 className="text-lg font-semibold text-[var(--brand-fg)]">
+            <h3 className="text-lg font-semibold no-underline text-[var(--brand-fg)]">
               {ev.title}
             </h3>
-            <p className="text-sm text-[var(--brand-muted)]">
+            <p className="text-sm no-underline text-[var(--brand-muted)]">
               {ev.date}
               {ev.location ? ` • ${ev.location}` : ""}
             </p>
             {ev.description && (
-              <p className="text-base text-[var(--brand-fg)]">
+              <p className="text-base no-underline text-[var(--brand-fg)]">
                 {ev.description}
               </p>
             )}


### PR DESCRIPTION
## Summary
- remove inherited underlines from event titles, dates, and descriptions
- underline only the Learn more link in event cards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5a6e33304832cba6d64367607cb90