### PR TITLE
Add store link to site navigation

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,6 +19,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
     { href: "/ministries", label: "Ministries" },
     { href: "/events", label: "Events" },
     { href: "/livestreams", label: "Livestreams" },
+    { href: "/store", label: "Store" },
     { href: "/giving", label: "Giving" },
   ];
 


### PR DESCRIPTION
## Summary
- add Store to main navigation menu

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c83a7e2af0832cbda8f8e6d07a9da5