### PR TITLE
Fix mobile assistant panel overlapping with keyboard

### DIFF
--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -25,6 +25,24 @@ export default function Assistant() {
   const [escalationReason, setEscalationReason] = useState('');
   const [collectInfoMode, setCollectInfoMode] = useState<'soft' | 'hard' | null>(null);
   const logRef = useRef<HTMLDivElement>(null);
+  const baseBottom = 24;
+  const [viewportOffset, setViewportOffset] = useState(0);
+
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    const handle = () => {
+      if (!viewport) return;
+      const diff = Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop);
+      setViewportOffset(diff);
+    };
+    viewport?.addEventListener('resize', handle);
+    viewport?.addEventListener('scroll', handle);
+    handle();
+    return () => {
+      viewport?.removeEventListener('resize', handle);
+      viewport?.removeEventListener('scroll', handle);
+    };
+  }, []);
 
   function renderContent(text: string) {
     const regex = /(https?:\/\/[^\s]+|\/[A-Za-z0-9\-_/]+)/g;
@@ -186,7 +204,7 @@ export default function Assistant() {
   return (
     <div
       ref={containerRef}
-      style={{ transform: `translate(${offset.x}px, ${offset.y + enterOffset}px)`, opacity: entered ? 1 : 0 }}
+      style={{ transform: `translate(${offset.x}px, ${offset.y + enterOffset}px)`, opacity: entered ? 1 : 0, bottom: baseBottom + viewportOffset }}
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
       <div


### PR DESCRIPTION
## Summary
- adjust assistant position based on visual viewport
- offset panel from bottom to remain visible when keyboard opens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c77d34f650832c8482b46e55da3978