### PR TITLE
Improve dark mode link contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -54,15 +54,7 @@ body::before {
 }
 
 a {
-  color: var(--brand-link);
-  text-decoration-color: color-mix(in oklab, var(--brand-link) 70%, transparent);
-  @apply underline transition-colors;
-}
-
-a:hover,
-a:focus-visible {
-  color: var(--brand-link-hover);
-  text-decoration-color: var(--brand-link-hover);
+  @apply underline;
 }
 
 /* Header: do not underline links by default; keep hover underline for affordance */
@@ -100,8 +92,6 @@ img {
   --brand-surface-contrast: #FFFFFF; /* white for headings on surface */
   --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
   --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
-  --brand-link: var(--brand-accent);
-  --brand-link-hover: color-mix(in oklab, var(--brand-accent) 80%, var(--brand-alt) 20%);
 
   /* Layout and component variables (defaults) */
   --layout-max-width: 90vw;
@@ -127,8 +117,6 @@ img {
     --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
     --brand-border: var(--brand-accent);
     --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 60%, transparent);
-    --brand-link: color-mix(in oklab, var(--brand-primary-contrast) 65%, var(--brand-accent) 35%);
-    --brand-link-hover: color-mix(in oklab, var(--brand-primary-contrast) 80%, var(--brand-accent) 20%);
   }
 }
 
@@ -141,8 +129,6 @@ html[data-theme="dark"] {
   --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
   --brand-border: var(--brand-accent);
   --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 60%, transparent);
-  --brand-link: color-mix(in oklab, var(--brand-primary-contrast) 65%, var(--brand-accent) 35%);
-  --brand-link-hover: color-mix(in oklab, var(--brand-primary-contrast) 80%, var(--brand-accent) 20%);
 }
 
 
@@ -162,8 +148,6 @@ html {
   --brand-surface-contrast: #FFFFFF; /* white */
   --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
   --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
-  --brand-link: var(--brand-accent);
-  --brand-link-hover: color-mix(in oklab, var(--brand-accent) 80%, var(--brand-alt) 20%);
 
   /* Font variable fallbacks (overridden by next/font classes on <html>) */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/app/globals.css
+++ b/app/globals.css
@@ -54,7 +54,15 @@ body::before {
 }
 
 a {
-  @apply underline;
+  color: var(--brand-link);
+  text-decoration-color: color-mix(in oklab, var(--brand-link) 70%, transparent);
+  @apply underline transition-colors;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--brand-link-hover);
+  text-decoration-color: var(--brand-link-hover);
 }
 
 /* Header: do not underline links by default; keep hover underline for affordance */
@@ -92,6 +100,8 @@ img {
   --brand-surface-contrast: #FFFFFF; /* white for headings on surface */
   --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
   --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
+  --brand-link: var(--brand-accent);
+  --brand-link-hover: color-mix(in oklab, var(--brand-accent) 80%, var(--brand-alt) 20%);
 
   /* Layout and component variables (defaults) */
   --layout-max-width: 90vw;
@@ -117,6 +127,8 @@ img {
     --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
     --brand-border: var(--brand-accent);
     --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 60%, transparent);
+    --brand-link: color-mix(in oklab, var(--brand-primary-contrast) 65%, var(--brand-accent) 35%);
+    --brand-link-hover: color-mix(in oklab, var(--brand-primary-contrast) 80%, var(--brand-accent) 20%);
   }
 }
 
@@ -129,6 +141,8 @@ html[data-theme="dark"] {
   --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
   --brand-border: var(--brand-accent);
   --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 60%, transparent);
+  --brand-link: color-mix(in oklab, var(--brand-primary-contrast) 65%, var(--brand-accent) 35%);
+  --brand-link-hover: color-mix(in oklab, var(--brand-primary-contrast) 80%, var(--brand-accent) 20%);
 }
 
 
