### PR TITLE
Improve mobile layout on event details page

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -91,7 +91,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
   return (
     <>
       {liveStyleEl}
-      <article id="event-article" className="space-y-8">
+      <article id="event-article" className="mx-auto w-full max-w-screen-md space-y-8">
         {!hasHero && (
           <HeroSection
             title={detail.title}

--- a/components/eventDetailSections/GallerySection.tsx
+++ b/components/eventDetailSections/GallerySection.tsx
@@ -22,12 +22,12 @@ export default function GallerySection({ layout = 'grid', images }: GallerySecti
           alt={img.alt || ''}
           width={600}
           height={400}
-          className="h-60 w-auto rounded border border-[var(--brand-border)] object-cover"
+          className="h-60 w-auto max-w-full flex-shrink-0 rounded border border-[var(--brand-border)] object-cover"
         />
       ))}
     </div>
   ) : (
-    <div className="grid gap-4 grid-cols-2 md:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
       {images.map((img) => (
         <Image
           key={img._key}

--- a/components/eventDetailSections/HeroSection.tsx
+++ b/components/eventDetailSections/HeroSection.tsx
@@ -36,10 +36,10 @@ export default function HeroSection({
           />
         </div>
       )}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-4">
           {eventLogo && (
-            <div className="relative h-24 w-24">
+            <div className="relative h-20 w-20 sm:h-24 sm:w-24">
               <Image src={eventLogo.url} alt={eventLogo.alt || ''} fill className="object-contain" />
             </div>
           )}
@@ -51,7 +51,7 @@ export default function HeroSection({
           </div>
         </div>
         {subscribeUrl && (
-          <div className="flex items-center gap-4 text-right">
+          <div className="flex items-center gap-4 sm:text-right">
             {date && <p className="text-[var(--brand-fg)]">{date}</p>}
             <a
               href={subscribeUrl}


### PR DESCRIPTION
## Summary
- Constrain event detail content width for smaller screens
- Make hero section layout responsive with smaller logo and stacked subscribe area
- Adjust gallery to single-column grid on phones and prevent carousel images from exceeding width

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78080a464832c91a9bda46e2f90b5