### PR TITLE
Improve dark mode readability of escalation link

### DIFF
--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -285,8 +285,7 @@ export default function Assistant() {
                       <div className="mt-1 text-sm">
                         <button
                           type="button"
-                          className="underline hover:opacity-80 focus:outline-none focus:ring-1 cursor-pointer bg-transparent p-0 font-normal"
-                          style={{ color: 'var(--brand-accent)', '--tw-ring-color': 'var(--brand-accent)' } as CSSProperties}
+                          className="underline hover:opacity-80 focus:outline-none focus:ring-1 cursor-pointer bg-transparent p-0 font-normal text-[var(--brand-accent)] focus:ring-[var(--brand-accent)] dark:text-[var(--brand-primary-contrast)] dark:focus:ring-[var(--brand-primary-contrast)]"
                           onClick={() => {
                             const pct = Math.max(
                               0,


### PR DESCRIPTION
## Summary
- ensure "Reach Out to a Staff Member" button uses a contrasting color in dark mode for better accessibility

## Testing
- `npm test`
- `npm run lint` *(fails: Warning: The ref value 'containerRef.current' will likely have changed... etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c784a1ed38832ca4e19b8f3f727826