### PR TITLE
feat: add form settings schema

### DIFF
--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -1,6 +1,7 @@
 import announcement from './schemas/announcement';
 import staff from './schemas/staff';
 import siteSettings from './schemas/siteSettings';
+import formSettings from './schemas/formSettings';
 import ministry from './schemas/ministry';
 import heroSlide from './schemas/heroSlide';
 import chatbot from './schemas/chatbot';
@@ -16,6 +17,7 @@ export const schemaTypes = [
   announcement,
   staff,
   siteSettings,
+  formSettings,
   ministry,
   heroSlide,
   missionStatement,

--- a/sanity/schemas/formSettings.ts
+++ b/sanity/schemas/formSettings.ts
@@ -1,0 +1,31 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'formSettings',
+  title: 'Form Settings',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'targetEmail',
+      title: 'Target Email',
+      type: 'string',
+      validation: (Rule) => Rule.email().required(),
+    }),
+  ],
+});

--- a/types/formSettings.ts
+++ b/types/formSettings.ts
@@ -1,0 +1,5 @@
+export type FormSettings = {
+  title: string;
+  slug: string;
+  targetEmail: string;
+};


### PR DESCRIPTION
## Summary
- add Sanity schema for form settings
- expose optional FormSettings type for TypeScript
- register form settings schema in Sanity schema entrypoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7674fe6a8832c8b963185b3dbdc4a