### PR TITLE
Render external and internal links in assistant replies

### DIFF
--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -2,6 +2,7 @@
 
 import {FormEvent, useCallback, useEffect, useRef, useState} from 'react';
 import type {ChatMessage} from '@/types/chat';
+import Link from 'next/link';
 
 export default function Assistant() {
   const [open, setOpen] = useState(false);
@@ -23,6 +24,36 @@ export default function Assistant() {
   const [thinking, setThinking] = useState(false);
   const [escalationReason, setEscalationReason] = useState('');
   const logRef = useRef<HTMLDivElement>(null);
+
+  function renderContent(text: string) {
+    const regex = /(https?:\/\/[^\s]+|\/[A-Za-z0-9\-_/]+)/g;
+    const parts = text.split(regex).filter(Boolean);
+    return parts.map((part, idx) => {
+      if (/^https?:\/\//.test(part)) {
+        let label = part.replace(/^https?:\/\//, '');
+        if (label.endsWith('/')) label = label.slice(0, -1);
+        return (
+          <a
+            key={idx}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            {label}
+          </a>
+        );
+      }
+      if (/^\//.test(part)) {
+        return (
+          <Link key={idx} href={part} className="underline">
+            {part}
+          </Link>
+        );
+      }
+      return <span key={idx}>{part}</span>;
+    });
+  }
 
   const scheduleNudge = useCallback(() => {
     if (nudgeRef.current) clearTimeout(nudgeRef.current);
@@ -172,7 +203,8 @@ export default function Assistant() {
         <div role="log" aria-label="Chat messages" className="mb-2 max-h-60 overflow-y-auto" ref={logRef}>
           {messages.map((m, i) => (
             <div key={i} className="mb-1">
-              <span className="font-bold">{m.role === 'assistant' ? 'Assistant' : 'You'}:</span> {m.content}
+              <span className="font-bold">{m.role === 'assistant' ? 'Assistant' : 'You'}:</span>{' '}
+              {renderContent(m.content)}
             </div>
           ))}
           {thinking && !collectInfo && (

--- a/lib/chatbot.ts
+++ b/lib/chatbot.ts
@@ -175,6 +175,8 @@ export async function generateChatbotReply(
           'If a visitor uses "you", "your", or makes a vague reference, reinterpret it to be about the church or its website and answer in that framework. ' +
           'If a question is unrelated to the site, respond that you can only assist with website information. ' +
           'If the question is about the church or website but the answer is not present in the site content, say you are sorry and unsure, set confidence to 0, and suggest reaching out for further help. ' +
+          'When referencing a page on this site, include its path starting with "/". ' +
+          'Only provide external links that already appear in the site content and include the full URL. ' +
           'If the user requests to speak to a person or otherwise asks for escalation, set "escalate" to true and provide the trigger in "escalateReason". Avoid copy-paste escalation text; any escalation notice should reference the user\'s situation and kindly explain that providing their contact information is necessary for staff to reach out. ' +
           'Count how many times so far the user has asked this same or a very similar question, including the current attempt. Do not increase the count for new or different questions. Include this number as "similarityCount". Allow a visitor to repeat a question only twice; on the third time, set "escalate" to true with a friendly "escalateReason" indicating the question has been asked multiple times and a team member can follow up if they share contact details. ' +
           `The current date is ${dateStr}. ` +


### PR DESCRIPTION
## Summary
- Parse assistant chat messages to render internal page links and human-readable external URLs
- Instruct chatbot to include only site-sourced external links and explicit page paths

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c752eee7f4832cb1f4af45719e0a27