### PR TITLE
Add form submission API with Sanity lookup and email dispatch

### DIFF
--- a/app/api/submit-form/route.ts
+++ b/app/api/submit-form/route.ts
@@ -1,0 +1,43 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from 'next/server';
+import { sanity } from '@/lib/sanity';
+import { sendEmail } from '@/lib/gmail';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { slug, id, ...formData } = body || {};
+
+    if (!slug && !id) {
+      return NextResponse.json({ error: 'Missing page identifier' }, { status: 400 });
+    }
+
+    const params = slug ? { slug } : { id };
+    const query = slug
+      ? `*[_type == "formSettings" && slug.current == $slug][0]{ targetEmail }`
+      : `*[_type == "formSettings" && _id == $id][0]{ targetEmail }`;
+
+    const result = await sanity.fetch<{ targetEmail?: string }>(query, params);
+    const targetEmail = result?.targetEmail;
+
+    if (!targetEmail) {
+      return NextResponse.json({ error: 'Form settings not found' }, { status: 404 });
+    }
+
+    const replyTo = typeof formData.email === 'string' ? formData.email : undefined;
+    const from = process.env.FORM_FROM_EMAIL || targetEmail;
+    await sendEmail({
+      from,
+      to: targetEmail,
+      subject: `New form submission from ${slug || id}`,
+      text: JSON.stringify(formData, null, 2),
+      replyTo,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Form submission error', err);
+    return NextResponse.json({ error: 'Failed to submit form' }, { status: 500 });
+  }
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -1,0 +1,108 @@
+import fs from 'fs';
+import path from 'path';
+import { google } from 'googleapis';
+
+interface SendEmailOptions {
+  to: string;
+  from: string;
+  subject: string;
+  text: string;
+  replyTo?: string;
+}
+
+function loadCredentials(): { svcEmail: string; svcKey: string } {
+  let svcEmail = '';
+  let svcKeyRaw = '';
+
+  const defaultKeyPath = path.join(process.cwd(), 'config', 'gmail-service-account.json');
+  const keyFilePath = process.env.GMAIL_SERVICE_ACCOUNT_KEY_FILE || defaultKeyPath;
+  if (fs.existsSync(keyFilePath)) {
+    try {
+      const creds = JSON.parse(fs.readFileSync(keyFilePath, 'utf8'));
+      if (typeof creds.client_email === 'string') {
+        svcEmail = creds.client_email;
+      }
+      if (typeof creds.private_key === 'string') {
+        svcKeyRaw = creds.private_key;
+      }
+    } catch (e) {
+      throw new Error(`Failed to read Gmail service account file at ${keyFilePath}: ${(e as Error).message}`);
+    }
+  }
+
+  if (!svcEmail) {
+    svcEmail = process.env.GMAIL_SERVICE_ACCOUNT_EMAIL || '';
+  }
+  if (!svcKeyRaw) {
+    const envRaw = process.env.GMAIL_SERVICE_ACCOUNT_PRIVATE_KEY || '';
+    if (envRaw.trim().startsWith('{')) {
+      try {
+        const creds = JSON.parse(envRaw);
+        if (!svcEmail && typeof creds.client_email === 'string') {
+          svcEmail = creds.client_email;
+        }
+        if (typeof creds.private_key === 'string') {
+          svcKeyRaw = creds.private_key;
+        }
+      } catch {
+        // ignore JSON parse errors
+      }
+    } else {
+      svcKeyRaw = envRaw;
+    }
+  }
+
+  if (!svcEmail || !svcKeyRaw) {
+    throw new Error(
+      'Missing Gmail service account credentials. Provide JSON at config/gmail-service-account.json (or set GMAIL_SERVICE_ACCOUNT_KEY_FILE), or set GMAIL_SERVICE_ACCOUNT_EMAIL and GMAIL_SERVICE_ACCOUNT_PRIVATE_KEY (PEM or JSON).',
+    );
+  }
+
+  const looksPlaceholder = /\.\.\.snip\.\.\.|<your[-\s_]?private[-\s_]?key>|REDACTED|PLACEHOLDER/i.test(svcKeyRaw);
+  const hasPemHeader = /BEGIN [A-Z ]*PRIVATE KEY/.test(svcKeyRaw);
+  if (looksPlaceholder || !hasPemHeader) {
+    throw new Error(
+      'Gmail service account private key appears invalid or placeholder. Place a valid credentials file at config/gmail-service-account.json (or set GMAIL_SERVICE_ACCOUNT_KEY_FILE), or provide GMAIL_SERVICE_ACCOUNT_PRIVATE_KEY with a real PEM.',
+    );
+  }
+
+  const svcKey = svcKeyRaw.includes('\\n') ? svcKeyRaw.replace(/\\n/g, '\n') : svcKeyRaw;
+  return { svcEmail, svcKey };
+}
+
+export async function sendEmail({ to, from, subject, text, replyTo }: SendEmailOptions) {
+  const { svcEmail, svcKey } = loadCredentials();
+
+  const auth = new google.auth.JWT({
+    email: svcEmail,
+    key: svcKey,
+    scopes: ['https://www.googleapis.com/auth/gmail.send', 'https://mail.google.com/'],
+    subject: from,
+  } as any);
+  await auth.authorize();
+
+  const gmail = google.gmail({ version: 'v1', auth });
+
+  const headers = [
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    `From: ${from}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset="UTF-8"',
+  ];
+  if (replyTo) {
+    headers.push(`Reply-To: ${replyTo}`);
+  }
+  const message = headers.join('\r\n') + '\r\n\r\n' + text;
+  const raw = Buffer.from(message)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+  await gmail.users.messages.send({
+    userId: 'me',
+    requestBody: { raw },
+  });
+}
+


### PR DESCRIPTION
## Summary
- add submit-form API route that resolves target email from Sanity and sends form data via Gmail API
- include Gmail helper and remove nodemailer dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c77289ae7c832cabe96ce9ab77c799