### PR TITLE
style: differentiate assistant close button color

### DIFF
--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -248,9 +248,9 @@ export default function Assistant() {
           }}
           className="absolute right-2 top-2 grid h-8 w-8 place-items-center rounded-full border text-2xl leading-none cursor-pointer"
           style={{
-            backgroundColor: 'var(--brand-accent)',
+            backgroundColor: 'var(--brand-alt)',
             color: 'var(--brand-ink)',
-            borderColor: 'var(--brand-border)',
+            borderColor: 'var(--brand-alt)',
           }}
         >
           ×


### PR DESCRIPTION
## Summary
- use brand-alt for Assistant close button background and border so it stands out

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c83a0232f0832c9907496674ffa7aa