### PR TITLE
Refactor chatbot site context to structured JSON

### DIFF
--- a/lib/chatbot.test.ts
+++ b/lib/chatbot.test.ts
@@ -1,17 +1,22 @@
 process.env.SANITY_STUDIO_PROJECT_ID = 'test';
 process.env.SANITY_STUDIO_DATASET = 'test';
+process.env.TZ = 'UTC';
 
 import assert from 'node:assert';
 import { sanity } from './sanity';
-import { generateChatbotReply } from './chatbot';
+import { buildSiteContext, generateChatbotReply } from './chatbot';
 
 const sanityAny: any = sanity;
 sanityAny.fetch = async () => '' as any;
 
+const captured: { system?: string } = {};
+
 const fakeClient = {
   chat: {
     completions: {
-      create: async () => ({
+      create: async (payload: any) => {
+        captured.system = payload?.messages?.[0]?.content;
+        return {
         choices: [
           {
             message: {
@@ -25,12 +30,94 @@ const fakeClient = {
             },
           },
         ],
-      }),
+        };
+      },
     },
   },
 };
 
-(async () => {
+async function testBuildSiteContext() {
+  const ctxJson = await buildSiteContext({
+    siteSettings: async () =>
+      ({
+        title: 'Test GPT',
+        address: '123 Street',
+        serviceTimes: 'Sun 10am',
+        email: 'info@example.com',
+        phone: '123-456-7890',
+        socialLinks: [{ label: 'Facebook', href: 'https://fb.com/test' }],
+      }) as any,
+    announcementLatest: async () =>
+      ({
+        title: 'Latest',
+        message: 'Details',
+        cta: { label: 'Read more', href: 'https://example.com/latest' },
+      }) as any,
+    missionStatement: async () =>
+      ({
+        headline: 'Serve',
+        tagline: 'Tag',
+        message: 'Mission body',
+      }) as any,
+    staffAll: async () =>
+      ([
+        { name: 'Alice', role: 'Lead Pastor' },
+        { name: 'Bob', role: 'Deacon' },
+      ] as any),
+    ministriesAll: async () =>
+      ([
+        { name: 'Youth', description: 'Teens' },
+      ] as any),
+    givingOptions: [
+      { title: 'Online', content: 'Give', href: 'https://give.example.com' },
+    ],
+    getCurrentLivestream: async () =>
+      ({
+        name: 'Sunday Service',
+        link: 'https://example.com/live',
+        live: { status: 'streaming' },
+      }) as any,
+    getUpcomingEvents: async () =>
+      ([
+        {
+          title: 'Bible Study',
+          start: '2024-05-02T18:30:00Z',
+          location: 'Room 1',
+          href: 'https://example.com/bible-study',
+        },
+      ] as any),
+  });
+
+  assert.ok(ctxJson);
+  const parsed = JSON.parse(ctxJson);
+  assert.strictEqual(parsed.st.t, 'Test GPT');
+  assert.strictEqual(parsed.st.addr, '123 Street');
+  assert.strictEqual(parsed.st.svc, 'Sun 10am');
+  assert.strictEqual(parsed.st.email, 'info@example.com');
+  assert.strictEqual(parsed.st.phone, '123-456-7890');
+  assert.strictEqual(parsed.st.sl[0].u, 'https://fb.com/test');
+  assert.strictEqual(parsed.ann.t, 'Latest');
+  assert.strictEqual(parsed.ann.msg, 'Details');
+  assert.strictEqual(parsed.ann.cta.u, 'https://example.com/latest');
+  assert.strictEqual(parsed.ms.h, 'Serve');
+  assert.strictEqual(parsed.ms.tg, 'Tag');
+  assert.strictEqual(parsed.ms.msg, 'Mission body');
+  assert.strictEqual(parsed.sf[0].n, 'Alice');
+  assert.strictEqual(parsed.sf[0].r, 'Lead Pastor');
+  assert.strictEqual(parsed.mn[0].n, 'Youth');
+  assert.strictEqual(parsed.mn[0].d, 'Teens');
+  assert.strictEqual(parsed.gv[0].u, 'https://give.example.com');
+  assert.strictEqual(parsed.ls.st, 'live');
+  assert.strictEqual(parsed.ls.u, 'https://example.com/live');
+  assert.strictEqual(parsed.ev[0].t, 'Bible Study');
+  assert.ok(parsed.ev[0].dt);
+  assert.strictEqual(parsed.ev[0].loc, 'Room 1');
+  assert.strictEqual(parsed.ev[0].u, 'https://example.com/bible-study');
+  assert.ok(Array.isArray(parsed.nav));
+  assert.ok(parsed.nav.length > 0);
+}
+
+async function testGenerateChatbotReply() {
   const { reply, confidence, similarityCount, escalate, escalateReason } = await generateChatbotReply(
     [
       {
@@ -47,6 +134,12 @@ const fakeClient = {
   assert.strictEqual(similarityCount, 3);
   assert.strictEqual(escalate, false);
   assert.strictEqual(escalateReason, '');
+  assert.ok(captured.system?.includes('Site content JSON:'));
+}
+
+(async () => {
+  await testBuildSiteContext();
+  await testGenerateChatbotReply();
   console.log('tests passed');
 })();
 

--- a/lib/chatbot.ts
+++ b/lib/chatbot.ts
@@ -123,11 +123,40 @@ function buildAppSitemap(): string {
   }
 }
 
-async function buildSiteContext(): Promise<string> {
+type SiteContextSources = {
+  siteSettings: typeof siteSettings;
+  staffAll: typeof staffAll;
+  ministriesAll: typeof ministriesAll;
+  missionStatement: typeof missionStatement;
+  announcementLatest: typeof announcementLatest;
+  getCurrentLivestream: typeof getCurrentLivestream;
+  getUpcomingEvents: typeof getUpcomingEvents;
+  givingOptions: typeof givingOptions;
+};
+
+const defaultSiteContextSources: SiteContextSources = {
+  siteSettings,
+  staffAll,
+  ministriesAll,
+  missionStatement,
+  announcementLatest,
+  getCurrentLivestream,
+  getUpcomingEvents,
+  givingOptions,
+};
+
+const toArray = <T>(value: unknown): T[] => (Array.isArray(value) ? (value as T[]) : []);
+const toRecord = <T extends Record<string, unknown>>(value: unknown): T | null =>
+  value && typeof value === 'object' && !Array.isArray(value) ? (value as T) : null;
+
+export async function buildSiteContext(
+  overrides: Partial<SiteContextSources> = {},
+): Promise<string> {
   if (!process.env.SANITY_STUDIO_PROJECT_ID || !process.env.SANITY_STUDIO_DATASET) {
     return '';
   }
   try {
+    const sources = { ...defaultSiteContextSources, ...overrides } as SiteContextSources;
     const [
       settings,
       staff,
@@ -137,76 +166,129 @@ async function buildSiteContext(): Promise<string> {
       livestream,
       events,
     ] = await Promise.all([
-      siteSettings().catch(() => null),
-      staffAll().catch(() => []),
-      ministriesAll().catch(() => []),
-      missionStatement().catch(() => null),
-      announcementLatest().catch(() => null),
-      getCurrentLivestream().catch(() => null),
-      getUpcomingEvents(5).catch(() => []),
+      sources.siteSettings().catch(() => null),
+      sources.staffAll().catch(() => []),
+      sources.ministriesAll().catch(() => []),
+      sources.missionStatement().catch(() => null),
+      sources.announcementLatest().catch(() => null),
+      sources.getCurrentLivestream().catch(() => null),
+      sources.getUpcomingEvents(5).catch(() => []),
     ]);
-    let context = '';
+    const context: Record<string, unknown> = {};
     const tz = process.env.TZ || 'UTC';
     const dateFmt = new Intl.DateTimeFormat('en-US', { timeZone: tz, dateStyle: 'medium', timeStyle: 'short' });
+    const evFmt = new Intl.DateTimeFormat('en-US', { timeZone: tz, dateStyle: 'medium' });
     const sitemap = buildAppSitemap();
-    if (settings) {
-      context += `Site title: ${settings.title}. `;
-      if (settings.address) context += `Address: ${settings.address}. `;
-      if (settings.serviceTimes) context += `Service times: ${settings.serviceTimes}. `;
-      if (settings.email) context += `Email: ${settings.email}. `;
-      if (settings.phone) context += `Phone: ${settings.phone}. `;
-      if (settings.socialLinks?.length) {
-        context +=
-          'Social links: ' +
-          settings.socialLinks.map((s) => `${s.label} ${s.href}`).join('; ') +
-          '. ';
+    const settingsRecord = toRecord<NonNullable<Awaited<ReturnType<typeof siteSettings>>>>(settings);
+    if (settingsRecord) {
+      const st: Record<string, unknown> = {};
+      if (settingsRecord.title) st.t = settingsRecord.title;
+      if (settingsRecord.address) st.addr = settingsRecord.address;
+      if (settingsRecord.serviceTimes) st.svc = settingsRecord.serviceTimes;
+      if (settingsRecord.email) st.email = settingsRecord.email;
+      if (settingsRecord.phone) st.phone = settingsRecord.phone;
+      const socials = toArray(settingsRecord.socialLinks).map((s: any) => {
+        if (!s || typeof s !== 'object') return null;
+        const entry: Record<string, string> = {};
+        if (typeof s.label === 'string' && s.label) entry.l = s.label;
+        if (typeof s.href === 'string' && s.href) entry.u = s.href;
+        return Object.keys(entry).length ? entry : null;
+      }).filter(Boolean) as Record<string, string>[];
+      if (socials.length) st.sl = socials;
+      if (Object.keys(st).length) context.st = st;
+    }
+    const announcementRecord = toRecord<NonNullable<Awaited<ReturnType<typeof announcementLatest>>>>(announcement);
+    if (announcementRecord) {
+      const ann: Record<string, unknown> = {};
+      if (announcementRecord.title) ann.t = announcementRecord.title;
+      if (announcementRecord.message) ann.msg = announcementRecord.message;
+      if (announcementRecord.cta) {
+        const cta: Record<string, string> = {};
+        if (announcementRecord.cta.label) cta.l = announcementRecord.cta.label;
+        if (announcementRecord.cta.href) cta.u = announcementRecord.cta.href;
+        if (Object.keys(cta).length) ann.cta = cta;
       }
+      if (Object.keys(ann).length) context.ann = ann;
     }
-    if (announcement) {
-      context += `Latest announcement: ${announcement.title} - ${announcement.message}. `;
+    const missionRecord = toRecord<NonNullable<Awaited<ReturnType<typeof missionStatement>>>>(mission);
+    if (missionRecord) {
+      const ms: Record<string, unknown> = {};
+      if (missionRecord.headline) ms.h = missionRecord.headline;
+      if (missionRecord.tagline) ms.tg = missionRecord.tagline;
+      if (missionRecord.message) ms.msg = missionRecord.message;
+      if (Object.keys(ms).length) context.ms = ms;
     }
-    if (mission) {
-      context += `Mission statement: ${mission.headline}. ${mission.message || ''} `;
+    const staffList = toArray(staff).map((s: any) => {
+      if (!s || typeof s !== 'object') return null;
+      const entry: Record<string, string> = {};
+      if (typeof s.name === 'string' && s.name) entry.n = s.name;
+      if (typeof s.role === 'string' && s.role) entry.r = s.role;
+      return Object.keys(entry).length ? entry : null;
+    }).filter(Boolean) as Record<string, string>[];
+    if (staffList.length) {
+      context.sf = staffList;
     }
-    if (staff.length) {
-      context += 'Staff: ' + staff.map((s) => `${s.name} (${s.role})`).join('; ') + '. ';
+    const ministriesList = toArray(ministries).map((m: any) => {
+      if (!m || typeof m !== 'object') return null;
+      const entry: Record<string, string> = {};
+      if (typeof m.name === 'string' && m.name) entry.n = m.name;
+      if (typeof m.description === 'string' && m.description) entry.d = m.description;
+      return Object.keys(entry).length ? entry : null;
+    }).filter(Boolean) as Record<string, string>[];
+    if (ministriesList.length) {
+      context.mn = ministriesList;
     }
-    if (ministries.length) {
-      context +=
-        'Ministries: ' + ministries.map((m) => `${m.name} - ${m.description}`).join('; ') + '. ';
+    const givingList = toArray(sources.givingOptions).map((g: any) => {
+      if (!g || typeof g !== 'object') return null;
+      const entry: Record<string, string> = {};
+      if (typeof g.title === 'string' && g.title) entry.t = g.title;
+      if (typeof g.content === 'string' && g.content) entry.c = g.content;
+      if (typeof g.href === 'string' && g.href) entry.u = g.href;
+      return Object.keys(entry).length ? entry : null;
+    }).filter(Boolean) as Record<string, string>[];
+    if (givingList.length) {
+      context.gv = givingList;
     }
-    if (givingOptions.length) {
-      context +=
-        'Giving options: ' +
-        givingOptions
-          .map((g) => `${g.title} ${g.content}${g.href ? ' ' + g.href : ''}`)
-          .join('; ') +
-        '. ';
-    }
-    if (livestream) {
-      let status: string;
-      if (livestream.live?.status === 'streaming') {
-        status = 'live now';
-      } else if (livestream.live?.scheduled_time) {
-        status = `scheduled for ${dateFmt.format(new Date(livestream.live.scheduled_time))}`;
+    const livestreamRecord = toRecord<NonNullable<Awaited<ReturnType<typeof getCurrentLivestream>>>>(livestream);
+    if (livestreamRecord) {
+      const ls: Record<string, unknown> = {};
+      if (livestreamRecord.name) ls.n = livestreamRecord.name;
+      if (livestreamRecord.link) ls.u = livestreamRecord.link;
+      const liveStatus = livestreamRecord.live?.status;
+      if (liveStatus === 'streaming') {
+        ls.st = 'live';
+      } else if (livestreamRecord.live?.scheduled_time) {
+        ls.st = 'scheduled';
+        ls.sch = dateFmt.format(new Date(livestreamRecord.live.scheduled_time));
       } else {
-        status = 'offline';
+        ls.st = 'offline';
       }
-      context += `Livestream: ${livestream.name} ${status}. `;
+      if (Object.keys(ls).length) context.ls = ls;
     }
-    if (events.length) {
-      const evFmt = new Intl.DateTimeFormat('en-US', { timeZone: tz, dateStyle: 'medium' });
-      context +=
-        'Upcoming events: ' +
-        events
-          .map((e) => `${e.title} on ${evFmt.format(new Date(e.start))}${e.location ? ' at ' + e.location : ''}`)
-          .join('; ') +
-        '. ';
+    const eventsList = toArray(events).map((e: any) => {
+      if (!e || typeof e !== 'object') return null;
+      const entry: Record<string, string> = {};
+      if (typeof e.title === 'string' && e.title) entry.t = e.title;
+      if (typeof e.start === 'string' && e.start) {
+        entry.dt = evFmt.format(new Date(e.start));
+      }
+      const location = (e.location || e.loc || '') as string;
+      if (typeof location === 'string' && location) entry.loc = location;
+      const url = (e.href || e.htmlLink || '') as string;
+      if (typeof url === 'string' && url) entry.u = url;
+      return Object.keys(entry).length ? entry : null;
+    }).filter(Boolean) as Record<string, string>[];
+    if (eventsList.length) {
+      context.ev = eventsList;
     }
     if (sitemap) {
-      context += `Navigation (site map paths): ${sitemap}. `;
+      const nav = sitemap
+        .split('; ')
+        .map((p) => p.trim())
+        .filter(Boolean);
+      if (nav.length) context.nav = nav;
     }
-    return context.trim();
+    return JSON.stringify(context);
   } catch {
     return '';
   }
@@ -224,10 +306,11 @@ export async function generateChatbotReply(
   escalateReason: string;
 }> {
   const openai = getClient(client);
-  const [context, extra] = await Promise.all([
+  const [contextJson, extra] = await Promise.all([
     buildSiteContext(),
     getChatbotExtraContext(),
   ]);
+  const compactContext = contextJson || '{}';
   const tz = process.env.TZ || 'UTC';
   const dateStr = new Intl.DateTimeFormat('en-US', {
     timeZone: tz,
@@ -248,14 +331,24 @@ export async function generateChatbotReply(
           'If a question is unrelated to the site, respond that you can only assist with website information. ' +
           'If the question is about the church or website but the answer is not present in the site content, say you are sorry and unsure, set confidence to 0, and suggest reaching out for further help. ' +
           'When it would genuinely help the visitor accomplish their goal, suggest one or two specific relevant pages on this site and include their path(s) starting with "/". Do not add links unless they clearly improve the answer. ' +
-          'Use the paths listed in the "Navigation (site map paths)" section exactly as provided when referencing internal pages; do not guess paths, including for nested pages such as About and Contact. ' +
           'Only provide external links that already appear in the site content and include the full URL. ' +
           'If the user requests to speak to a person or otherwise asks for escalation, set "escalate" to true and provide the trigger in "escalateReason". Avoid copy-paste escalation text; any escalation notice should reference the user\'s situation and kindly explain that providing their contact information is necessary for staff to reach out. ' +
           'Write "escalateReason" as if you are speaking to a staff member: a concise internal note that clearly explains why this conversation was escalated, referencing the visitor\'s context. Do not address the visitor directly in this field. ' +
           'Count how many times so far the user has asked this same or a very similar question, including the current attempt. Do not increase the count for new or different questions. Include this number as "similarityCount". Allow a visitor to repeat a question only twice; on the third time, set "escalate" to true with a friendly "escalateReason" indicating the question has been asked multiple times and a team member can follow up if they share contact details. ' +
           `The current date is ${dateStr}. ` +
-          `Site content:\n${context}\n` +
+          'Site content is provided as compact JSON. Parse it before answering. Short key legend: ' +
+          'st=site settings {t:title, addr:address, svc:service times, email, phone, sl:[{l:label, u:url}]}; ' +
+          'ann=latest announcement {t:title, msg:message, cta:{l:label, u:url}}; ' +
+          'ms=mission statement {h:headline, msg:message, tg:tagline}; ' +
+          'sf=staff array [{n:name, r:role}]; ' +
+          'mn=ministries array [{n:name, d:description}]; ' +
+          'gv=giving options array [{t:title, c:content, u:url}]; ' +
+          'ls=livestream {n:name, st:status, sch:scheduled time, u:url}; ' +
+          'ev=upcoming events array [{t:title, dt:date/time, loc:location, u:url}]; ' +
+          'nav=site paths array. ' +
+          `Site content JSON: ${compactContext}. ` +
           'Calibrate "confidence" strictly between 0 and 1, where 1 means the answer is clearly supported by the provided site content and 0 means the information is missing or uncertain; decrease confidence proportionally when context is weak or ambiguous, and never invent facts beyond the provided content. ' +
+          'Use the paths in the "nav" array exactly as provided when referencing internal pages; do not guess paths, including for nested pages such as About and Contact. ' +
           'Respond in JSON with keys "reply", "confidence", "similarityCount" (number), "escalate" (boolean), and "escalateReason" (string).',
       },
       ...messages.map(({ role, content }) => ({ role, content } as any)),


### PR DESCRIPTION
## Summary
- refactor `buildSiteContext` to assemble compact JSON data with abbreviated keys and arrays
- adjust the chatbot system prompt to describe the structured context and updated navigation instructions
- expand chatbot tests to verify the structured context contents and confirm the prompt includes the JSON reference

## Testing
- npx ts-node lib/chatbot.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9ae95b6c4832ca2682e78b4462c16