### PR TITLE
feat: enhance giving awareness and escalation behavior

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -57,7 +57,6 @@ export async function POST(req: Request) {
     });
   }
 
-  // Soft optional escalation: if confidence is low, suggest option but do not auto-open form
   const softThreshold = 0.3;
   const softEscalate = confidence <= softThreshold;
 

--- a/app/giving/page.tsx
+++ b/app/giving/page.tsx
@@ -1,11 +1,10 @@
 import type { SVGProps } from "react";
+import type { GivingOption } from "@/lib/giving";
+import { givingOptions } from "@/lib/giving";
 
 export const metadata = { title: "Giving" };
 
-type Option = {
-  title: string;
-  content: string;
-  href?: string;
+type Option = GivingOption & {
   icon: (props: SVGProps<SVGSVGElement>) => JSX.Element;
 };
 
@@ -86,30 +85,17 @@ function LinkIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
-const options: Option[] = [
-  {
-    title: "Mailing Address",
-    content: "864 Splitlog Ave., Kansas City, KS 66101",
-    icon: MailIcon,
-  },
-  {
-    title: "Cash App",
-    content: "$GPTKCK",
-    icon: CashIcon,
-  },
-  {
-    title: "Givelify",
-    content: "Greater Pentecostal Temple Church",
-    href: "https://www.givelify.com/donate/MTUxODY4MQ==/selection",
-    icon: HeartIcon,
-  },
-  {
-    title: "Razmobile",
-    content: "Give securely online",
-    href: "https://www.razmobile.com/GPTChurch",
-    icon: LinkIcon,
-  },
-];
+const iconMap: Record<string, (props: SVGProps<SVGSVGElement>) => JSX.Element> = {
+  "Mailing Address": MailIcon,
+  "Cash App": CashIcon,
+  Givelify: HeartIcon,
+  Razmobile: LinkIcon,
+};
+
+const options: Option[] = givingOptions.map((opt) => ({
+  ...opt,
+  icon: iconMap[opt.title] ?? LinkIcon,
+}));
 
 function OptionCard({ option, delay }: { option: Option; delay: string }) {
   const Icon = option.icon;

--- a/lib/chatbot.ts
+++ b/lib/chatbot.ts
@@ -11,6 +11,7 @@ import { getCurrentLivestream } from './vimeo';
 import { getUpcomingEvents } from './googleCalendar';
 import fs from 'fs';
 import path from 'path';
+import { givingOptions } from './giving';
 
 export async function getChatbotTone(): Promise<string> {
   const tone = await sanity.fetch(groq`*[_type == "chatbotSettings"][0].tone`);
@@ -113,6 +114,14 @@ async function buildSiteContext(): Promise<string> {
     if (ministries.length) {
       context +=
         'Ministries: ' + ministries.map((m) => `${m.name} - ${m.description}`).join('; ') + '. ';
+    }
+    if (givingOptions.length) {
+      context +=
+        'Giving options: ' +
+        givingOptions
+          .map((g) => `${g.title} ${g.content}${g.href ? ' ' + g.href : ''}`)
+          .join('; ') +
+        '. ';
     }
     if (livestream) {
       let status: string;

--- a/lib/giving.ts
+++ b/lib/giving.ts
@@ -1,0 +1,26 @@
+export type GivingOption = {
+  title: string;
+  content: string;
+  href?: string;
+};
+
+export const givingOptions: GivingOption[] = [
+  {
+    title: 'Mailing Address',
+    content: '864 Splitlog Ave., Kansas City, KS 66101',
+  },
+  {
+    title: 'Cash App',
+    content: '$GPTKCK',
+  },
+  {
+    title: 'Givelify',
+    content: 'Greater Pentecostal Temple Church',
+    href: 'https://www.givelify.com/donate/MTUxODY4MQ==/selection',
+  },
+  {
+    title: 'Razmobile',
+    content: 'Give securely online',
+    href: 'https://www.razmobile.com/GPTChurch',
+  },
+];


### PR DESCRIPTION
## Summary
- share giving options in a centralized module for UI and chatbot context
- surface giving options in chatbot's site context so it can answer donation questions
- suggest soft escalation whenever the assistant's confidence ≤ 0.3, relying solely on the model's confidence
- remove redundant comments around soft escalation handling in the chat API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c75c580a24832cab0e71831f54926a