### PR TITLE
Add product schema

### DIFF
--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -5,6 +5,7 @@ import ministry from './schemas/ministry';
 import heroSlide from './schemas/heroSlide';
 import missionStatement from './schemas/missionStatement';
 import eventDetail from './schemas/eventDetail';
+import product from './schemas/product';
 import heroSection from './schemas/sections/heroSection';
 import gallerySection from './schemas/sections/gallerySection';
 import calendarSection from './schemas/sections/calendarSection';
@@ -19,6 +20,7 @@ export const schemaTypes = [
   heroSlide,
   missionStatement,
   eventDetail,
+  product,
   heroSection,
   gallerySection,
   calendarSection,

--- a/sanity/schemas/product.ts
+++ b/sanity/schemas/product.ts
@@ -1,0 +1,41 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'product',
+  title: 'Product',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title', maxLength: 96 },
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+    }),
+    defineField({
+      name: 'price',
+      title: 'Price',
+      type: 'number',
+    }),
+    defineField({
+      name: 'images',
+      title: 'Images',
+      type: 'array',
+      of: [{ type: 'image', options: { hotspot: true } }],
+    }),
+    defineField({
+      name: 'inventory',
+      title: 'Inventory',
+      type: 'number',
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- add product schema with title, slug, description, price, images, inventory fields
- export product in Sanity schema

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5ad118230832c80916468c0f3a104