### PR TITLE
Hide auto-generated page documents in Sanity

### DIFF
--- a/sanity/deskStructure.ts
+++ b/sanity/deskStructure.ts
@@ -7,7 +7,6 @@ export const structure = (S: any) =>
       S.documentTypeListItem('ministry').title('Ministries'),
       S.documentTypeListItem('heroSlide').title('Hero Slides'),
       S.documentTypeListItem('eventDetail').title('Event Details'),
-      S.documentTypeListItem('page').title('Pages'),
       S.listItem()
         .title('Site Settings')
         .child(

--- a/sanity/schemas/page.ts
+++ b/sanity/schemas/page.ts
@@ -4,6 +4,13 @@ export default defineType({
   name: 'page',
   title: 'Page',
   type: 'document',
+  hidden: true,
+  __experimental_actions: [] as (
+    | 'create'
+    | 'delete'
+    | 'publish'
+    | 'update'
+  )[],
   fields: [
     defineField({
       name: 'title',


### PR DESCRIPTION
## Summary
- remove the Pages document list from the custom desk structure
- mark the page document type as hidden and disable Studio actions so auto-generated entries cannot be edited manually

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce01a14e28832c91266aebe0eb559b