### PR TITLE
Show loading overlay on navigation start

### DIFF
--- a/app/events/[slug]/loading.tsx
+++ b/app/events/[slug]/loading.tsx
@@ -1,9 +1,11 @@
 import LogoSpinner from "@/components/LogoSpinner";
+import { siteSettings } from "@/lib/queries";
 
-export default function Loading() {
+export default async function Loading() {
+  const settings = await siteSettings();
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--brand-bg)]">
-      <LogoSpinner />
+      <LogoSpinner logoUrl={settings?.logo} />
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import Footer from "@/components/Footer";
 import AnnouncementBanner from "@/components/AnnouncementBanner";
 import BannerAnchor from "@/components/BannerAnchor";
 import Assistant from "@/components/Assistant";
+import NavigationLoading from "@/components/NavigationLoading";
 import { siteSettings, announcementLatest } from "@/lib/queries";
 import { getCurrentLivestream } from "@/lib/vimeo";
 import AutoRefresh from "@/components/AutoRefresh";
@@ -127,6 +128,7 @@ gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');`}
         <main className="max-w-site flex-1 px-4 py-8">{children}</main>
         {!isEmbedded && <Footer />}
         {!isEmbedded && <Assistant />}
+        <NavigationLoading logoUrl={settings?.logo} />
       </body>
     </html>
   );

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,9 +1,11 @@
 import LogoSpinner from "@/components/LogoSpinner";
+import { siteSettings } from "@/lib/queries";
 
-export default function Loading() {
+export default async function Loading() {
+  const settings = await siteSettings();
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--brand-bg)]">
-      <LogoSpinner />
+      <LogoSpinner logoUrl={settings?.logo} />
     </div>
   );
 }

--- a/components/LogoSpinner.tsx
+++ b/components/LogoSpinner.tsx
@@ -1,13 +1,12 @@
+"use client";
+
 import Image from "next/image";
-import { siteSettings } from "@/lib/queries";
 
-export default async function LogoSpinner() {
-  const settings = await siteSettings();
-  const logoUrl = settings?.logo ?? "/static/favicon.svg";
-
+export default function LogoSpinner({ logoUrl }: { logoUrl?: string }) {
+  const src = logoUrl ?? "/static/favicon.svg";
   return (
     <div className="flex items-center justify-center">
-      <Image src={logoUrl} alt="Logo" width={64} height={64} className="animate-logo-pulse rounded-full" />
+      <Image src={src} alt="Logo" width={64} height={64} className="animate-logo-pulse rounded-full" />
     </div>
   );
 }

--- a/components/NavigationLoading.tsx
+++ b/components/NavigationLoading.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import LogoSpinner from "@/components/LogoSpinner";
+
+export default function NavigationLoading({ logoUrl }: { logoUrl?: string }) {
+  const pathname = usePathname();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+      }
+      const target = e.target as HTMLElement | null;
+      const anchor = target?.closest?.("a[href]") as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+      // Only handle internal links
+      const url = new URL(href, window.location.href);
+      if (url.origin !== window.location.origin) return;
+      // Ignore same-page anchors
+      const current = new URL(window.location.href);
+      if (url.pathname === current.pathname && url.search === current.search) return;
+      if (anchor.target === "_blank") return;
+      setLoading(true);
+    };
+    window.addEventListener("click", handleClick);
+    return () => window.removeEventListener("click", handleClick);
+  }, []);
+
+  useEffect(() => {
+    setLoading(false);
+  }, [pathname]);
+
+  if (!loading) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--brand-bg)]">
+      <LogoSpinner logoUrl={logoUrl} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- display logo spinner overlay immediately after an internal link is clicked
- refactor logo spinner for reuse across navigation and route loading states

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c758069e90832caf28ecbae3b2c1c7