### PR TITLE
feat: apply brand colors to assistant

### DIFF
--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -24,6 +24,19 @@ export default function Assistant() {
   const [escalationReason, setEscalationReason] = useState('');
   const logRef = useRef<HTMLDivElement>(null);
 
+  const panelClass =
+    'absolute bottom-0 right-0 w-80 rounded border border-brand-purple bg-brand-purpleLt p-4 text-brand-ink shadow-lg transition-all duration-700 ease-in-out transform dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100';
+  const inputClass =
+    'border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt';
+  const buttonClass =
+    'border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink hover:bg-brand-gold/90 focus:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt dark:focus:bg-brand-purpleLt';
+  const iconButtonClass =
+    'flex h-14 w-14 items-center justify-center rounded-full bg-brand-gold text-brand-ink shadow-lg hover:bg-brand-gold/90 cursor-pointer dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt';
+  const dismissButtonClass =
+    'absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer dark:bg-brand-gold dark:text-brand-ink';
+  const closeButtonClass =
+    'absolute right-2 top-2 text-xl leading-none cursor-pointer text-brand-ink hover:text-brand-ink/80 dark:text-brand-gold dark:hover:text-brand-gold/80';
+
   const scheduleNudge = useCallback(() => {
     if (nudgeRef.current) clearTimeout(nudgeRef.current);
     const timeout = Math.floor(Math.random() * 45000) + 45000;
@@ -156,7 +169,7 @@ export default function Assistant() {
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
       <div
-        className={`absolute bottom-0 right-0 w-80 rounded border border-brand-purple bg-brand-purpleLt text-brand-ink p-4 shadow-lg transition-all duration-700 ease-in-out transform dark:border-brand-gold dark:bg-brand-ink dark:text-neutral-100 ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
+        className={`${panelClass} ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
       >
         <button
           type="button"
@@ -165,7 +178,7 @@ export default function Assistant() {
             setOpen(false);
             resetNudge();
           }}
-          className="absolute right-2 top-2 text-xl leading-none cursor-pointer text-brand-ink dark:text-brand-gold"
+          className={closeButtonClass}
         >
           ×
         </button>
@@ -183,7 +196,7 @@ export default function Assistant() {
           <form onSubmit={sendInfo} className="flex flex-col gap-2" aria-label="Contact form">
             <input
               type="text"
-              className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
+              className={inputClass}
               placeholder="Name"
               value={info.name}
               onChange={(e) => setInfo({ ...info, name: e.target.value })}
@@ -192,7 +205,7 @@ export default function Assistant() {
             />
             <input
               type="text"
-              className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
+              className={inputClass}
               placeholder="Contact Number"
               value={info.contact}
               onChange={(e) => setInfo({ ...info, contact: e.target.value })}
@@ -201,7 +214,7 @@ export default function Assistant() {
             />
             <input
               type="email"
-              className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
+              className={inputClass}
               placeholder="Email"
               value={info.email}
               onChange={(e) => setInfo({ ...info, email: e.target.value })}
@@ -209,24 +222,24 @@ export default function Assistant() {
               required
             />
             <textarea
-              className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
+              className={inputClass}
               placeholder="Any extra details"
               value={info.details}
               onChange={(e) => setInfo({ ...info, details: e.target.value })}
               aria-label="Any extra details"
             />
-            <button type="submit" className="border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink cursor-pointer dark:bg-brand-purple dark:text-neutral-100">Send</button>
+            <button type="submit" className={buttonClass}>Send</button>
           </form>
         ) : (
           <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
             <input
               type="text"
-              className="flex-1 border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
+              className={`flex-1 ${inputClass}`}
               value={input}
               onChange={(e) => setInput(e.target.value)}
               aria-label="Message"
             />
-            <button type="submit" className="border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink cursor-pointer dark:bg-brand-purple dark:text-neutral-100">Send</button>
+            <button type="submit" className={buttonClass}>Send</button>
           </form>
         )}
       </div>
@@ -247,7 +260,7 @@ export default function Assistant() {
               setOpen(true);
             }
           }}
-          className={`flex h-14 w-14 items-center justify-center rounded-full bg-brand-gold text-brand-ink shadow-lg dark:bg-brand-purple dark:text-neutral-100 cursor-pointer ${nudge ? 'animate-shake' : ''}`}
+          className={`${iconButtonClass} ${nudge ? 'animate-shake' : ''}`}
         >
           <span className="text-2xl">🤖</span>
         </button>
@@ -256,7 +269,7 @@ export default function Assistant() {
             type="button"
             aria-label="Dismiss assistant"
             onClick={dock}
-            className="absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer"
+            className={dismissButtonClass}
           >
             ×
           </button>

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -169,14 +169,28 @@ export default function Assistant() {
           >
             ×
           </button>
-        <div role="log" aria-label="Chat messages" className="mb-2 max-h-60 overflow-y-auto" ref={logRef}>
+        <div
+          role="log"
+          aria-label="Chat messages"
+          className="mb-2 flex max-h-60 flex-col gap-1 overflow-y-auto"
+          ref={logRef}
+        >
           {messages.map((m, i) => (
-            <div key={i} className="mb-1">
-              <span className={`font-bold ${m.role === 'assistant' ? 'text-brand-purple' : 'text-brand-gold'}`}>{m.role === 'assistant' ? 'Assistant' : 'You'}:</span> {m.content}
+            <div
+              key={i}
+              className={`w-fit rounded px-2 py-1 ${
+                m.role === 'assistant'
+                  ? 'self-start bg-brand-purpleLt text-brand-ink dark:bg-brand-purple dark:text-neutral-100'
+                  : 'self-end bg-brand-gold text-brand-ink dark:bg-brand-gold'
+              }`}
+            >
+              {m.content}
             </div>
           ))}
           {thinking && !collectInfo && (
-            <div className="mb-1 text-brand-purple">Assistant is thinking…</div>
+            <div className="self-start w-fit rounded bg-brand-purpleLt px-2 py-1 text-brand-ink dark:bg-brand-purple dark:text-neutral-100">
+              Assistant is thinking…
+            </div>
           )}
         </div>
         {collectInfo ? (

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -156,7 +156,7 @@ export default function Assistant() {
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
         <div
-          className={`absolute bottom-0 right-0 w-80 rounded border border-brand-gold bg-brand-purple p-4 text-neutral-50 shadow-lg transition-all duration-700 ease-in-out transform dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
+          className={`absolute bottom-0 right-0 w-80 rounded border border-brand-gold bg-brand-ink p-4 text-neutral-50 shadow-lg transition-all duration-700 ease-in-out transform dark:border-brand-gold dark:bg-brand-ink dark:text-neutral-100 ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
         >
           <button
             type="button"
@@ -165,7 +165,7 @@ export default function Assistant() {
               setOpen(false);
               resetNudge();
             }}
-            className="absolute right-2 top-2 text-xl leading-none cursor-pointer text-brand-gold hover:text-brand-gold/80 dark:text-brand-gold dark:hover:text-brand-gold/80"
+            className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-brand-purple text-neutral-50 hover:bg-brand-purpleLt dark:bg-brand-gold dark:text-brand-ink dark:hover:bg-brand-gold/80"
           >
             ×
           </button>
@@ -180,7 +180,7 @@ export default function Assistant() {
               key={i}
               className={`w-fit rounded px-2 py-1 ${
                 m.role === 'assistant'
-                  ? 'self-start bg-brand-purpleLt text-brand-ink dark:bg-brand-purple dark:text-neutral-100'
+                  ? 'self-start bg-brand-purple text-neutral-100 dark:bg-brand-purple'
                   : 'self-end bg-brand-gold text-brand-ink dark:bg-brand-gold'
               }`}
             >
@@ -188,7 +188,7 @@ export default function Assistant() {
             </div>
           ))}
           {thinking && !collectInfo && (
-            <div className="self-start w-fit rounded bg-brand-purpleLt px-2 py-1 text-brand-ink dark:bg-brand-purple dark:text-neutral-100">
+            <div className="self-start w-fit rounded bg-brand-purple px-2 py-1 text-neutral-100 dark:bg-brand-purple">
               Assistant is thinking…
             </div>
           )}
@@ -197,7 +197,7 @@ export default function Assistant() {
           <form onSubmit={sendInfo} className="flex flex-col gap-2" aria-label="Contact form">
               <input
                 type="text"
-                className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className="border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
                 placeholder="Name"
                 value={info.name}
                 onChange={(e) => setInfo({ ...info, name: e.target.value })}
@@ -206,7 +206,7 @@ export default function Assistant() {
               />
               <input
                 type="text"
-                className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className="border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
                 placeholder="Contact Number"
                 value={info.contact}
                 onChange={(e) => setInfo({ ...info, contact: e.target.value })}
@@ -215,7 +215,7 @@ export default function Assistant() {
               />
               <input
                 type="email"
-                className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className="border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
                 placeholder="Email"
                 value={info.email}
                 onChange={(e) => setInfo({ ...info, email: e.target.value })}
@@ -223,7 +223,7 @@ export default function Assistant() {
                 required
               />
               <textarea
-                className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className="border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
                 placeholder="Any extra details"
                 value={info.details}
                 onChange={(e) => setInfo({ ...info, details: e.target.value })}
@@ -235,7 +235,7 @@ export default function Assistant() {
             <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
               <input
                 type="text"
-                className="flex-1 border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className="flex-1 border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 aria-label="Message"
@@ -261,7 +261,7 @@ export default function Assistant() {
                 setOpen(true);
               }
             }}
-            className={`flex h-14 w-14 items-center justify-center rounded-full bg-brand-gold text-brand-ink shadow-lg hover:bg-brand-gold/90 cursor-pointer dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt ${nudge ? 'animate-shake' : ''}`}
+            className={`flex h-14 w-14 items-center justify-center rounded-full border border-brand-purple bg-brand-gold text-brand-ink shadow-lg hover:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt ${nudge ? 'animate-shake' : ''}`}
           >
             <span className="text-2xl">🤖</span>
           </button>
@@ -270,7 +270,7 @@ export default function Assistant() {
               type="button"
               aria-label="Dismiss assistant"
               onClick={dock}
-              className="absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer dark:bg-brand-gold dark:text-brand-ink"
+              className="absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full border border-brand-gold bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer dark:border-brand-purple dark:bg-brand-gold dark:text-brand-ink"
             >
               ×
             </button>

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -24,19 +24,6 @@ export default function Assistant() {
   const [escalationReason, setEscalationReason] = useState('');
   const logRef = useRef<HTMLDivElement>(null);
 
-  const panelClass =
-    'absolute bottom-0 right-0 w-80 rounded border border-brand-purple bg-brand-purpleLt p-4 text-brand-ink shadow-lg transition-all duration-700 ease-in-out transform dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100';
-  const inputClass =
-    'border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt';
-  const buttonClass =
-    'border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink hover:bg-brand-gold/90 focus:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt dark:focus:bg-brand-purpleLt';
-  const iconButtonClass =
-    'flex h-14 w-14 items-center justify-center rounded-full bg-brand-gold text-brand-ink shadow-lg hover:bg-brand-gold/90 cursor-pointer dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt';
-  const dismissButtonClass =
-    'absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer dark:bg-brand-gold dark:text-brand-ink';
-  const closeButtonClass =
-    'absolute right-2 top-2 text-xl leading-none cursor-pointer text-brand-ink hover:text-brand-ink/80 dark:text-brand-gold dark:hover:text-brand-gold/80';
-
   const scheduleNudge = useCallback(() => {
     if (nudgeRef.current) clearTimeout(nudgeRef.current);
     const timeout = Math.floor(Math.random() * 45000) + 45000;
@@ -168,20 +155,20 @@ export default function Assistant() {
       style={{ transform: `translate(${offset.x}px, ${offset.y + enterOffset}px)`, opacity: entered ? 1 : 0 }}
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
-      <div
-        className={`${panelClass} ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
-      >
-        <button
-          type="button"
-          aria-label="Close assistant"
-          onClick={() => {
-            setOpen(false);
-            resetNudge();
-          }}
-          className={closeButtonClass}
+        <div
+          className={`absolute bottom-0 right-0 w-80 rounded border border-brand-gold bg-brand-purple p-4 text-neutral-50 shadow-lg transition-all duration-700 ease-in-out transform dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
         >
-          ×
-        </button>
+          <button
+            type="button"
+            aria-label="Close assistant"
+            onClick={() => {
+              setOpen(false);
+              resetNudge();
+            }}
+            className="absolute right-2 top-2 text-xl leading-none cursor-pointer text-brand-gold hover:text-brand-gold/80 dark:text-brand-gold dark:hover:text-brand-gold/80"
+          >
+            ×
+          </button>
         <div role="log" aria-label="Chat messages" className="mb-2 max-h-60 overflow-y-auto" ref={logRef}>
           {messages.map((m, i) => (
             <div key={i} className="mb-1">
@@ -194,86 +181,86 @@ export default function Assistant() {
         </div>
         {collectInfo ? (
           <form onSubmit={sendInfo} className="flex flex-col gap-2" aria-label="Contact form">
-            <input
-              type="text"
-              className={inputClass}
-              placeholder="Name"
-              value={info.name}
-              onChange={(e) => setInfo({ ...info, name: e.target.value })}
-              aria-label="Name"
-              required
-            />
-            <input
-              type="text"
-              className={inputClass}
-              placeholder="Contact Number"
-              value={info.contact}
-              onChange={(e) => setInfo({ ...info, contact: e.target.value })}
-              aria-label="Contact Number"
-              required
-            />
-            <input
-              type="email"
-              className={inputClass}
-              placeholder="Email"
-              value={info.email}
-              onChange={(e) => setInfo({ ...info, email: e.target.value })}
-              aria-label="Email"
-              required
-            />
-            <textarea
-              className={inputClass}
-              placeholder="Any extra details"
-              value={info.details}
-              onChange={(e) => setInfo({ ...info, details: e.target.value })}
-              aria-label="Any extra details"
-            />
-            <button type="submit" className={buttonClass}>Send</button>
+              <input
+                type="text"
+                className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                placeholder="Name"
+                value={info.name}
+                onChange={(e) => setInfo({ ...info, name: e.target.value })}
+                aria-label="Name"
+                required
+              />
+              <input
+                type="text"
+                className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                placeholder="Contact Number"
+                value={info.contact}
+                onChange={(e) => setInfo({ ...info, contact: e.target.value })}
+                aria-label="Contact Number"
+                required
+              />
+              <input
+                type="email"
+                className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                placeholder="Email"
+                value={info.email}
+                onChange={(e) => setInfo({ ...info, email: e.target.value })}
+                aria-label="Email"
+                required
+              />
+              <textarea
+                className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                placeholder="Any extra details"
+                value={info.details}
+                onChange={(e) => setInfo({ ...info, details: e.target.value })}
+                aria-label="Any extra details"
+              />
+              <button type="submit" className="border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink hover:bg-brand-gold/90 focus:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt dark:focus:bg-brand-purpleLt">Send</button>
           </form>
         ) : (
-          <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
-            <input
-              type="text"
-              className={`flex-1 ${inputClass}`}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              aria-label="Message"
-            />
-            <button type="submit" className={buttonClass}>Send</button>
-          </form>
-        )}
+            <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
+              <input
+                type="text"
+                className="flex-1 border border-brand-purple bg-neutral-50 p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                aria-label="Message"
+              />
+              <button type="submit" className="border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink hover:bg-brand-gold/90 focus:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt dark:focus:bg-brand-purpleLt">Send</button>
+            </form>
+          )}
       </div>
       <div
         className={`relative group transition-all duration-700 ease-in-out ${
           open ? 'translate-y-4 opacity-0 pointer-events-none' : 'opacity-100'
         }`}
       >
-        <button
-          type="button"
-          aria-label="Open assistant"
-          onClick={() => {
-            resetNudge();
-            if (docked) {
-              undock();
-              setTimeout(() => setOpen(true), ANIM_MS);
-            } else {
-              setOpen(true);
-            }
-          }}
-          className={`${iconButtonClass} ${nudge ? 'animate-shake' : ''}`}
-        >
-          <span className="text-2xl">🤖</span>
-        </button>
-        {!docked && (
           <button
             type="button"
-            aria-label="Dismiss assistant"
-            onClick={dock}
-            className={dismissButtonClass}
+            aria-label="Open assistant"
+            onClick={() => {
+              resetNudge();
+              if (docked) {
+                undock();
+                setTimeout(() => setOpen(true), ANIM_MS);
+              } else {
+                setOpen(true);
+              }
+            }}
+            className={`flex h-14 w-14 items-center justify-center rounded-full bg-brand-gold text-brand-ink shadow-lg hover:bg-brand-gold/90 cursor-pointer dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt ${nudge ? 'animate-shake' : ''}`}
           >
-            ×
+            <span className="text-2xl">🤖</span>
           </button>
-        )}
+          {!docked && (
+            <button
+              type="button"
+              aria-label="Dismiss assistant"
+              onClick={dock}
+              className="absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer dark:bg-brand-gold dark:text-brand-ink"
+            >
+              ×
+            </button>
+          )}
       </div>
     </div>
   );

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -24,6 +24,26 @@ export default function Assistant() {
   const [escalationReason, setEscalationReason] = useState('');
   const logRef = useRef<HTMLDivElement>(null);
 
+  const panelBase =
+    'absolute bottom-0 right-0 w-80 rounded border p-4 shadow-lg transition-all duration-700 ease-in-out transform';
+  const panelColors =
+    'border-brand-gold bg-brand-purple text-neutral-100 dark:bg-brand-ink dark:text-neutral-100';
+  const closeBtn =
+    'absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-brand-gold text-brand-ink hover:bg-brand-gold/90 dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt';
+  const inputClass =
+    'border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-gold dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt';
+  const sendBtn =
+    'border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink hover:bg-brand-gold/90 focus:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt dark:focus:bg-brand-purpleLt';
+  const floatBtn =
+    'flex h-14 w-14 items-center justify-center rounded-full border border-brand-gold bg-brand-purple text-neutral-100 shadow-lg hover:bg-brand-purpleLt cursor-pointer dark:border-brand-purple dark:bg-brand-gold dark:text-brand-ink dark:hover:bg-brand-gold/90';
+  const dismissBtn =
+    'absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full border border-brand-gold bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer dark:border-brand-purple dark:bg-brand-gold dark:text-brand-ink';
+  const assistantBubble =
+    'w-fit self-start rounded px-2 py-1 bg-brand-purpleLt text-brand-ink dark:bg-brand-purple dark:text-neutral-100';
+  const userBubble = 'w-fit self-end rounded px-2 py-1 bg-brand-gold text-brand-ink dark:bg-brand-gold';
+  const thinkingBubble =
+    'self-start w-fit rounded bg-brand-purpleLt px-2 py-1 text-brand-ink dark:bg-brand-purple dark:text-neutral-100';
+
   const scheduleNudge = useCallback(() => {
     if (nudgeRef.current) clearTimeout(nudgeRef.current);
     const timeout = Math.floor(Math.random() * 45000) + 45000;
@@ -156,7 +176,7 @@ export default function Assistant() {
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
         <div
-          className={`absolute bottom-0 right-0 w-80 rounded border border-brand-gold bg-brand-ink p-4 text-neutral-50 shadow-lg transition-all duration-700 ease-in-out transform dark:border-brand-gold dark:bg-brand-ink dark:text-neutral-100 ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
+          className={`${panelBase} ${panelColors} ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
         >
           <button
             type="button"
@@ -165,39 +185,33 @@ export default function Assistant() {
               setOpen(false);
               resetNudge();
             }}
-            className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-brand-purple text-neutral-50 hover:bg-brand-purpleLt dark:bg-brand-gold dark:text-brand-ink dark:hover:bg-brand-gold/80"
+            className={closeBtn}
           >
             ×
           </button>
-        <div
-          role="log"
-          aria-label="Chat messages"
-          className="mb-2 flex max-h-60 flex-col gap-1 overflow-y-auto"
-          ref={logRef}
-        >
-          {messages.map((m, i) => (
-            <div
-              key={i}
-              className={`w-fit rounded px-2 py-1 ${
-                m.role === 'assistant'
-                  ? 'self-start bg-brand-purple text-neutral-100 dark:bg-brand-purple'
-                  : 'self-end bg-brand-gold text-brand-ink dark:bg-brand-gold'
-              }`}
-            >
-              {m.content}
-            </div>
-          ))}
-          {thinking && !collectInfo && (
-            <div className="self-start w-fit rounded bg-brand-purple px-2 py-1 text-neutral-100 dark:bg-brand-purple">
-              Assistant is thinking…
-            </div>
+          <div
+            role="log"
+            aria-label="Chat messages"
+            className="mb-2 flex max-h-60 flex-col gap-1 overflow-y-auto"
+            ref={logRef}
+          >
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={m.role === 'assistant' ? assistantBubble : userBubble}
+              >
+                {m.content}
+              </div>
+            ))}
+            {thinking && !collectInfo && (
+            <div className={thinkingBubble}>Assistant is thinking…</div>
           )}
-        </div>
-        {collectInfo ? (
-          <form onSubmit={sendInfo} className="flex flex-col gap-2" aria-label="Contact form">
+          </div>
+          {collectInfo ? (
+            <form onSubmit={sendInfo} className="flex flex-col gap-2" aria-label="Contact form">
               <input
                 type="text"
-                className="border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className={inputClass}
                 placeholder="Name"
                 value={info.name}
                 onChange={(e) => setInfo({ ...info, name: e.target.value })}
@@ -206,7 +220,7 @@ export default function Assistant() {
               />
               <input
                 type="text"
-                className="border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className={inputClass}
                 placeholder="Contact Number"
                 value={info.contact}
                 onChange={(e) => setInfo({ ...info, contact: e.target.value })}
@@ -215,7 +229,7 @@ export default function Assistant() {
               />
               <input
                 type="email"
-                className="border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className={inputClass}
                 placeholder="Email"
                 value={info.email}
                 onChange={(e) => setInfo({ ...info, email: e.target.value })}
@@ -223,24 +237,24 @@ export default function Assistant() {
                 required
               />
               <textarea
-                className="border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className={inputClass}
                 placeholder="Any extra details"
                 value={info.details}
                 onChange={(e) => setInfo({ ...info, details: e.target.value })}
                 aria-label="Any extra details"
               />
-              <button type="submit" className="border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink hover:bg-brand-gold/90 focus:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt dark:focus:bg-brand-purpleLt">Send</button>
+              <button type="submit" className={sendBtn}>Send</button>
           </form>
         ) : (
             <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
               <input
                 type="text"
-                className="flex-1 border border-brand-purple bg-brand-purpleLt p-1 text-brand-ink placeholder-brand-purple focus:border-brand-gold focus:outline-none dark:border-brand-purple dark:bg-brand-ink dark:text-neutral-100 dark:placeholder-brand-purpleLt"
+                className={`flex-1 ${inputClass}`}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 aria-label="Message"
               />
-              <button type="submit" className="border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink hover:bg-brand-gold/90 focus:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt dark:focus:bg-brand-purpleLt">Send</button>
+              <button type="submit" className={sendBtn}>Send</button>
             </form>
           )}
       </div>
@@ -261,7 +275,7 @@ export default function Assistant() {
                 setOpen(true);
               }
             }}
-            className={`flex h-14 w-14 items-center justify-center rounded-full border border-brand-purple bg-brand-gold text-brand-ink shadow-lg hover:bg-brand-gold/90 cursor-pointer dark:border-brand-gold dark:bg-brand-purple dark:text-neutral-100 dark:hover:bg-brand-purpleLt ${nudge ? 'animate-shake' : ''}`}
+            className={`${floatBtn} ${nudge ? 'animate-shake' : ''}`}
           >
             <span className="text-2xl">🤖</span>
           </button>
@@ -270,7 +284,7 @@ export default function Assistant() {
               type="button"
               aria-label="Dismiss assistant"
               onClick={dock}
-              className="absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full border border-brand-gold bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer dark:border-brand-purple dark:bg-brand-gold dark:text-brand-ink"
+              className={dismissBtn}
             >
               ×
             </button>

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -156,7 +156,7 @@ export default function Assistant() {
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
       <div
-        className={`absolute bottom-0 right-0 w-80 rounded border bg-neutral-100 p-4 shadow-lg transition-all duration-700 ease-in-out transform dark:bg-neutral-800 ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
+        className={`absolute bottom-0 right-0 w-80 rounded border border-brand-purple bg-brand-purpleLt text-brand-ink p-4 shadow-lg transition-all duration-700 ease-in-out transform dark:border-brand-gold dark:bg-brand-ink dark:text-neutral-100 ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
       >
         <button
           type="button"
@@ -165,25 +165,25 @@ export default function Assistant() {
             setOpen(false);
             resetNudge();
           }}
-          className="absolute right-2 top-2 text-xl leading-none cursor-pointer"
+          className="absolute right-2 top-2 text-xl leading-none cursor-pointer text-brand-ink dark:text-brand-gold"
         >
           ×
         </button>
         <div role="log" aria-label="Chat messages" className="mb-2 max-h-60 overflow-y-auto" ref={logRef}>
           {messages.map((m, i) => (
             <div key={i} className="mb-1">
-              <span className="font-bold">{m.role === 'assistant' ? 'Assistant' : 'You'}:</span> {m.content}
+              <span className={`font-bold ${m.role === 'assistant' ? 'text-brand-purple' : 'text-brand-gold'}`}>{m.role === 'assistant' ? 'Assistant' : 'You'}:</span> {m.content}
             </div>
           ))}
           {thinking && !collectInfo && (
-            <div className="mb-1 text-neutral-500">Assistant is thinking…</div>
+            <div className="mb-1 text-brand-purple">Assistant is thinking…</div>
           )}
         </div>
         {collectInfo ? (
           <form onSubmit={sendInfo} className="flex flex-col gap-2" aria-label="Contact form">
             <input
               type="text"
-              className="border p-1"
+              className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
               placeholder="Name"
               value={info.name}
               onChange={(e) => setInfo({ ...info, name: e.target.value })}
@@ -192,7 +192,7 @@ export default function Assistant() {
             />
             <input
               type="text"
-              className="border p-1"
+              className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
               placeholder="Contact Number"
               value={info.contact}
               onChange={(e) => setInfo({ ...info, contact: e.target.value })}
@@ -201,7 +201,7 @@ export default function Assistant() {
             />
             <input
               type="email"
-              className="border p-1"
+              className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
               placeholder="Email"
               value={info.email}
               onChange={(e) => setInfo({ ...info, email: e.target.value })}
@@ -209,24 +209,24 @@ export default function Assistant() {
               required
             />
             <textarea
-              className="border p-1"
+              className="border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
               placeholder="Any extra details"
               value={info.details}
               onChange={(e) => setInfo({ ...info, details: e.target.value })}
               aria-label="Any extra details"
             />
-            <button type="submit" className="border px-2 py-1 cursor-pointer">Send</button>
+            <button type="submit" className="border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink cursor-pointer dark:bg-brand-purple dark:text-neutral-100">Send</button>
           </form>
         ) : (
           <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
             <input
               type="text"
-              className="flex-1 border p-1"
+              className="flex-1 border border-brand-purple bg-neutral-50 p-1 text-brand-ink dark:bg-brand-ink dark:text-neutral-100"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               aria-label="Message"
             />
-            <button type="submit" className="border px-2 py-1 cursor-pointer">Send</button>
+            <button type="submit" className="border border-brand-purple bg-brand-gold px-2 py-1 text-brand-ink cursor-pointer dark:bg-brand-purple dark:text-neutral-100">Send</button>
           </form>
         )}
       </div>
@@ -247,7 +247,7 @@ export default function Assistant() {
               setOpen(true);
             }
           }}
-          className={`flex h-14 w-14 items-center justify-center rounded-full bg-neutral-100 shadow-lg dark:bg-neutral-800 cursor-pointer ${nudge ? 'animate-shake' : ''}`}
+          className={`flex h-14 w-14 items-center justify-center rounded-full bg-brand-gold text-brand-ink shadow-lg dark:bg-brand-purple dark:text-neutral-100 cursor-pointer ${nudge ? 'animate-shake' : ''}`}
         >
           <span className="text-2xl">🤖</span>
         </button>
@@ -256,7 +256,7 @@ export default function Assistant() {
             type="button"
             aria-label="Dismiss assistant"
             onClick={dock}
-            className="absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full bg-neutral-400 text-xs text-neutral-50 group-hover:flex cursor-pointer"
+            className="absolute -top-3 -right-3 hidden h-5 w-5 items-center justify-center rounded-full bg-brand-purple text-xs text-neutral-50 group-hover:flex cursor-pointer"
           >
             ×
           </button>


### PR DESCRIPTION
## Summary
- restyle assistant chat panel with brand purple, gold, and ink colors for light and dark modes
- theme inputs and buttons with brand palette for a cohesive look
- update floating action and dismiss buttons to use brand colors and improve contrast

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c753f229fc832c963b484b894055ba