@@ -148,6 +162,8 @@ html {
   --brand-surface-contrast: #FFFFFF; /* white */
   --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
   --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
+  --brand-link: var(--brand-accent);
+  --brand-link-hover: color-mix(in oklab, var(--brand-accent) 80%, var(--brand-alt) 20%);
 
   /* Font variable fallbacks (overridden by next/font classes on <html>) */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -56,7 +56,7 @@ export default function Assistant() {
     );
     const parts = text.split(regex).filter(Boolean);
     const accentLinkClass =
-      'underline text-[var(--brand-accent)] hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-accent)]';
+      'underline text-[#f4f4f5] decoration-[#f4f4f5] hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f4f4f5]';
     return parts.map((part, idx) => {
       if (/^https?:\/\//.test(part)) {
         let label = part.replace(/^https?:\/\//, '');
@@ -290,7 +290,7 @@ export default function Assistant() {
                       <div className="mt-1 text-sm">
                         <button
                           type="button"
-                          className="underline hover:opacity-80 focus:outline-none focus:ring-1 cursor-pointer bg-transparent p-0 font-normal text-[var(--brand-accent)] focus:ring-[var(--brand-accent)] dark:text-[var(--brand-primary-contrast)] dark:focus:ring-[var(--brand-primary-contrast)]"
+                          className="underline text-[#f4f4f5] decoration-[#f4f4f5] hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-[#f4f4f5] cursor-pointer bg-transparent p-0 font-normal"
                           onClick={() => {
                             const pct = Math.max(
                               0,

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {FormEvent, useCallback, useEffect, useRef, useState, type CSSProperties} from 'react';
+import {FormEvent, useCallback, useEffect, useRef, useState, type CSSProperties, type ReactNode} from 'react';
 import type {ChatMessage} from '@/types/chat';
 import Link from 'next/link';
 
@@ -44,7 +44,10 @@ export default function Assistant() {
     };
   }, []);
 
-  function renderContent(text: string) {
+  function renderContent(text: string, role: ChatMessage['role']): ReactNode {
+    if (role !== 'assistant') {
+      return text;
+    }
     const emailRegex = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
     const phoneRegex = /\+?\d[\d\s().-]{7,}\d/;
     const regex = new RegExp(
@@ -52,6 +55,8 @@ export default function Assistant() {
       'g',
     );
     const parts = text.split(regex).filter(Boolean);
+    const accentLinkClass =
+      'underline text-[var(--brand-accent)] hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-accent)]';
     return parts.map((part, idx) => {
       if (/^https?:\/\//.test(part)) {
         let label = part.replace(/^https?:\/\//, '');
@@ -62,7 +67,7 @@ export default function Assistant() {
             href={part}
             target="_blank"
             rel="noopener noreferrer"
-            className="underline hover:opacity-80 text-[var(--brand-accent)]"
+            className={accentLinkClass}
           >
             {label}
           </a>
@@ -73,7 +78,7 @@ export default function Assistant() {
           <Link
             key={idx}
             href={part}
-            className="underline hover:opacity-80 text-[var(--brand-accent)]"
+            className={accentLinkClass}
           >
             {part}
           </Link>
@@ -81,7 +86,7 @@ export default function Assistant() {
       }
       if (emailRegex.test(part)) {
         return (
-          <a key={idx} href={`mailto:${part}`} className="underline">
+          <a key={idx} href={`mailto:${part}`} className={accentLinkClass}>
             {part}
           </a>
         );
@@ -89,7 +94,7 @@ export default function Assistant() {
       if (phoneRegex.test(part)) {
         const tel = part.replace(/[^\d+]/g, '');
         return (
-          <a key={idx} href={`tel:${tel}`} className="underline">
+          <a key={idx} href={`tel:${tel}`} className={accentLinkClass}>
             {part}
           </a>
         );
@@ -280,7 +285,7 @@ export default function Assistant() {
                       borderColor: 'var(--brand-border)',
                     }}
                   >
-                    {renderContent(m.content)}
+                    {renderContent(m.content, m.role)}
                     {m.role === 'assistant' && m.softEscalate && !collectInfo && (
                       <div className="mt-1 text-sm">
                         <button


### PR DESCRIPTION
## Summary
- update global anchor styles to use dedicated link tokens with smoother hover/focus feedback
- define brand link color variables for light and dark themes, brightening dark mode links for readability

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cdfd731acc832c90d9f76562f49902