### PR TITLE
Remove unused slug from product schema

### DIFF
--- a/sanity/schemas/product.ts
+++ b/sanity/schemas/product.ts
@@ -11,12 +11,6 @@ export default defineType({
       type: 'string',
     }),
     defineField({
-      name: 'slug',
-      title: 'Slug',
-      type: 'slug',
-      options: { source: 'title', maxLength: 96 },
-    }),
-    defineField({
       name: 'description',
       title: 'Description',
       type: 'text',


### PR DESCRIPTION
## Summary
- remove the unused slug field from the product Sanity schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c83d7fe1dc832c91a93c1fd69c69b3