### PR TITLE
feat: load giving options from site settings

### DIFF
--- a/app/giving/page.tsx
+++ b/app/giving/page.tsx
@@ -1,6 +1,6 @@
 import type { SVGProps } from "react";
 import type { GivingOption } from "@/lib/giving";
-import { givingOptions } from "@/lib/giving";
+import { getGivingOptions } from "@/lib/giving";
 
 export const metadata = { title: "Giving" };
 
@@ -92,11 +92,6 @@ const iconMap: Record<string, (props: SVGProps<SVGSVGElement>) => JSX.Element> =
   Razmobile: LinkIcon,
 };
 
-const options: Option[] = givingOptions.map((opt) => ({
-  ...opt,
-  icon: iconMap[opt.title] ?? LinkIcon,
-}));
-
 function OptionCard({ option, delay }: { option: Option; delay: string }) {
   const Icon = option.icon;
   return (
@@ -126,7 +121,12 @@ function OptionCard({ option, delay }: { option: Option; delay: string }) {
   );
 }
 
-export default function Page() {
+export default async function Page() {
+  const givingOptions = await getGivingOptions();
+  const options: Option[] = givingOptions.map((opt) => ({
+    ...opt,
+    icon: iconMap[opt.title] ?? LinkIcon,
+  }));
   return (
     <div className="w-full space-y-8">
       <div className="space-y-2">

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -106,7 +106,7 @@ export default function Assistant() {
         const trailing = trimmed.slice(email.length);
         return (
           <span key={idx}>
-            <a href={`mailto:${email}`} {accentLinkClass} break-words>
+            <a href={`mailto:${email}`} className={accentLinkClass} break-words>
               {email}
             </a>
             {trailing}

--- a/lib/chatbot.test.ts
+++ b/lib/chatbot.test.ts
@@ -82,6 +82,9 @@ async function testBuildSiteContext() {
         email: 'info@example.com',
         phone: '123-456-7890',
         socialLinks: [{ label: 'Facebook', href: 'https://fb.com/test' }],
+        givingOptions: [
+          { title: 'Online', content: 'Give', href: 'https://give.example.com' },
+        ],
       }) as any,
     announcementLatest: async () =>
       ({
@@ -104,9 +107,6 @@ async function testBuildSiteContext() {
       ([
         { name: 'Youth', description: 'Teens' },
       ] as any),
-    givingOptions: [
-      { title: 'Online', content: 'Give', href: 'https://give.example.com' },
-    ],
     getCurrentLivestream: async () =>
       ({
         name: 'Sunday Service',

--- a/lib/giving.ts
+++ b/lib/giving.ts
@@ -1,26 +1,38 @@
-export type GivingOption = {
-  title: string;
-  content: string;
-  href?: string;
-};
+import { siteSettings } from './queries';
+import type { GivingOption } from './queries';
 
-export const givingOptions: GivingOption[] = [
-  {
-    title: 'Mailing Address',
-    content: '864 Splitlog Ave., Kansas City, KS 66101',
-  },
-  {
-    title: 'Cash App',
-    content: '$GPTKCK',
-  },
-  {
-    title: 'Givelify',
-    content: 'Greater Pentecostal Temple Church',
-    href: 'https://www.givelify.com/donate/MTUxODY4MQ==/selection',
-  },
-  {
-    title: 'Razmobile',
-    content: 'Give securely online',
-    href: 'https://www.razmobile.com/GPTChurch',
-  },
-];
+export type { GivingOption } from './queries';
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export async function getGivingOptions(): Promise<GivingOption[]> {
+  try {
+    const settings = await siteSettings();
+    const options = settings?.givingOptions;
+    if (!Array.isArray(options)) {
+      return [];
+    }
+
+    return options
+      .map((option) => {
+        const title = isString(option?.title) ? option.title.trim() : '';
+        const content = isString(option?.content) ? option.content.trim() : '';
+        const href = isString(option?.href) ? option.href.trim() : undefined;
+
+        if (!title || !content) {
+          return null;
+        }
+
+        return {
+          title,
+          content,
+          href,
+        } satisfies GivingOption;
+      })
+      .filter((option): option is GivingOption => option !== null);
+  } catch {
+    return [];
+  }
+}

--- a/lib/giving.ts
+++ b/lib/giving.ts
@@ -29,7 +29,7 @@ export async function getGivingOptions(): Promise<GivingOption[]> {
           title,
           content,
           href,
-        } satisfies GivingOption;
+        } as GivingOption;
       })
       .filter((option): option is GivingOption => option !== null);
   } catch {

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -55,6 +55,12 @@ export interface SocialLink {
   icon: string;
 }
 
+export interface GivingOption {
+  title: string;
+  content: string;
+  href?: string;
+}
+
 export interface SiteSettings {
   _id: string;
   title: string;
@@ -64,11 +70,22 @@ export interface SiteSettings {
   phone?: string;
   logo?: string;
   socialLinks?: SocialLink[];
+  givingOptions?: GivingOption[];
 }
 
 export const siteSettings = () =>
   sanity.fetch<SiteSettings | null>(
-    groq`*[_id == "siteSettings"][0]{_id, title, email, phone, address, serviceTimes, "logo": logo.asset->url, "socialLinks": socialLinks[]{label, href, description, icon}}`
+    groq`*[_id == "siteSettings"][0]{
+      _id,
+      title,
+      email,
+      phone,
+      address,
+      serviceTimes,
+      "logo": logo.asset->url,
+      "socialLinks": socialLinks[]{label, href, description, icon},
+      "givingOptions": givingOptions[]{title, content, href}
+    }`
   );
 
 export interface FormSettings {

--- a/sanity/schemas/siteSettings.ts
+++ b/sanity/schemas/siteSettings.ts
@@ -75,5 +75,38 @@ export default defineType({
         },
       ],
     }),
+    defineField({
+      name: 'givingOptions',
+      title: 'Giving Options',
+      description: 'Giving methods surfaced in the chatbot and on the giving page.',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'givingOption',
+          fields: [
+            {
+              name: 'title',
+              title: 'Title',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: 'content',
+              title: 'Content',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+              description: 'Shown as the detail such as an address or username.',
+            },
+            {
+              name: 'href',
+              title: 'Link',
+              type: 'url',
+              validation: (Rule) => Rule.uri({ scheme: ['http', 'https'] }),
+            },
+          ],
+        },
+      ],
+    }),
   ],
 });


### PR DESCRIPTION
## Summary
- add giving options to the Sanity site settings schema and expose them in the site settings query
- replace the hard-coded giving options with a helper that reads from Sanity for both the giving page and chatbot context
- adjust chatbot tests to expect giving options from the site settings source

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdfd50a6c4832c99aba99f7664df66