### PR TITLE
Add store page querying Sanity for products

### DIFF
--- a/app/store/page.tsx
+++ b/app/store/page.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import { productsAll } from "@/lib/queries";
+
+export default async function Page() {
+  const products = await productsAll();
+
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
+      {products.map((product) => (
+        <div
+          key={product._id}
+          className="flex flex-col items-center rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] p-4 text-center"
+        >
+          {product.image && (
+            <Image
+              src={product.image}
+              alt={product.title}
+              width={300}
+              height={300}
+              className="mb-4 object-cover"
+            />
+          )}
+          <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">
+            {product.title}
+          </h3>
+          <p className="mt-2 text-[var(--brand-accent)]">${product.price.toFixed(2)}</p>
+          <button className="btn-primary mt-4">Add to Cart</button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -180,3 +180,20 @@ export const eventDetailBySlug = (slug: string, preview = false) => {
   );
 };
 
+export interface Product {
+  _id: string;
+  title: string;
+  price: number;
+  image?: string;
+}
+
+export const productsAll = () =>
+  sanity.fetch<Product[]>(
+    groq`*[_type == "product"] | order(_createdAt desc){
+      _id,
+      title,
+      price,
+      "image": image.asset->url
+    }`
+  );
+


### PR DESCRIPTION
## Summary
- fetch product documents via Sanity client
- add `/store` page to display products with image, price, and cart button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5ad135da4832c9f880cd550eb7e5e