### PR TITLE
Connect contact form to submit API

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,7 +1,10 @@
 import ContactForm from "@/components/ContactForm";
+import { contactFormSettings } from "@/lib/queries";
 
 export const metadata = { title: "Contact" };
-export default function Page() {
+export default async function Page() {
+  const formSettings = await contactFormSettings();
+
   return (
     <div>
       <div className="text-center">
@@ -10,7 +13,7 @@ export default function Page() {
           Get in touch with us using the contact form below.
         </p>
       </div>
-      <ContactForm />
+      <ContactForm formSlug={formSettings?.slug} formId={formSettings?._id} />
     </div>
   );
 }

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,19 +1,108 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ChangeEvent, type FormEvent } from "react";
 
-export default function ContactForm() {
-  const [submitted, setSubmitted] = useState(false);
+type FormValues = {
+  name: string;
+  email: string;
+  message: string;
+};
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setSubmitted(true);
+type SubmissionStatus = "idle" | "loading" | "success" | "error";
+
+interface ContactFormProps {
+  formSlug?: string;
+  formId?: string;
+}
+
+const initialValues: FormValues = {
+  name: "",
+  email: "",
+  message: "",
+};
+
+export default function ContactForm({ formSlug, formId }: ContactFormProps) {
+  const [values, setValues] = useState<FormValues>(initialValues);
+  const [status, setStatus] = useState<SubmissionStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleChange = (
+    field: keyof FormValues
+  ) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { value } = event.target;
+    setValues((prev) => ({ ...prev, [field]: value }));
+
+    if (status === "error") {
+      setStatus("idle");
+      setErrorMessage(null);
+    }
   };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (status === "loading") {
+      return;
+    }
+
+    if (!formSlug && !formId) {
+      setErrorMessage("Form configuration is missing. Please try again later.");
+      setStatus("error");
+      return;
+    }
+
+    setStatus("loading");
+    setErrorMessage(null);
+
+    try {
+      const payload: Record<string, string> = {
+        name: values.name,
+        email: values.email,
+        message: values.message,
+      };
+
+      if (formSlug) {
+        payload.slug = formSlug;
+      } else if (formId) {
+        payload.id = formId;
+      }
+
+      const response = await fetch("/api/submit-form", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await response.json().catch(() => null);
+
+      if (!response.ok || !data?.success) {
+        const message =
+          data && typeof data.error === "string"
+            ? data.error
+            : "There was a problem sending your message. Please try again.";
+        setErrorMessage(message);
+        setStatus("error");
+        return;
+      }
+
+      setValues(initialValues);
+      setStatus("success");
+    } catch (error) {
+      setErrorMessage(
+        "There was a problem sending your message. Please try again."
+      );
+      setStatus("error");
+    }
+  };
+
+  const isLoading = status === "loading";
 
   return (
     <div className="mt-8 max-w-md mx-auto">
-      {submitted ? (
-        <p className="text-center animate-fade-in-up">
+      {status === "success" ? (
+        <p className="text-center animate-fade-in-up" role="status">
           Thanks for reaching out! We&apos;ll get back to you soon.
         </p>
       ) : (
@@ -27,6 +116,8 @@ export default function ContactForm() {
               type="text"
               required
               placeholder="Your name"
+              value={values.name}
+              onChange={handleChange("name")}
               className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-5 pb-3 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
             />
             <label
@@ -42,6 +133,8 @@ export default function ContactForm() {
               type="email"
               required
               placeholder="Your email"
+              value={values.email}
+              onChange={handleChange("email")}
               className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-5 pb-3 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
             />
             <label
@@ -57,6 +150,8 @@ export default function ContactForm() {
               required
               rows={4}
               placeholder="Your message"
+              value={values.message}
+              onChange={handleChange("message")}
               className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-6 pb-4 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
             />
             <label
@@ -66,11 +161,20 @@ export default function ContactForm() {
               Message
             </label>
           </div>
+          {status === "error" && errorMessage ? (
+            <p
+              className="text-sm text-center text-[var(--brand-accent)]"
+              role="alert"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
           <button
             type="submit"
-            className="btn-outline-cta pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md hover:shadow-lg transform transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)]"
+            disabled={isLoading}
+            className="btn-outline-cta pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md hover:shadow-lg transform transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            <span>Send Message</span>
+            <span>{isLoading ? "Sending..." : "Send Message"}</span>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -71,6 +71,19 @@ export const siteSettings = () =>
     groq`*[_id == "siteSettings"][0]{_id, title, email, phone, address, serviceTimes, "logo": logo.asset->url, "socialLinks": socialLinks[]{label, href, description, icon}}`
   );
 
+export interface FormSettings {
+  _id: string;
+  slug?: string;
+}
+
+export const contactFormSettings = () =>
+  sanity.fetch<FormSettings | null>(
+    groq`*[_type == "formSettings" && page->slug.current == "contact"][0]{
+      _id,
+      "slug": slug.current
+    }`
+  );
+
 export interface Ministry {
   _id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add a Sanity query helper to read the contact form settings document with slug and id
- load the contact form settings in the contact page server component and pass the identifier to the form
- update the contact form to manage field state, submit to `/api/submit-form`, and surface loading/success/error feedback

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f1c36264832ca5e1bfc21e48de8c