### PR TITLE
Remove manual escalation button

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -57,6 +57,5 @@ export async function POST(req: Request) {
     });
   }
 
-  const offerHelp = confidence < 0.5;
-  return NextResponse.json({ reply, confidence, offerHelp, similarityCount });
+  return NextResponse.json({ reply, confidence, similarityCount });
 }

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -21,7 +21,6 @@ export default function Assistant() {
   const [enterOffset, setEnterOffset] = useState(20);
   const NUDGE_MS = 2400;
   const [thinking, setThinking] = useState(false);
-  const [offerHelp, setOfferHelp] = useState(true);
   const [escalationReason, setEscalationReason] = useState('');
   const logRef = useRef<HTMLDivElement>(null);
 
@@ -104,10 +103,7 @@ export default function Assistant() {
     ]);
     if (data.escalate) {
       setCollectInfo(true);
-      setOfferHelp(false);
       setEscalationReason(data.reason || '');
-    } else if (typeof data.offerHelp !== 'undefined') {
-      setOfferHelp(Boolean(data.offerHelp));
     }
     setThinking(false);
   }
@@ -121,7 +117,6 @@ export default function Assistant() {
       body: JSON.stringify({ escalate: true, info, messages: messages, reason: escalationReason }),
     });
     setCollectInfo(false);
-    setOfferHelp(false);
     setMessages((prev) => [
       ...prev,
       {
@@ -233,17 +228,6 @@ export default function Assistant() {
             />
             <button type="submit" className="border px-2 py-1 cursor-pointer">Send</button>
           </form>
-        )}
-        {!collectInfo && offerHelp && (
-          <button
-            onClick={() => {
-              setCollectInfo(true);
-              resetNudge();
-            }}
-            className="mt-2 text-sm underline cursor-pointer"
-          >
-            Still need help?
-          </button>
         )}
       </div>
       <div


### PR DESCRIPTION
## Summary
- Remove "Still need help?" manual escalation option from assistant UI
- Simplify chat API response by dropping `offerHelp`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c65c306484832c868be1e9cf4967e0