### PR TITLE
Add impersonation email config and enhance form emails

### DIFF
--- a/app/api/submit-form/route.ts
+++ b/app/api/submit-form/route.ts
@@ -2,7 +2,37 @@ export const runtime = "nodejs";
 
 import { NextResponse } from 'next/server';
 import { sanity } from '@/lib/sanity';
-import { sendEmail } from '@/lib/gmail';
+import { getImpersonationAddress, sendEmail } from '@/lib/gmail';
+
+const headerSanitizer = /[\r\n]+/g;
+
+const sanitizeHeader = (value: unknown) => String(value ?? '').replace(headerSanitizer, ' ').trim();
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const safeEmail = (value: unknown): string | null => {
+  const sanitized = sanitizeHeader(value);
+  return emailRegex.test(sanitized) ? sanitized : null;
+};
+
+const formatLabel = (key: string) => {
+  const normalized = key.replace(/[_-]/g, ' ').replace(/([a-z])([A-Z])/g, '$1 $2');
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => formatValue(item)).filter((item) => item).join(', ');
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
 
 export async function POST(req: Request) {
   try {
@@ -15,25 +45,95 @@ export async function POST(req: Request) {
 
     const params = slug ? { slug } : { id };
     const query = slug
-      ? `*[_type == "formSettings" && slug.current == $slug][0]{ targetEmail }`
-      : `*[_type == "formSettings" && _id == $id][0]{ targetEmail }`;
+      ? `*[_type == "formSettings" && slug.current == $slug][0]{ targetEmail, title }`
+      : `*[_type == "formSettings" && _id == $id][0]{ targetEmail, title }`;
 
-    const result = await sanity.fetch<{ targetEmail?: string }>(query, params);
-    const targetEmail = result?.targetEmail;
+    const result = await sanity.fetch<{ targetEmail?: string; title?: string }>(query, params);
+    const targetEmail = sanitizeHeader(result?.targetEmail);
+    const title = sanitizeHeader(result?.title);
 
     if (!targetEmail) {
       return NextResponse.json({ error: 'Form settings not found' }, { status: 404 });
     }
 
-    const replyTo = typeof formData.email === 'string' ? formData.email : undefined;
-    const from = process.env.FORM_FROM_EMAIL || targetEmail;
-    await sendEmail({
-      from,
-      to: targetEmail,
-      subject: `New form submission from ${slug || id}`,
-      text: JSON.stringify(formData, null, 2),
-      replyTo,
+    const impersonationAddress = getImpersonationAddress();
+    const replyTo = safeEmail(formData.email);
+    const submittedAt = new Date();
+    const tz = process.env.TZ || 'UTC';
+    const timestampFormatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      dateStyle: 'medium',
+      timeStyle: 'short',
     });
+    const submittedAtText = timestampFormatter.format(submittedAt);
+
+    const entryLines = Object.entries(formData)
+      .map(([key, value]) => {
+        const formatted = formatValue(value);
+        if (!formatted) return null;
+        return `${formatLabel(key)}: ${formatted}`;
+      })
+      .filter((line): line is string => Boolean(line));
+
+    const subjectTitle = sanitizeHeader(
+      title || (typeof slug === 'string' ? slug : typeof id === 'string' ? id : 'form'),
+    );
+    const submitterName = sanitizeHeader(formData.name || replyTo || 'Visitor');
+    const staffSubject = sanitizeHeader(`New ${subjectTitle} submission from ${submitterName}`);
+
+    const staffLines: string[] = [
+      `Form: ${subjectTitle}`,
+      `Submitted At: ${submittedAtText}`,
+    ];
+    if (slug) {
+      staffLines.push(`Form Slug: ${sanitizeHeader(slug)}`);
+    } else if (id) {
+      staffLines.push(`Form ID: ${sanitizeHeader(id)}`);
+    }
+    if (entryLines.length) {
+      staffLines.push('');
+      staffLines.push(...entryLines);
+    }
+    const staffBody = staffLines.join('\n');
+
+    await sendEmail({
+      from: impersonationAddress,
+      to: targetEmail,
+      subject: staffSubject,
+      text: staffBody,
+      replyTo: replyTo || undefined,
+    });
+
+    if (replyTo) {
+      const ackName = sanitizeHeader(formData.name || 'there');
+      const ackSubject = sanitizeHeader(`We received your ${subjectTitle} submission`);
+      const ackLines: string[] = [
+        `Hi ${ackName},`,
+        '',
+        `Thanks for reaching out! We've received your ${subjectTitle} submission on ${submittedAtText}.`,
+      ];
+      if (entryLines.length) {
+        ackLines.push('');
+        ackLines.push('Here is a copy of what you sent:');
+        ackLines.push('');
+        ackLines.push(...entryLines);
+      }
+      ackLines.push('');
+      ackLines.push('We will get back to you soon.');
+      const ackBody = ackLines.join('\n');
+
+      try {
+        await sendEmail({
+          from: impersonationAddress,
+          to: replyTo,
+          subject: ackSubject,
+          text: ackBody,
+          replyTo: targetEmail,
+        });
+      } catch (copyError) {
+        console.warn('Failed to send confirmation copy to submitter', copyError);
+      }
+    }
 
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/app/api/submit-form/route.ts
+++ b/app/api/submit-form/route.ts
@@ -10,6 +10,14 @@ const sanitizeHeader = (value: unknown) => String(value ?? '').replace(headerSan
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 const safeEmail = (value: unknown): string | null => {
   const sanitized = sanitizeHeader(value);
   return emailRegex.test(sanitized) ? sanitized : null;
@@ -74,6 +82,10 @@ export async function POST(req: Request) {
         return `${formatLabel(key)}: ${formatted}`;
       })
       .filter((line): line is string => Boolean(line));
+    const entryBlockText = entryLines.join('\n');
+    const entryBlockHtml = entryLines.length
+      ? `<pre style="font-family:'Courier New',monospace;background-color:rgb(238,238,238);padding:8px;">${escapeHtml(entryBlockText)}</pre>`
+      : '';
 
     const subjectTitle = sanitizeHeader(
       title || (typeof slug === 'string' ? slug : typeof id === 'string' ? id : 'form'),
@@ -122,12 +134,28 @@ export async function POST(req: Request) {
       ackLines.push('We will get back to you soon.');
       const ackBody = ackLines.join('\n');
 
+      const ackHtmlParts: string[] = [
+        `<p style="margin:0 0 16px 0;">Hi ${escapeHtml(ackName)},</p>`,
+        `<p style="margin:0 0 16px 0;">Thanks for reaching out! We've received your ${escapeHtml(
+          subjectTitle,
+        )} submission on ${escapeHtml(submittedAtText)}.</p>`,
+      ];
+      if (entryBlockHtml) {
+        ackHtmlParts.push('<p style="margin:0 0 12px 0;">Here is a copy of what you sent:</p>');
+        ackHtmlParts.push(entryBlockHtml);
+      }
+      ackHtmlParts.push('<p style="margin:16px 0 0 0;">We will get back to you soon.</p>');
+      const ackHtmlContainerStart =
+        `<div style="font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:14px;">`;
+      const ackHtml = `${ackHtmlContainerStart}${ackHtmlParts.join('')}</div>`;
+
       try {
         await sendEmail({
           from: impersonationAddress,
           to: replyTo,
           subject: ackSubject,
           text: ackBody,
+          html: ackHtml,
           replyTo: targetEmail,
         });
       } catch (copyError) {

--- a/app/api/submit-form/route.ts
+++ b/app/api/submit-form/route.ts
@@ -99,11 +99,11 @@ export async function POST(req: Request) {
     const normalizedId = typeof id === 'string' ? sanitizeHeader(id) : '';
 
     const staffLines: string[] = [
-      `Form: ${subjectTitle}`,
+      `Page: ${subjectTitle}`,
       `Submitted At: ${submittedAtText}`,
     ];
     if (normalizedSlug) {
-      staffLines.push(`Form Slug: ${normalizedSlug}`);
+      staffLines.push(`Form ID: ${normalizedSlug}`);
     } else if (normalizedId) {
       staffLines.push(`Form ID: ${normalizedId}`);
     }
@@ -114,12 +114,12 @@ export async function POST(req: Request) {
     const staffBody = staffLines.join('\n');
 
     const staffHtmlParts: string[] = [
-      `<p style="margin:0 0 12px 0;"><strong>Form:</strong> ${escapeHtml(subjectTitle)}</p>`,
+      `<p style="margin:0 0 12px 0;"><strong>Page:</strong> ${escapeHtml(subjectTitle)}</p>`,
       `<p style="margin:0 0 12px 0;"><strong>Submitted At:</strong> ${escapeHtml(submittedAtText)}</p>`,
     ];
     if (normalizedSlug) {
       staffHtmlParts.push(
-        `<p style="margin:0 0 12px 0;"><strong>Form Slug:</strong> ${escapeHtml(normalizedSlug)}</p>`,
+        `<p style="margin:0 0 12px 0;"><strong>Form ID:</strong> ${escapeHtml(normalizedSlug)}</p>`,
       );
     } else if (normalizedId) {
       staffHtmlParts.push(`<p style="margin:0 0 12px 0;"><strong>Form ID:</strong> ${escapeHtml(normalizedId)}</p>`);

--- a/app/contact/prayer-requests/page.tsx
+++ b/app/contact/prayer-requests/page.tsx
@@ -76,7 +76,7 @@ export default function Page() {
 
             <button
               type="submit"
-              className="btn-outline-cta pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md hover:shadow-lg transform transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)]"
+              className="btn-outline-cta pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md cursor-pointer hover:shadow-lg transform transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)]"
             >
               <span>Send Request</span>
               <svg

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -172,7 +172,7 @@ export default function ContactForm({ formSlug, formId }: ContactFormProps) {
           <button
             type="submit"
             disabled={isLoading}
-            className="btn-outline-cta pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md hover:shadow-lg transform transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
+            className="btn-outline-cta pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md cursor-pointer hover:shadow-lg transform transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
           >
             <span>{isLoading ? "Sending..." : "Send Message"}</span>
             <svg

--- a/lib/chatbot.ts
+++ b/lib/chatbot.ts
@@ -12,6 +12,7 @@ import { getUpcomingEvents } from './googleCalendar';
 import fs from 'fs';
 import path from 'path';
 import { givingOptions } from './giving';
+import { getImpersonationAddress } from './gmail';
 
 export async function getChatbotTone(): Promise<string> {
   const tone = await sanity.fetch(groq`*[_type == "chatbotSettings"][0].tone`);
@@ -33,15 +34,16 @@ export async function getChatbotExtraContext(): Promise<string> {
 }
 
 export async function getEscalationAddresses(): Promise<{ from: string; to: string }> {
-  const result = await sanity.fetch(groq`*[_type == "chatbotSettings"][0]{
-    "from": escalationFrom,
-    "to": escalationTo,
-  }`);
-  const from = result?.from?.trim();
+  const result = await sanity.fetch(
+    groq`*[_type == "chatbotSettings"][0]{
+      "to": escalationTo,
+    }`,
+  );
   const to = result?.to?.trim();
-  if (!from || !to) {
-    throw new Error('Chatbot escalation email settings are missing in Sanity (escalationFrom/escalationTo)');
+  if (!to) {
+    throw new Error('Chatbot escalation email settings are missing in Sanity (escalationTo)');
   }
+  const from = getImpersonationAddress();
   return { from, to };
 }
 
@@ -313,7 +315,7 @@ export async function sendEscalationEmail(
   reason: string,
 ) {
   // Require server-to-server auth via a Google Workspace Service Account with
-  // domain-wide delegation, impersonating a fixed sender account sourced from Sanity.
+  // domain-wide delegation, impersonating a fixed sender account from configuration.
   // Allow disabling email sending only via an explicit flag.
   const emailsDisabled = String(process.env.DISABLE_ESCALATION_EMAILS || '').toLowerCase() === 'true';
 
@@ -410,18 +412,24 @@ export async function sendEscalationEmail(
   }
   dlog('Credential source in use:', credsSource);
 
-  // Get sender and recipient from Sanity
+  // Get impersonated sender from config and recipient from Sanity
   const { from, to } = await getEscalationAddresses();
-  dlog('Fetched escalation addresses from Sanity', { from: maskEmail(from), to: maskEmail(to) });
-  // Sanity check parsed mailbox portions (handles "Name <email@...>")
   const parsedFrom = extractAngleEmail(from);
   const parsedTo = extractAngleEmail(to);
-  dlog('Escalation address parsing', {
+  dlog('Fetched escalation addresses from configuration', {
+    fromHeader: maskEmail(from),
     fromParsed: maskEmail(parsedFrom),
     toParsed: maskEmail(parsedTo),
+  });
+  dlog('Escalation address validation', {
     fromValid: isValidEmail(parsedFrom),
     toValid: isValidEmail(parsedTo),
   });
+  if (!isValidEmail(parsedFrom) || !isValidEmail(parsedTo)) {
+    throw new Error(
+      'Escalation email configuration is invalid. Verify EMAIL_IMPERSONATION_ADDRESS and the escalationTo field in Sanity.',
+    );
+  }
 
   // If emails are disabled by flag, skip sending.
   if (emailsDisabled) {
@@ -444,9 +452,9 @@ export async function sendEscalationEmail(
     email: svcEmail,
     key: svcKey,
     scopes: ['https://www.googleapis.com/auth/gmail.send','https://mail.google.com/'],
-    subject: from, // act as this user
+    subject: parsedFrom, // act as this user
   } as any);
-  dlog('Authorizing Gmail client as subject', maskEmail(from));
+  dlog('Authorizing Gmail client as subject', maskEmail(parsedFrom));
   await auth.authorize();
   dlog('Gmail authorization successful');
 

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -4,10 +4,36 @@ import { google } from 'googleapis';
 
 interface SendEmailOptions {
   to: string;
-  from: string;
+  from?: string;
   subject: string;
   text: string;
   replyTo?: string;
+}
+
+const headerSanitizer = /[\r\n]+/g;
+
+const sanitizeHeader = (value: string) => value.replace(headerSanitizer, ' ').trim();
+
+const extractAngleEmail = (value: string) => {
+  const match = value.match(/<([^>]+)>/);
+  return (match ? match[1] : value).trim();
+};
+
+export function getImpersonationAddress(): string {
+  const envValue = sanitizeHeader(String(process.env.EMAIL_IMPERSONATION_ADDRESS || ''));
+  if (envValue) {
+    return envValue;
+  }
+  const legacy = sanitizeHeader(String(process.env.FORM_FROM_EMAIL || ''));
+  if (legacy) {
+    console.warn(
+      '[Email] EMAIL_IMPERSONATION_ADDRESS is not set; falling back to legacy FORM_FROM_EMAIL. Please update your configuration.',
+    );
+    return legacy;
+  }
+  throw new Error(
+    'EMAIL_IMPERSONATION_ADDRESS is not set. Configure it with the Google Workspace user the service account should impersonate.',
+  );
 }
 
 function loadCredentials(): { svcEmail: string; svcKey: string } {
@@ -73,25 +99,33 @@ function loadCredentials(): { svcEmail: string; svcKey: string } {
 export async function sendEmail({ to, from, subject, text, replyTo }: SendEmailOptions) {
   const { svcEmail, svcKey } = loadCredentials();
 
+  const fromHeader = sanitizeHeader(from || getImpersonationAddress());
+  const impersonationEmail = extractAngleEmail(fromHeader);
+  if (!impersonationEmail) {
+    throw new Error('Impersonation email is missing or invalid.');
+  }
+
+  const subjectHeader = sanitizeHeader(subject);
+
   const auth = new google.auth.JWT({
     email: svcEmail,
     key: svcKey,
     scopes: ['https://www.googleapis.com/auth/gmail.send', 'https://mail.google.com/'],
-    subject: from,
+    subject: impersonationEmail,
   } as any);
   await auth.authorize();
 
   const gmail = google.gmail({ version: 'v1', auth });
 
   const headers = [
-    `To: ${to}`,
-    `Subject: ${subject}`,
-    `From: ${from}`,
+    `To: ${sanitizeHeader(to)}`,
+    `Subject: ${subjectHeader}`,
+    `From: ${fromHeader}`,
     'MIME-Version: 1.0',
     'Content-Type: text/plain; charset="UTF-8"',
   ];
   if (replyTo) {
-    headers.push(`Reply-To: ${replyTo}`);
+    headers.push(`Reply-To: ${sanitizeHeader(replyTo)}`);
   }
   const message = headers.join('\r\n') + '\r\n\r\n' + text;
   const raw = Buffer.from(message)

--- a/sanity/schemas/chatbot.ts
+++ b/sanity/schemas/chatbot.ts
@@ -26,13 +26,6 @@ export default defineType({
         "Optional additional background/context the assistant should consider for every conversation (e.g., corrections, policies, irregular hours).",
     }),
     defineField({
-      name: "escalationFrom",
-      title: "Escalation From (sender email)",
-      type: "string",
-      validation: (Rule) => Rule.email().warning("Should be a valid email address"),
-      description: "The Google Workspace user the service account will impersonate when sending (e.g., support@yourdomain.com)",
-    }),
-    defineField({
       name: "escalationTo",
       title: "Escalation To (recipient email)",
       type: "string",


### PR DESCRIPTION
## Summary
- add an impersonation email helper and use it when impersonating the Gmail service account
- enhance the form submission API with better subjects/body formatting and confirmation emails to submitters
- remove the escalation sender field from Sanity and rely on the configured impersonation address

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9f6536a6c832cbca7009377b34c50