### PR TITLE
fix: restrict event underline to Learn more

### DIFF
--- a/components/EventCalendar.tsx
+++ b/components/EventCalendar.tsx
@@ -83,7 +83,7 @@ export default function EventCalendar({ events }: { events: CalendarEvent[] }) {
                       <a
                         key={ev.id}
                         href={ev.href}
-                        className="group block mt-1 rounded border border-[var(--brand-border)] bg-[var(--brand-accent)]/20 p-0.5 no-underline transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
+                        className="group block mt-1 rounded border border-[var(--brand-border)] bg-[var(--brand-accent)]/20 p-0.5 no-underline hover:no-underline focus:no-underline focus-visible:no-underline transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
                       >
                         <div>{ev.title}</div>
                         <span className="text-[0.625rem] text-[var(--brand-accent)] group-hover:underline">Learn more</span>

--- a/components/EventCalendar.tsx
+++ b/components/EventCalendar.tsx
@@ -83,10 +83,11 @@ export default function EventCalendar({ events }: { events: CalendarEvent[] }) {
                       <a
                         key={ev.id}
                         href={ev.href}
-                        className="group block mt-1 rounded border border-[var(--brand-border)] bg-[var(--brand-accent)]/20 p-0.5 no-underline hover:no-underline focus:no-underline focus-visible:no-underline transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
+                        className="group block mt-1 rounded border border-[var(--brand-border)] bg-[var(--brand-accent)]/20 p-0.5 no-underline hover:no-underline focus:no-underline focus-visible:no-underline visited:no-underline active:no-underline transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
+                        style={{ textDecoration: 'none' }}
                       >
                         <div>{ev.title}</div>
-                        <span className="text-[0.625rem] text-[var(--brand-accent)] group-hover:underline">Learn more</span>
+                        <span className="text-[0.625rem] text-[var(--brand-accent)] underline">Learn more</span>
                       </a>
                     ) : (
                       <div

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -38,8 +38,8 @@ export function EventCard({
     return (
       <Link
         href={event.href}
-        className="group card relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-visible:-translate-y-1 focus-visible:-rotate-1 focus-visible:scale-[1.02] focus-visible:shadow-lg transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)] no-underline hover:no-underline focus:no-underline focus-visible:no-underline"
-        style={style}
+        className="group card relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-visible:-translate-y-1 focus-visible:-rotate-1 focus-visible:scale-[1.02] focus-visible:shadow-lg transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)] no-underline hover:no-underline focus:no-underline focus-visible:no-underline visited:no-underline active:no-underline"
+        style={{ ...style, textDecoration: 'none' }}
       >
         {event.image && (
           <Image
@@ -61,7 +61,7 @@ export function EventCard({
               {event.description}
             </p>
           )}
-          <span className="relative mt-4 inline-block rounded px-1 py-0.5 text-sm font-medium text-[var(--brand-accent)] transition-colors group-hover:underline group-hover:text-[var(--brand-primary-contrast)]">
+          <span className="relative mt-4 inline-block rounded px-1 py-0.5 text-sm font-medium text-[var(--brand-accent)] transition-colors underline group-hover:text-[var(--brand-primary-contrast)]">
             Learn more
           </span>
         </div>

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -38,7 +38,7 @@ export function EventCard({
     return (
       <Link
         href={event.href}
-        className="group card relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-visible:-translate-y-1 focus-visible:-rotate-1 focus-visible:scale-[1.02] focus-visible:shadow-lg transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)] no-underline"
+        className="group card relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-visible:-translate-y-1 focus-visible:-rotate-1 focus-visible:scale-[1.02] focus-visible:shadow-lg transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)] no-underline hover:no-underline focus:no-underline focus-visible:no-underline"
         style={style}
       >
         {event.image && (

--- a/components/EventTimeline.tsx
+++ b/components/EventTimeline.tsx
@@ -80,7 +80,7 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
           {ev.href ? (
             <a
               href={ev.href}
-              className="no-underline w-full max-w-md p-6 space-y-2 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-bg)] transition-transform transition-colors duration-300 group-hover:scale-105 group-hover:shadow-lg hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
+              className="no-underline hover:no-underline focus:no-underline focus-visible:no-underline w-full max-w-md p-6 space-y-2 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-bg)] transition-transform transition-colors duration-300 group-hover:scale-105 group-hover:shadow-lg hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
             >
               {ev.image && (
                 <Image

--- a/components/EventTimeline.tsx
+++ b/components/EventTimeline.tsx
@@ -80,7 +80,8 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
           {ev.href ? (
             <a
               href={ev.href}
-              className="no-underline hover:no-underline focus:no-underline focus-visible:no-underline w-full max-w-md p-6 space-y-2 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-bg)] transition-transform transition-colors duration-300 group-hover:scale-105 group-hover:shadow-lg hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
+              className="no-underline hover:no-underline focus:no-underline focus-visible:no-underline visited:no-underline active:no-underline w-full max-w-md p-6 space-y-2 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-bg)] transition-transform transition-colors duration-300 group-hover:scale-105 group-hover:shadow-lg hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
+              style={{ textDecoration: 'none' }}
             >
               {ev.image && (
                 <Image
@@ -103,7 +104,7 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
                   {ev.description}
                 </p>
               )}
-              <span className="inline-block mt-2 text-sm font-medium text-[var(--brand-accent)] group-hover:underline">
+              <span className="inline-block mt-2 text-sm font-medium text-[var(--brand-accent)] underline">
                 Learn more
               </span>
             </a>


### PR DESCRIPTION
## Summary
- ensure event card links don't underline entire content
- restrict calendar and timeline event underlines to Learn more text only

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5a9e25a0c832cbff00359860a066e