### PR TITLE
Fix event date patching in Sanity calendar input

### DIFF
--- a/sanity/components/CalendarEventIdInput.tsx
+++ b/sanity/components/CalendarEventIdInput.tsx
@@ -1,12 +1,48 @@
-import { useEffect, useState } from "react";
-import { PatchEvent, set, unset } from "sanity";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { PatchEvent, set, unset, useFormCallbacks, useFormValue } from "sanity";
 
 type CalendarEvent = { id: string; title: string; start: string };
 
 export default function CalendarEventIdInput(props: any) {
-  const { value, onChange } = props;
+  const { value, onChange, path } = props;
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [loading, setLoading] = useState(false);
+  const { onChange: onRootChange } = useFormCallbacks();
+
+  const parentPath = useMemo(() => {
+    if (!Array.isArray(path)) return [];
+    return path.slice(0, -1);
+  }, [path]);
+
+  const eventDatePath = useMemo(
+    () => [...parentPath, "eventDate"],
+    [parentPath]
+  );
+
+  const eventDateValue = useFormValue(eventDatePath) as string | undefined;
+
+  const updateEventDate = useCallback(
+    (isoDate?: string) => {
+      if (!onRootChange) return;
+      const currentValue =
+        typeof eventDateValue === "string" && eventDateValue.length > 0
+          ? eventDateValue
+          : undefined;
+      const nextValue = isoDate && isoDate.length > 0 ? isoDate : undefined;
+      if (currentValue === nextValue) return;
+
+      let patch = PatchEvent.from([nextValue ? set(nextValue) : unset()]).prefixAll(
+        "eventDate"
+      );
+
+      for (let i = parentPath.length - 1; i >= 0; i -= 1) {
+        patch = patch.prefixAll(parentPath[i]);
+      }
+
+      onRootChange(patch);
+    },
+    [eventDateValue, onRootChange, parentPath]
+  );
 
   async function load() {
     setLoading(true);
@@ -30,13 +66,22 @@ export default function CalendarEventIdInput(props: any) {
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const v = e.target.value;
     const selected = events.find((ev) => ev.id === v);
-    onChange(
-      PatchEvent.from([
-        v ? set(v) : unset(),
-        selected ? set(selected.start, ["eventDate"]) : unset(["eventDate"]),
-      ])
-    );
+    onChange(PatchEvent.from([v ? set(v) : unset()]));
+    updateEventDate(selected?.start);
   }
+
+  useEffect(() => {
+    if (!value) {
+      if (eventDateValue) {
+        updateEventDate(undefined);
+      }
+      return;
+    }
+    const selected = events.find((ev) => ev.id === value);
+    if (selected) {
+      updateEventDate(selected.start);
+    }
+  }, [value, events, updateEventDate, eventDateValue]);
 
   return (
     <select value={value || ""} onChange={handleChange} onFocus={load}>


### PR DESCRIPTION
## Summary
- update the custom Sanity calendar input to patch the sibling `eventDate` field through the root form callbacks
- sync the read-only event date when the selected calendar event changes or is cleared

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccd3279c98832c9d773bb94dd24214