### PR TITLE
Centralize OpenAI client usage

### DIFF
--- a/lib/chatbot.ts
+++ b/lib/chatbot.ts
@@ -48,21 +48,9 @@ export async function getEscalationAddresses(): Promise<{ from: string; to: stri
 import type { ChatMessage, EscalationInfo as SharedEscalationInfo } from '@/types/chat';
 export type Message = ChatMessage;
 
-import OpenAI from 'openai';
+import type OpenAI from 'openai';
 import { google } from 'googleapis';
-
-let defaultClient: OpenAI | null = null;
-
-function getClient(client?: OpenAI): OpenAI {
-  if (client) return client;
-  if (!defaultClient) {
-    if (!process.env.OPENAI_API_KEY) {
-      throw new Error('OPENAI_API_KEY is not set');
-    }
-    defaultClient = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-  }
-  return defaultClient;
-}
+import { getOpenAIClient } from './openaiClient';
 
 // Build a simple sitemap from the Next.js app directory so the assistant knows exact page paths.
 function buildAppSitemap(): string {
@@ -223,7 +211,7 @@ export async function generateChatbotReply(
   escalate: boolean;
   escalateReason: string;
 }> {
-  const openai = getClient(client);
+  const openai = getOpenAIClient(client);
   const [context, extra] = await Promise.all([
     buildSiteContext(),
     getChatbotExtraContext(),
@@ -289,7 +277,7 @@ export async function escalationNotice(
   lastUserMessage: string,
   client?: OpenAI,
 ): Promise<string> {
-  const openai = getClient(client);
+  const openai = getOpenAIClient(client);
   const completion = await openai.chat.completions.create({
     model: 'gpt-4o-mini',
     messages: [

--- a/lib/openaiClient.ts
+++ b/lib/openaiClient.ts
@@ -1,0 +1,21 @@
+import OpenAI from 'openai';
+
+let cachedClient: OpenAI | null = null;
+
+export function getOpenAIClient(client?: OpenAI): OpenAI {
+  if (client) {
+    return client;
+  }
+
+  if (!cachedClient) {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error('OPENAI_API_KEY is not set');
+    }
+
+    cachedClient = new OpenAI({ apiKey });
+  }
+
+  return cachedClient;
+}
+


### PR DESCRIPTION
## Summary
- add a shared OpenAI client helper that caches a singleton instance and validates the API key
- refactor the chatbot module to consume the shared helper while keeping optional client injection for tests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99721dec8832c8787bdc2eceac39f