### PR TITLE
Improve calendar tool header and status styling

### DIFF
--- a/sanity/plugins/calendarSyncTool/index.tsx
+++ b/sanity/plugins/calendarSyncTool/index.tsx
@@ -922,6 +922,14 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       --calendar-selected-color: ${EVENT_SELECTION_COLOR};
       --calendar-selected-shadow: ${EVENT_SELECTION_TINT};
     }
+    .calendar-tool-calendarCard {
+      --calendar-header-fg-color: rgba(30, 41, 59, 0.92);
+      --calendar-header-text-shadow: 0 1px 1px rgba(255, 255, 255, 0.85);
+    }
+    [data-ui-color-scheme='dark'] .calendar-tool-calendarCard {
+      --calendar-header-fg-color: rgba(226, 232, 240, 0.96);
+      --calendar-header-text-shadow: 0 2px 10px rgba(15, 23, 42, 0.9);
+    }
     .calendar-tool-calendarCard .fc {
       --fc-page-bg-color: transparent;
       --fc-neutral-bg-color: transparent;
@@ -982,30 +990,26 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       border-bottom-color: rgba(148, 163, 184, 0.45);
       box-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.66);
     }
-    [data-ui-color-scheme='dark'] .calendar-tool-calendarCard .fc-col-header-cell-cushion {
-      color: rgba(241, 245, 249, 0.96);
-      text-shadow: 0 2px 10px rgba(15, 23, 42, 0.9);
-    }
     [data-ui-color-scheme='light'] .calendar-tool-calendarCard .fc-scrollgrid-section-header,
     [data-ui-color-scheme='light'] .calendar-tool-calendarCard thead.fc-col-header {
       background: linear-gradient(180deg, rgba(248, 250, 252, 0.95) 0%, rgba(226, 232, 240, 0.72) 100%);
       border-bottom-color: rgba(148, 163, 184, 0.45);
       box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.24);
     }
-    [data-ui-color-scheme='light'] .calendar-tool-calendarCard .fc-col-header-cell-cushion {
-      color: rgba(30, 41, 59, 0.92);
-      text-shadow: 0 1px 1px rgba(255, 255, 255, 0.85);
-    }
     .calendar-tool-calendarCard .fc-col-header-cell {
       border: none;
     }
-    .calendar-tool-calendarCard .fc-col-header-cell-cushion {
+    .calendar-tool-calendarCard .fc-col-header-cell-cushion,
+    .calendar-tool-calendarCard .fc-col-header-cell-cushion:link,
+    .calendar-tool-calendarCard .fc-col-header-cell-cushion:visited {
       font-size: 0.78rem;
       font-weight: 700;
       letter-spacing: 0.12em;
       text-transform: uppercase;
       padding: 0.75rem 0.4rem;
       transition: color 0.2s ease;
+      color: var(--calendar-header-fg-color);
+      text-shadow: var(--calendar-header-text-shadow);
     }
     .calendar-tool-calendarCard .fc-daygrid-day-number {
       font-weight: 600;
@@ -1019,12 +1023,17 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     }
     .calendar-tool-calendarCard .fc-daygrid-day-events {
       margin: 0.35rem 0.5rem 0.6rem 0.5rem;
-      display: flex;
-      flex-direction: column;
+      position: relative;
+      display: grid;
+      grid-auto-rows: minmax(0, auto);
+      align-content: start;
       gap: 0.55rem;
+      min-height: 0;
     }
     .calendar-tool-calendarCard .fc .fc-daygrid-event {
       margin: 0;
+      width: 100%;
+      min-width: 0;
     }
     .calendar-tool-calendarCard .fc-daygrid-day-frame {
       position: relative;
@@ -1055,13 +1064,19 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       flex-direction: column;
       gap: 0.45rem;
       box-sizing: border-box;
-      padding: 0.75rem 1rem 0.9rem 1.15rem;
-      border-radius: 16px;
+      padding: 0.75rem 1rem 0.9rem 1.1rem;
+      border-radius: 14px;
       border: 1px solid var(--calendar-event-outline, color-mix(in srgb, var(--card-border-color) 68%, transparent 32%));
+      border-inline-start: 5px solid var(
+        --calendar-event-accent,
+        color-mix(in srgb, var(--card-border-color) 68%, transparent 32%)
+      );
       background: var(--calendar-event-fill, color-mix(in srgb, var(--card-bg-color) 90%, transparent 10%));
       color: var(--calendar-event-ink, var(--card-fg-color));
       box-shadow: var(--calendar-event-shadow, ${DEFAULT_EVENT_SHADOW});
       cursor: pointer;
+      width: 100%;
+      min-width: 0;
       min-height: 0;
       overflow: hidden;
       isolation: isolate;
@@ -1071,23 +1086,13 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       content: '';
       position: absolute;
       inset: 0;
-      border-radius: 14px;
-      background: var(--calendar-event-sheen, linear-gradient(135deg, rgba(148, 163, 184, 0.18) 0%, rgba(148, 163, 184, 0.08) 100%));
+      border-radius: inherit;
+      background: var(
+        --calendar-event-sheen,
+        linear-gradient(135deg, rgba(148, 163, 184, 0.18) 0%, rgba(148, 163, 184, 0.08) 100%)
+      );
       pointer-events: none;
       z-index: 0;
-    }
-    .calendar-event::after {
-      content: '';
-      position: absolute;
-      top: 12px;
-      bottom: 12px;
-      left: 12px;
-      width: 6px;
-      border-radius: 999px;
-      background: var(--calendar-event-accent, var(--calendar-selected-color));
-      box-shadow: 0 0 14px color-mix(in srgb, var(--calendar-event-accent, var(--calendar-selected-color)) 42%, transparent 58%);
-      opacity: 0.9;
-      z-index: 1;
     }
     .calendar-event:hover {
       transform: translateY(-1px);
@@ -1098,10 +1103,7 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     }
     .calendar-event[data-calendar-selected='true'] {
       transform: translateY(-1px);
-    }
-    .calendar-event[data-calendar-selected='true']::after {
-      opacity: 1;
-      box-shadow: 0 0 18px color-mix(in srgb, var(--calendar-event-accent, var(--calendar-selected-color)) 55%, transparent 45%);
+      border-inline-start-width: 6px;
     }
     .calendar-event-content {
       position: relative;
@@ -1113,6 +1115,8 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       line-height: 1.4;
       pointer-events: none;
       min-height: 0;
+      min-width: 0;
+      width: 100%;
     }
     .calendar-event-statusIndicator {
       width: 0.72rem;
@@ -1381,7 +1385,6 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
             'transparent',
           )} 100%)`
       const outline = accent ? accent.border : mixColor(baseColor, 0.52, 'transparent')
-      const glow = accent ? accent.halo : mixColor(baseColor, 0.35, 'rgba(15, 23, 42, 0.35)')
       const indicator = accent ? accent.indicator : mixColor(baseColor, 0.76, '#ffffff')
       const baseShadow = accent
         ? `0 20px 36px ${tintColor(accent.primary, 0.4) || accent.halo}`
@@ -1406,7 +1409,6 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       element.style.setProperty('--calendar-event-fill', baseFill)
       element.style.setProperty('--calendar-event-sheen', sheen)
       element.style.setProperty('--calendar-event-outline', outline)
-      element.style.setProperty('--calendar-event-glow', glow)
       element.style.setProperty('--calendar-event-shadow', baseShadow)
       element.style.setProperty('--calendar-event-hover-shadow', hoverShadow)
       element.style.setProperty('--calendar-event-indicator', indicator)
@@ -1459,10 +1461,6 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         )
         element.style.setProperty('--calendar-event-outline', EVENT_SELECTION_COLOR)
         element.style.setProperty(
-          '--calendar-event-glow',
-          tintColor(EVENT_SELECTION_COLOR, 0.45) || EVENT_SELECTION_TINT,
-        )
-        element.style.setProperty(
           '--calendar-event-shadow',
           `0 26px 48px ${tintColor(EVENT_SELECTION_COLOR, 0.4) || EVENT_SELECTION_TINT}`,
         )
@@ -1488,7 +1486,6 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       '--calendar-event-sheen',
       '--calendar-event-outline',
       '--calendar-event-ink',
-      '--calendar-event-glow',
       '--calendar-event-shadow',
       '--calendar-event-hover-shadow',
       '--calendar-event-indicator',
@@ -1826,13 +1823,14 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         const relatedPublic = entry.public
         const status = resolveCombinedStatus(relatedInternal, relatedPublic)
         const displayTitle = resolveEventTitle(primary)
+        const sanitizedDisplayTitle = stripStatusTokens(displayTitle)
         const accent = STATUS_ACCENTS[status]
         const textColor = accent.text
         const primaryKey = `${primary.source}:${primary.id}`
         const sourceColor = primary.source === 'internal' ? internalColor : publicColor
         const extendedProps: CalendarEventExtendedProps = {
           event: primary,
-          displayTitle,
+          displayTitle: sanitizedDisplayTitle,
           relatedInternal,
           relatedPublic,
           status,
@@ -1849,7 +1847,7 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         })
         results.push({
           id: primaryKey,
-          title: displayTitle,
+          title: sanitizedDisplayTitle,
           start: primary.start,
           end: primary.end ?? undefined,
           allDay: primary.allDay,

--- a/sanity/plugins/calendarSyncTool/index.tsx
+++ b/sanity/plugins/calendarSyncTool/index.tsx
@@ -78,8 +78,6 @@ type StatusAccent = {
   border: string
   tint: string
   surface: string
-  badge: string
-  badgeText: string
 }
 
 const DISPLAY_STATUS_LABELS: Record<CalendarDisplayStatus, string> = {
@@ -96,25 +94,19 @@ const DISPLAY_STATUS_BADGE_TONES: Record<CalendarDisplayStatus, BadgeTone> = {
 
 const STATUS_ACCENTS: Record<CalendarDisplayStatus, StatusAccent> = {
   published: {
-    border: 'rgb(16, 185, 129)',
-    tint: 'rgba(16, 185, 129, 0.28)',
-    surface: 'color-mix(in srgb, var(--card-bg-color) 82%, rgb(16, 185, 129) 18%)',
-    badge: 'color-mix(in srgb, rgb(16, 185, 129) 70%, black 30%)',
-    badgeText: 'rgb(240, 253, 244)',
+    border: '#10b981',
+    tint: 'rgba(16, 185, 129, 0.45)',
+    surface: 'rgba(16, 185, 129, 0.28)',
   },
   unpublished: {
-    border: 'rgb(220, 38, 38)',
-    tint: 'rgba(220, 38, 38, 0.3)',
-    surface: 'color-mix(in srgb, var(--card-bg-color) 80%, rgb(220, 38, 38) 20%)',
-    badge: 'color-mix(in srgb, rgb(220, 38, 38) 72%, black 28%)',
-    badgeText: 'rgb(255, 241, 242)',
+    border: '#ef4444',
+    tint: 'rgba(239, 68, 68, 0.45)',
+    surface: 'rgba(239, 68, 68, 0.3)',
   },
   draft: {
-    border: 'rgb(234, 179, 8)',
-    tint: 'rgba(234, 179, 8, 0.28)',
-    surface: 'color-mix(in srgb, var(--card-bg-color) 82%, rgb(234, 179, 8) 18%)',
-    badge: 'color-mix(in srgb, rgb(234, 179, 8) 74%, black 26%)',
-    badgeText: 'rgb(255, 251, 235)',
+    border: '#f59e0b',
+    tint: 'rgba(245, 158, 11, 0.4)',
+    surface: 'rgba(245, 158, 11, 0.32)',
   },
 }
 
@@ -296,8 +288,6 @@ interface CalendarEventExtendedProps {
   statusTint?: string
   sourceColor?: string
   statusSurface?: string
-  statusBadge?: string
-  statusBadgeText?: string
 }
 
 type EventStatusMeta = {
@@ -306,8 +296,6 @@ type EventStatusMeta = {
   tint?: string
   sourceColor?: string
   surface?: string
-  badge?: string
-  badgeText?: string
 }
 
 const CALENDAR_VIEW_CONTAINER_STYLE: React.CSSProperties = {
@@ -641,16 +629,17 @@ function StatusLegendItem(props: {status: CalendarDisplayStatus; label: string})
         style={{
           display: 'inline-flex',
           alignItems: 'center',
-          gap: '0.35rem',
-          padding: '0.15rem 0.5rem 0.15rem 0.35rem',
+          gap: '0.4rem',
+          padding: '0.2rem 0.6rem 0.2rem 0.45rem',
           borderRadius: '999px',
-          background: accent.badge,
-          color: accent.badgeText,
+          background: accent.surface,
+          color: 'var(--card-fg-color)',
+          border: `1px solid ${accent.border}`,
           fontSize: '0.65rem',
           fontWeight: 600,
           letterSpacing: '0.08em',
           textTransform: 'uppercase',
-          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.18)',
+          boxShadow: '0 2px 6px rgba(0, 0, 0, 0.25)',
         }}
       >
         <Box
@@ -660,7 +649,7 @@ function StatusLegendItem(props: {status: CalendarDisplayStatus; label: string})
             height: 8,
             borderRadius: '999px',
             backgroundColor: accent.border,
-            boxShadow: '0 0 0 2px rgba(255, 255, 255, 0.35)',
+            boxShadow: '0 0 0 2px color-mix(in srgb, var(--card-bg-color) 70%, transparent 30%)',
             flexShrink: 0,
           }}
         />
@@ -781,103 +770,140 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     .calendar-tool-root {
       --calendar-internal-color: ${internalColor};
       --calendar-public-color: ${publicColor};
+      --calendar-grid-border: color-mix(in srgb, var(--card-border-color) 82%, transparent 18%);
+      --calendar-grid-surface: color-mix(in srgb, var(--card-bg-color) 90%, black 10%);
+      --calendar-header-bg: color-mix(in srgb, var(--card-bg-color) 42%, black 58%);
+      --calendar-header-text: color-mix(in srgb, var(--card-fg-color) 97%, white 3%);
+      --calendar-header-subtle: color-mix(in srgb, var(--card-muted-fg-color) 92%, white 8%);
+      --calendar-toolbar-bg: color-mix(in srgb, var(--card-bg-color) 60%, black 40%);
+      --calendar-toolbar-button-bg: color-mix(in srgb, var(--card-bg-color) 70%, black 30%);
+      --calendar-toolbar-button-hover: color-mix(in srgb, var(--card-bg-color) 45%, black 55%);
+    }
+    .calendar-tool-calendarCard .fc {
+      --fc-page-bg-color: transparent;
+      --fc-neutral-bg-color: var(--calendar-grid-surface);
+      --fc-border-color: var(--calendar-grid-border);
+      --fc-list-event-hover-bg-color: color-mix(in srgb, var(--calendar-grid-surface) 92%, transparent 8%);
     }
     .calendar-tool-calendarCard .fc-scrollgrid {
-      border-color: color-mix(in srgb, var(--card-border-color) 70%, transparent 30%);
-      background: color-mix(in srgb, var(--card-bg-color) 96%, var(--card-border-color) 4%);
+      border: 1px solid var(--calendar-grid-border);
+      background: var(--calendar-grid-surface);
+      border-radius: 16px;
+      overflow: hidden;
     }
-    .calendar-tool-calendarCard .fc-theme-standard td,
-    .calendar-tool-calendarCard .fc-theme-standard th {
-      border-color: color-mix(in srgb, var(--card-border-color) 65%, transparent 35%);
+    .calendar-tool-calendarCard .fc-scrollgrid-section-header,
+    .calendar-tool-calendarCard .fc-scrollgrid-section-header .fc-scroller {
+      background: var(--calendar-header-bg);
     }
-    .calendar-tool-calendarCard .fc-col-header {
-      background: color-mix(in srgb, var(--card-bg-color) 65%, var(--card-border-color) 35%);
+    .calendar-tool-calendarCard thead.fc-col-header {
+      border-bottom: 1px solid var(--calendar-grid-border);
+    }
+    .calendar-tool-calendarCard .fc-col-header-cell {
+      border: none;
     }
     .calendar-tool-calendarCard .fc-col-header-cell-cushion {
-      color: color-mix(in srgb, var(--card-fg-color) 94%, white 6%);
-      font-size: 0.72rem;
+      color: var(--calendar-header-text);
+      font-size: 0.75rem;
       font-weight: 700;
       letter-spacing: 0.12em;
       text-transform: uppercase;
-      padding: 0.55rem 0.25rem;
+      padding: 0.75rem 0.25rem;
     }
-    .calendar-tool-calendarCard .fc-col-header-cell-cushion:hover {
-      color: color-mix(in srgb, var(--card-fg-color) 98%, white 2%);
+    .calendar-tool-calendarCard .fc-col-header-cell-cushion:hover,
+    .calendar-tool-calendarCard .fc-col-header-cell-cushion:focus-visible {
+      color: color-mix(in srgb, var(--card-fg-color) 99%, white 1%);
+      text-decoration: none;
     }
     .calendar-tool-calendarCard .fc-daygrid-day-number {
-      color: color-mix(in srgb, var(--card-fg-color) 96%, white 4%);
+      color: var(--calendar-header-text);
       font-weight: 600;
     }
+    .calendar-tool-calendarCard .fc-theme-standard td,
+    .calendar-tool-calendarCard .fc-theme-standard th {
+      border-color: var(--calendar-grid-border);
+    }
+    .calendar-tool-calendarCard .fc-daygrid-day-frame {
+      background: color-mix(in srgb, var(--calendar-grid-surface) 94%, transparent 6%);
+    }
+    .calendar-tool-calendarCard .fc-toolbar.fc-header-toolbar {
+      padding: 0.75rem;
+      background: var(--calendar-toolbar-bg);
+      border-bottom: 1px solid var(--calendar-grid-border);
+    }
     .calendar-tool-calendarCard .fc-toolbar-title {
-      color: color-mix(in srgb, var(--card-fg-color) 96%, white 4%);
-      font-size: 1.25rem;
+      color: var(--calendar-header-text);
+      font-size: 1.28rem;
       font-weight: 700;
-      letter-spacing: 0.03em;
+      letter-spacing: 0.04em;
     }
     .calendar-tool-calendarCard .fc-toolbar .fc-button {
-      background: color-mix(in srgb, var(--card-bg-color) 90%, var(--card-border-color) 10%);
-      color: color-mix(in srgb, var(--card-fg-color) 90%, white 10%);
-      border: 1px solid color-mix(in srgb, var(--card-border-color) 68%, transparent 32%);
+      background: var(--calendar-toolbar-button-bg);
+      border: 1px solid color-mix(in srgb, var(--calendar-grid-border) 75%, transparent 25%);
+      color: var(--calendar-header-text);
       text-transform: uppercase;
-      font-size: 0.7rem;
+      font-size: 0.68rem;
       letter-spacing: 0.08em;
       padding: 0.45rem 0.75rem;
     }
     .calendar-tool-calendarCard .fc-toolbar .fc-button:hover,
     .calendar-tool-calendarCard .fc-toolbar .fc-button:focus-visible {
-      background: color-mix(in srgb, var(--card-bg-color) 76%, var(--card-border-color) 24%);
+      background: var(--calendar-toolbar-button-hover);
       color: var(--card-fg-color);
     }
     .calendar-tool-calendarCard .fc-toolbar .fc-button:disabled {
-      background: color-mix(in srgb, var(--card-bg-color) 85%, var(--card-border-color) 15%);
-      color: color-mix(in srgb, var(--card-muted-fg-color) 90%, white 10%);
+      opacity: 0.6;
+      color: var(--calendar-header-subtle);
     }
     .fc .calendar-event {
       border-radius: 12px;
+      overflow: hidden;
     }
     .calendar-event {
       position: relative;
       box-sizing: border-box;
       border-radius: 12px;
-      padding: 1rem 0.8rem 0.75rem;
-      background-color: var(--calendar-event-status-surface, color-mix(in srgb, var(--card-bg-color) 88%, var(--card-border-color) 12%));
+      padding: 0.75rem 0.85rem 0.65rem 1.05rem;
+      background-color: var(--calendar-event-status-surface, color-mix(in srgb, var(--card-bg-color) 88%, var(--card-border-color) 12%)) !important;
+      border: 1px solid color-mix(in srgb, var(--calendar-event-status-color, var(--card-border-color)) 85%, transparent 15%) !important;
       color: var(--card-fg-color);
-      border: 2px solid color-mix(in srgb, var(--calendar-event-status-color, var(--card-border-color)) 82%, var(--card-bg-color) 18%);
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
-      overflow: visible;
-      transition: transform 0.16s ease, box-shadow 0.2s ease, border-color 0.16s ease;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
     .calendar-event::before {
       content: '';
       position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 6px;
-      border-radius: 10px 10px 0 0;
-      background: var(--calendar-event-status-color, var(--card-border-color));
-      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
+      top: 0.55rem;
+      bottom: 0.55rem;
+      left: 0.6rem;
+      width: 0.35rem;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 90%, transparent 10%);
+      box-shadow: 0 0 12px color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 70%, transparent 30%);
       pointer-events: none;
     }
     .calendar-event::after {
       content: '';
       position: absolute;
       inset: 0;
-      border-radius: 10px;
-      background: linear-gradient(125deg, color-mix(in srgb, var(--calendar-event-source-color, transparent) 32%, transparent 68%), transparent 70%);
+      border-radius: inherit;
+      background: linear-gradient(120deg, color-mix(in srgb, var(--calendar-event-source-color, transparent) 55%, transparent 45%), transparent 70%);
       opacity: 0.35;
       pointer-events: none;
     }
+    .calendar-event > * {
+      position: relative;
+      z-index: 1;
+    }
     .calendar-event:hover {
       transform: translateY(-2px);
-      box-shadow: 0 10px 26px rgba(0, 0, 0, 0.26);
+      box-shadow: 0 14px 34px rgba(0, 0, 0, 0.35);
     }
     .calendar-event-selected {
       transform: translateY(-1px);
       box-shadow:
-        0 0 0 2px color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 88%, white 12%),
-        0 0 0 9px var(--calendar-event-status-tint, rgba(59, 130, 246, 0.22)),
-        0 14px 32px rgba(0, 0, 0, 0.3);
+        0 0 0 2px color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 82%, white 18%),
+        0 0 0 12px var(--calendar-event-status-tint, rgba(59, 130, 246, 0.24)),
+        0 16px 40px rgba(0, 0, 0, 0.45);
       z-index: 3;
     }
     .calendar-event-content {
@@ -885,68 +911,63 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       display: flex;
       flex-direction: column;
       gap: 0.4rem;
-      font-size: 0.85rem;
-      line-height: 1.32;
+      font-size: 0.86rem;
+      line-height: 1.35;
       max-width: 100%;
       pointer-events: none;
     }
     .calendar-event-metaRow {
       display: flex;
       align-items: center;
-      gap: 0.45rem;
-      width: 100%;
+      gap: 0.5rem;
       min-width: 0;
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: color-mix(in srgb, var(--card-fg-color) 92%, white 8%);
     }
     .calendar-event-time {
       font-weight: 600;
       white-space: nowrap;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      font-size: 0.72rem;
-      color: color-mix(in srgb, var(--card-fg-color) 90%, white 10%);
-      flex: 0 1 auto;
     }
-    .calendar-event-statusPill {
+    .calendar-event-statusIndicator {
+      position: relative;
       display: inline-flex;
       align-items: center;
-      gap: 0.3rem;
-      padding: 0.12rem 0.55rem;
+      justify-content: center;
+      width: 1.05rem;
+      height: 1.05rem;
       border-radius: 999px;
-      background: var(--calendar-event-status-badge, color-mix(in srgb, var(--calendar-event-status-color, var(--card-border-color)) 82%, var(--card-bg-color) 18%));
-      color: var(--calendar-event-status-badge-text, var(--card-fg-color));
-      font-size: 0.62rem;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      margin-left: auto;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.32);
-      pointer-events: none;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 68%;
+      background: color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 28%, transparent 72%);
+      box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--card-bg-color) 65%, transparent 35%), 0 0 0 1px color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 36%, transparent 64%), 0 0 12px color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 45%, transparent 55%);
+      flex-shrink: 0;
     }
-    .calendar-event-statusPill:first-child {
-      margin-left: 0;
-    }
-    .calendar-event-statusPill::before {
-      content: '';
+    .calendar-event-statusIndicatorDot {
       width: 0.45rem;
       height: 0.45rem;
-      border-radius: 50%;
-      background: var(--calendar-event-status-color, var(--card-border-color));
-      flex-shrink: 0;
-      box-shadow: 0 0 0 2px color-mix(in srgb, var(--calendar-event-status-badge, transparent) 45%, transparent 55%);
+      border-radius: 999px;
+      background: var(--calendar-event-status-color, var(--card-focus-ring-color));
+      box-shadow: 0 0 6px color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 60%, transparent 40%);
+    }
+    .calendar-sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
     .calendar-event-title {
       font-weight: 600;
-      font-size: 0.95rem;
+      font-size: 0.97rem;
       word-break: break-word;
       overflow-wrap: anywhere;
-      pointer-events: none;
     }
     .fc-daygrid-event .calendar-event-content {
-      gap: 0.35rem;
+      gap: 0.32rem;
     }
     .fc-daygrid-event .calendar-event-title {
       display: -webkit-box;
@@ -954,20 +975,20 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       -webkit-box-orient: vertical;
     }
     .fc-timegrid-event .calendar-event-content {
-      gap: 0.5rem;
+      gap: 0.48rem;
       font-size: 0.92rem;
-      line-height: 1.35;
+      line-height: 1.38;
     }
     .calendar-event-listItem {
       position: relative;
       display: flex;
       flex-direction: column;
-      gap: 0.3rem;
+      gap: 0.35rem;
       font-size: 0.95rem;
       line-height: 1.35;
     }
     .calendar-event-listItem .calendar-event-metaRow {
-      margin-bottom: 0.15rem;
+      margin-bottom: 0.1rem;
     }
     .calendar-event-listItemTitle {
       font-weight: 600;
@@ -975,7 +996,7 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       overflow-wrap: anywhere;
     }
     .calendar-event-note {
-      font-size: 0.78rem;
+      font-size: 0.8rem;
       color: color-mix(in srgb, var(--card-fg-color) 80%, var(--card-muted-fg-color) 20%);
     }
     .calendar-event-drift {
@@ -983,26 +1004,34 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
         135deg,
         transparent,
         transparent 8px,
-        color-mix(in srgb, var(--calendar-event-status-color, rgba(0, 0, 0, 0.3)) 18%, rgba(0, 0, 0, 0.35) 82%) 8px,
-        color-mix(in srgb, var(--calendar-event-status-color, rgba(0, 0, 0, 0.3)) 18%, rgba(0, 0, 0, 0.35) 82%) 16px
+        color-mix(in srgb, var(--calendar-event-status-color, rgba(0, 0, 0, 0.35)) 24%, rgba(0, 0, 0, 0.4) 76%) 8px,
+        color-mix(in srgb, var(--calendar-event-status-color, rgba(0, 0, 0, 0.35)) 24%, rgba(0, 0, 0, 0.4) 76%) 16px
       );
-      outline: 2px dashed color-mix(in srgb, var(--calendar-event-status-color, var(--card-border-color)) 80%, transparent 20%);
+      outline: 2px dashed color-mix(in srgb, var(--calendar-event-status-color, var(--card-border-color)) 82%, transparent 18%);
       outline-offset: -6px;
     }
     .fc-daygrid-day[data-calendar-selected='true'] .fc-daygrid-day-frame {
       position: relative;
     }
+    .fc-daygrid-day[data-calendar-selected='true'] .fc-daygrid-day-frame::before {
+      content: '';
+      position: absolute;
+      inset: 3px;
+      border-radius: 12px;
+      background: color-mix(in srgb, var(--calendar-day-selected-tint, rgba(59, 130, 246, 0.25)) 38%, transparent 62%);
+      pointer-events: none;
+    }
     .fc-daygrid-day[data-calendar-selected='true'] .fc-daygrid-day-frame::after {
       content: '';
       position: absolute;
-      inset: 2px;
+      inset: 3px;
       border-radius: 12px;
-      border: 3px solid color-mix(in srgb, var(--calendar-day-selected-color, var(--card-focus-ring-color)) 90%, white 10%);
-      box-shadow: 0 0 0 7px var(--calendar-day-selected-tint, rgba(59, 130, 246, 0.18));
+      border: 2px solid color-mix(in srgb, var(--calendar-day-selected-color, var(--card-focus-ring-color)) 88%, white 12%);
+      box-shadow: 0 0 0 8px color-mix(in srgb, var(--calendar-day-selected-tint, rgba(59, 130, 246, 0.22)) 55%, transparent 45%);
       pointer-events: none;
     }
     .fc-daygrid-day[data-calendar-selected='true'] .fc-daygrid-day-number {
-      color: color-mix(in srgb, var(--calendar-day-selected-color, var(--card-fg-color)) 95%, white 5%);
+      color: color-mix(in srgb, var(--calendar-day-selected-color, var(--card-fg-color)) 92%, white 8%);
       font-weight: 700;
     }
     .calendar-slot-label {
@@ -1144,7 +1173,9 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         elements.forEach((element) => {
           element.style.removeProperty('--calendar-event-status-color')
           element.style.removeProperty('--calendar-event-status-tint')
+          element.style.removeProperty('--calendar-event-status-surface')
           element.style.removeProperty('--calendar-event-source-color')
+          element.style.backgroundColor = ''
           element.classList.remove('calendar-event-selected')
           element.removeAttribute('data-calendar-selected')
           element.removeAttribute('aria-current')
@@ -1233,8 +1264,6 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
           statusColor: accent.border,
           statusTint: accent.tint,
           statusSurface: accent.surface,
-          statusBadge: accent.badge,
-          statusBadgeText: accent.badgeText,
           sourceColor,
         }
         results.push({
@@ -1243,8 +1272,8 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
           start: primary.start,
           end: primary.end ?? undefined,
           allDay: primary.allDay,
-          backgroundColor: 'var(--card-bg-color)',
-          borderColor: 'transparent',
+          backgroundColor: accent.surface,
+          borderColor: accent.border,
           textColor,
           extendedProps,
         })
@@ -1459,14 +1488,14 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       const statusLabel = status ? DISPLAY_STATUS_LABELS[status] : undefined
       const accessibleParts = [statusLabel, fallbackTitle].filter(Boolean)
       const accessibleTitle = (accessibleParts.join(' · ') || fallbackTitle || 'Untitled event').trim()
-      const statusBadge = statusLabel ? (
+      const statusIndicator = statusLabel ? (
         <span
-          className="calendar-event-statusPill"
-          data-calendar-status-pill={status}
-          aria-hidden="true"
+          className="calendar-event-statusIndicator"
+          data-calendar-status-indicator={status}
           title={statusLabel}
         >
-          {statusLabel}
+          <span className="calendar-event-statusIndicatorDot" aria-hidden="true" />
+          <span className="calendar-sr-only">{statusLabel}</span>
         </span>
       ) : null
       if (!sourceEvent) {
@@ -1474,10 +1503,10 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         const displayText = fallbackTitle || 'Untitled event'
         return (
           <div className="calendar-event-content" title={accessibleTitle} aria-label={accessibleTitle}>
-            {(timeLabel || statusBadge) && (
+            {(timeLabel || statusIndicator) && (
               <div className="calendar-event-metaRow">
+                {statusIndicator}
                 {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
-                {statusBadge}
               </div>
             )}
             <span className="calendar-event-title">{displayText}</span>
@@ -1503,10 +1532,10 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
             aria-label={accessibleTitle}
             data-calendar-source={sourceEvent.source}
           >
-            {(timeLabel || statusBadge) && (
+            {(timeLabel || statusIndicator) && (
               <div className="calendar-event-metaRow">
+                {statusIndicator}
                 {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
-                {statusBadge}
               </div>
             )}
             <span className="calendar-event-listItemTitle">{displayTitle}</span>
@@ -1522,10 +1551,10 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
           aria-label={accessibleTitle}
           data-calendar-source={sourceEvent.source}
         >
-          {(timeLabel || statusBadge) && (
+          {(timeLabel || statusIndicator) && (
             <div className="calendar-event-metaRow">
+              {statusIndicator}
               {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
-              {statusBadge}
             </div>
           )}
           <span className="calendar-event-title">{displayTitle}</span>
@@ -1604,18 +1633,10 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       }
       if (extended?.statusSurface) {
         arg.el.style.setProperty('--calendar-event-status-surface', extended.statusSurface)
+        arg.el.style.backgroundColor = extended.statusSurface
       } else {
         arg.el.style.removeProperty('--calendar-event-status-surface')
-      }
-      if (extended?.statusBadge) {
-        arg.el.style.setProperty('--calendar-event-status-badge', extended.statusBadge)
-      } else {
-        arg.el.style.removeProperty('--calendar-event-status-badge')
-      }
-      if (extended?.statusBadgeText) {
-        arg.el.style.setProperty('--calendar-event-status-badge-text', extended.statusBadgeText)
-      } else {
-        arg.el.style.removeProperty('--calendar-event-status-badge-text')
+        arg.el.style.backgroundColor = ''
       }
       if (extended?.sourceColor) {
         arg.el.style.setProperty('--calendar-event-source-color', extended.sourceColor)
@@ -1627,8 +1648,6 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         color: extended?.statusColor,
         tint: extended?.statusTint,
         surface: extended?.statusSurface,
-        badge: extended?.statusBadge,
-        badgeText: extended?.statusBadgeText,
         sourceColor: extended?.sourceColor,
       })
       const dayCell = arg.el.closest('.fc-daygrid-day') as HTMLElement | null
@@ -1695,9 +1714,8 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
     arg.el.style.removeProperty('--calendar-event-status-color')
     arg.el.style.removeProperty('--calendar-event-status-tint')
     arg.el.style.removeProperty('--calendar-event-status-surface')
-    arg.el.style.removeProperty('--calendar-event-status-badge')
-    arg.el.style.removeProperty('--calendar-event-status-badge-text')
     arg.el.style.removeProperty('--calendar-event-source-color')
+    arg.el.style.backgroundColor = ''
     const elements = eventElementsRef.current.get(key)
     if (elements) {
       elements.delete(arg.el)
@@ -1740,18 +1758,10 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         }
         if (meta?.surface) {
           element.style.setProperty('--calendar-event-status-surface', meta.surface)
+          element.style.backgroundColor = meta.surface
         } else {
           element.style.removeProperty('--calendar-event-status-surface')
-        }
-        if (meta?.badge) {
-          element.style.setProperty('--calendar-event-status-badge', meta.badge)
-        } else {
-          element.style.removeProperty('--calendar-event-status-badge')
-        }
-        if (meta?.badgeText) {
-          element.style.setProperty('--calendar-event-status-badge-text', meta.badgeText)
-        } else {
-          element.style.removeProperty('--calendar-event-status-badge-text')
+          element.style.backgroundColor = ''
         }
         if (meta?.sourceColor) {
           element.style.setProperty('--calendar-event-source-color', meta.sourceColor)

--- a/sanity/plugins/calendarSyncTool/index.tsx
+++ b/sanity/plugins/calendarSyncTool/index.tsx
@@ -74,6 +74,14 @@ type CalendarDisplayStatus = 'published' | 'unpublished' | 'draft'
 
 type BadgeTone = React.ComponentProps<typeof Badge>['tone']
 
+type StatusAccent = {
+  border: string
+  tint: string
+  surface: string
+  badge: string
+  badgeText: string
+}
+
 const DISPLAY_STATUS_LABELS: Record<CalendarDisplayStatus, string> = {
   published: 'Published',
   unpublished: 'Unpublished',
@@ -86,10 +94,28 @@ const DISPLAY_STATUS_BADGE_TONES: Record<CalendarDisplayStatus, BadgeTone> = {
   draft: 'caution',
 }
 
-const STATUS_ACCENTS: Record<CalendarDisplayStatus, {border: string; tint: string}> = {
-  published: {border: 'rgb(16, 185, 129)', tint: 'rgba(16, 185, 129, 0.24)'},
-  unpublished: {border: 'rgb(239, 68, 68)', tint: 'rgba(239, 68, 68, 0.28)'},
-  draft: {border: 'rgb(245, 158, 11)', tint: 'rgba(245, 158, 11, 0.26)'},
+const STATUS_ACCENTS: Record<CalendarDisplayStatus, StatusAccent> = {
+  published: {
+    border: 'rgb(16, 185, 129)',
+    tint: 'rgba(16, 185, 129, 0.28)',
+    surface: 'color-mix(in srgb, var(--card-bg-color) 82%, rgb(16, 185, 129) 18%)',
+    badge: 'color-mix(in srgb, rgb(16, 185, 129) 70%, black 30%)',
+    badgeText: 'rgb(240, 253, 244)',
+  },
+  unpublished: {
+    border: 'rgb(220, 38, 38)',
+    tint: 'rgba(220, 38, 38, 0.3)',
+    surface: 'color-mix(in srgb, var(--card-bg-color) 80%, rgb(220, 38, 38) 20%)',
+    badge: 'color-mix(in srgb, rgb(220, 38, 38) 72%, black 28%)',
+    badgeText: 'rgb(255, 241, 242)',
+  },
+  draft: {
+    border: 'rgb(234, 179, 8)',
+    tint: 'rgba(234, 179, 8, 0.28)',
+    surface: 'color-mix(in srgb, var(--card-bg-color) 82%, rgb(234, 179, 8) 18%)',
+    badge: 'color-mix(in srgb, rgb(234, 179, 8) 74%, black 26%)',
+    badgeText: 'rgb(255, 251, 235)',
+  },
 }
 
 interface StatusInfo {
@@ -269,6 +295,19 @@ interface CalendarEventExtendedProps {
   statusColor?: string
   statusTint?: string
   sourceColor?: string
+  statusSurface?: string
+  statusBadge?: string
+  statusBadgeText?: string
+}
+
+type EventStatusMeta = {
+  status?: CalendarDisplayStatus
+  color?: string
+  tint?: string
+  sourceColor?: string
+  surface?: string
+  badge?: string
+  badgeText?: string
 }
 
 const CALENDAR_VIEW_CONTAINER_STYLE: React.CSSProperties = {
@@ -598,17 +637,35 @@ function StatusLegendItem(props: {status: CalendarDisplayStatus; label: string})
   return (
     <Flex align="center" gap={2} wrap="wrap">
       <Box
+        as="span"
         style={{
-          width: 16,
-          height: 16,
-          borderRadius: 6,
-          backgroundColor: accent.tint,
-          border: `3px solid ${accent.border}`,
-          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08) inset',
-          boxSizing: 'border-box',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.35rem',
+          padding: '0.15rem 0.5rem 0.15rem 0.35rem',
+          borderRadius: '999px',
+          background: accent.badge,
+          color: accent.badgeText,
+          fontSize: '0.65rem',
+          fontWeight: 600,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.18)',
         }}
-      />
-      <Text size={1}>{props.label}</Text>
+      >
+        <Box
+          as="span"
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '999px',
+            backgroundColor: accent.border,
+            boxShadow: '0 0 0 2px rgba(255, 255, 255, 0.35)',
+            flexShrink: 0,
+          }}
+        />
+        <span>{props.label}</span>
+      </Box>
     </Flex>
   )
 }
@@ -725,115 +782,192 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       --calendar-internal-color: ${internalColor};
       --calendar-public-color: ${publicColor};
     }
+    .calendar-tool-calendarCard .fc-scrollgrid {
+      border-color: color-mix(in srgb, var(--card-border-color) 70%, transparent 30%);
+      background: color-mix(in srgb, var(--card-bg-color) 96%, var(--card-border-color) 4%);
+    }
+    .calendar-tool-calendarCard .fc-theme-standard td,
+    .calendar-tool-calendarCard .fc-theme-standard th {
+      border-color: color-mix(in srgb, var(--card-border-color) 65%, transparent 35%);
+    }
+    .calendar-tool-calendarCard .fc-col-header {
+      background: color-mix(in srgb, var(--card-bg-color) 65%, var(--card-border-color) 35%);
+    }
+    .calendar-tool-calendarCard .fc-col-header-cell-cushion {
+      color: color-mix(in srgb, var(--card-fg-color) 94%, white 6%);
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      padding: 0.55rem 0.25rem;
+    }
+    .calendar-tool-calendarCard .fc-col-header-cell-cushion:hover {
+      color: color-mix(in srgb, var(--card-fg-color) 98%, white 2%);
+    }
+    .calendar-tool-calendarCard .fc-daygrid-day-number {
+      color: color-mix(in srgb, var(--card-fg-color) 96%, white 4%);
+      font-weight: 600;
+    }
+    .calendar-tool-calendarCard .fc-toolbar-title {
+      color: color-mix(in srgb, var(--card-fg-color) 96%, white 4%);
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+    }
+    .calendar-tool-calendarCard .fc-toolbar .fc-button {
+      background: color-mix(in srgb, var(--card-bg-color) 90%, var(--card-border-color) 10%);
+      color: color-mix(in srgb, var(--card-fg-color) 90%, white 10%);
+      border: 1px solid color-mix(in srgb, var(--card-border-color) 68%, transparent 32%);
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      padding: 0.45rem 0.75rem;
+    }
+    .calendar-tool-calendarCard .fc-toolbar .fc-button:hover,
+    .calendar-tool-calendarCard .fc-toolbar .fc-button:focus-visible {
+      background: color-mix(in srgb, var(--card-bg-color) 76%, var(--card-border-color) 24%);
+      color: var(--card-fg-color);
+    }
+    .calendar-tool-calendarCard .fc-toolbar .fc-button:disabled {
+      background: color-mix(in srgb, var(--card-bg-color) 85%, var(--card-border-color) 15%);
+      color: color-mix(in srgb, var(--card-muted-fg-color) 90%, white 10%);
+    }
     .fc .calendar-event {
-      border-radius: 10px;
+      border-radius: 12px;
     }
     .calendar-event {
       position: relative;
       box-sizing: border-box;
-      border-radius: 10px;
-      background-color: var(--card-bg-color);
+      border-radius: 12px;
+      padding: 1rem 0.8rem 0.75rem;
+      background-color: var(--calendar-event-status-surface, color-mix(in srgb, var(--card-bg-color) 88%, var(--card-border-color) 12%));
       color: var(--card-fg-color);
-      overflow: hidden;
-      border: 2px solid var(--calendar-event-status-color, var(--card-border-color));
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
-      transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease;
+      border: 2px solid color-mix(in srgb, var(--calendar-event-status-color, var(--card-border-color)) 82%, var(--card-bg-color) 18%);
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+      overflow: visible;
+      transition: transform 0.16s ease, box-shadow 0.2s ease, border-color 0.16s ease;
     }
     .calendar-event::before {
       content: '';
       position: absolute;
-      inset: 1px;
-      border-radius: 8px;
-      background: var(--calendar-event-status-tint, transparent);
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 6px;
+      border-radius: 10px 10px 0 0;
+      background: var(--calendar-event-status-color, var(--card-border-color));
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
       pointer-events: none;
     }
     .calendar-event::after {
       content: '';
       position: absolute;
-      inset: 1px;
-      border-radius: 8px;
-      background: linear-gradient(
-        135deg,
-        transparent 0%,
-        transparent 55%,
-        var(--calendar-event-source-color, transparent) 100%
-      );
-      opacity: 0.28;
+      inset: 0;
+      border-radius: 10px;
+      background: linear-gradient(125deg, color-mix(in srgb, var(--calendar-event-source-color, transparent) 32%, transparent 68%), transparent 70%);
+      opacity: 0.35;
       pointer-events: none;
     }
     .calendar-event:hover {
-      transform: translateY(-1px);
-      border-color: color-mix(
-        in oklab,
-        var(--calendar-event-status-color, var(--card-border-color)) 75%,
-        white 25%
-      );
-      box-shadow: 0 6px 14px rgba(0, 0, 0, 0.2);
+      transform: translateY(-2px);
+      box-shadow: 0 10px 26px rgba(0, 0, 0, 0.26);
     }
     .calendar-event-selected {
-      transform: translateY(0);
+      transform: translateY(-1px);
       box-shadow:
-        0 0 0 3px var(--calendar-event-status-tint, rgba(59, 130, 246, 0.3)),
-        0 10px 24px rgba(0, 0, 0, 0.25);
-      z-index: 2;
+        0 0 0 2px color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 88%, white 12%),
+        0 0 0 9px var(--calendar-event-status-tint, rgba(59, 130, 246, 0.22)),
+        0 14px 32px rgba(0, 0, 0, 0.3);
+      z-index: 3;
     }
     .calendar-event-content {
       position: relative;
       display: flex;
+      flex-direction: column;
       gap: 0.4rem;
-      align-items: center;
       font-size: 0.85rem;
-      line-height: 1.25;
+      line-height: 1.32;
       max-width: 100%;
-      overflow: hidden;
+      pointer-events: none;
     }
-    .calendar-event-listItem {
-      position: relative;
+    .calendar-event-metaRow {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      width: 100%;
+      min-width: 0;
     }
     .calendar-event-time {
       font-weight: 600;
       white-space: nowrap;
-      letter-spacing: 0.01em;
-      flex-shrink: 0;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      font-size: 0.72rem;
+      color: color-mix(in srgb, var(--card-fg-color) 90%, white 10%);
+      flex: 0 1 auto;
     }
-    .calendar-event-title {
-      flex: 1 1 auto;
-      min-width: 0;
+    .calendar-event-statusPill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      padding: 0.12rem 0.55rem;
+      border-radius: 999px;
+      background: var(--calendar-event-status-badge, color-mix(in srgb, var(--calendar-event-status-color, var(--card-border-color)) 82%, var(--card-bg-color) 18%));
+      color: var(--calendar-event-status-badge-text, var(--card-fg-color));
+      font-size: 0.62rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-left: auto;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.32);
+      pointer-events: none;
+      white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      max-width: 68%;
+    }
+    .calendar-event-statusPill:first-child {
+      margin-left: 0;
+    }
+    .calendar-event-statusPill::before {
+      content: '';
+      width: 0.45rem;
+      height: 0.45rem;
+      border-radius: 50%;
+      background: var(--calendar-event-status-color, var(--card-border-color));
+      flex-shrink: 0;
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--calendar-event-status-badge, transparent) 45%, transparent 55%);
+    }
+    .calendar-event-title {
+      font-weight: 600;
+      font-size: 0.95rem;
       word-break: break-word;
       overflow-wrap: anywhere;
+      pointer-events: none;
+    }
+    .fc-daygrid-event .calendar-event-content {
+      gap: 0.35rem;
     }
     .fc-daygrid-event .calendar-event-title {
-      white-space: normal;
       display: -webkit-box;
       -webkit-line-clamp: 3;
       -webkit-box-orient: vertical;
-      line-height: 1.25;
-      word-break: break-word;
-    }
-    .fc-daygrid-event .calendar-event-content {
-      align-items: flex-start;
-      gap: 0.25rem;
-      flex-direction: column;
     }
     .fc-timegrid-event .calendar-event-content {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.25rem;
-      font-size: 0.9rem;
+      gap: 0.5rem;
+      font-size: 0.92rem;
       line-height: 1.35;
-    }
-    .fc-timegrid-event .calendar-event-title {
-      white-space: normal;
-      overflow-wrap: anywhere;
     }
     .calendar-event-listItem {
+      position: relative;
       display: flex;
       flex-direction: column;
-      gap: 0.2rem;
+      gap: 0.3rem;
       font-size: 0.95rem;
       line-height: 1.35;
+    }
+    .calendar-event-listItem .calendar-event-metaRow {
+      margin-bottom: 0.15rem;
     }
     .calendar-event-listItemTitle {
       font-weight: 600;
@@ -841,19 +975,19 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       overflow-wrap: anywhere;
     }
     .calendar-event-note {
-      font-size: 0.75rem;
-      opacity: 0.85;
+      font-size: 0.78rem;
+      color: color-mix(in srgb, var(--card-fg-color) 80%, var(--card-muted-fg-color) 20%);
     }
     .calendar-event-drift {
       background-image: repeating-linear-gradient(
         135deg,
         transparent,
-        transparent 6px,
-        rgba(0, 0, 0, 0.08) 6px,
-        rgba(0, 0, 0, 0.08) 12px
+        transparent 8px,
+        color-mix(in srgb, var(--calendar-event-status-color, rgba(0, 0, 0, 0.3)) 18%, rgba(0, 0, 0, 0.35) 82%) 8px,
+        color-mix(in srgb, var(--calendar-event-status-color, rgba(0, 0, 0, 0.3)) 18%, rgba(0, 0, 0, 0.35) 82%) 16px
       );
-      outline: 2px dashed var(--calendar-event-status-color, var(--card-border-color));
-      outline-offset: -4px;
+      outline: 2px dashed color-mix(in srgb, var(--calendar-event-status-color, var(--card-border-color)) 80%, transparent 20%);
+      outline-offset: -6px;
     }
     .fc-daygrid-day[data-calendar-selected='true'] .fc-daygrid-day-frame {
       position: relative;
@@ -862,21 +996,21 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       content: '';
       position: absolute;
       inset: 2px;
-      border-radius: 10px;
-      border: 3px solid var(--calendar-day-selected-color, var(--card-focus-ring-color));
-      box-shadow: 0 0 0 6px var(--calendar-day-selected-tint, rgba(59, 130, 246, 0.22));
+      border-radius: 12px;
+      border: 3px solid color-mix(in srgb, var(--calendar-day-selected-color, var(--card-focus-ring-color)) 90%, white 10%);
+      box-shadow: 0 0 0 7px var(--calendar-day-selected-tint, rgba(59, 130, 246, 0.18));
       pointer-events: none;
     }
     .fc-daygrid-day[data-calendar-selected='true'] .fc-daygrid-day-number {
-      color: var(--calendar-day-selected-color, var(--card-fg-color));
+      color: color-mix(in srgb, var(--calendar-day-selected-color, var(--card-fg-color)) 95%, white 5%);
       font-weight: 700;
     }
     .calendar-slot-label {
       font-size: 0.75rem;
       font-weight: 600;
-      color: var(--card-fg-color);
-      opacity: 0.85;
-      letter-spacing: 0.02em;
+      color: color-mix(in srgb, var(--card-fg-color) 92%, white 8%);
+      opacity: 0.95;
+      letter-spacing: 0.04em;
     }
     .fc .fc-timegrid-slot-label-cushion {
       padding: 0.25rem 0.5rem;
@@ -886,8 +1020,6 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     }
   `
 }
-
-
 function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
   const toast = useToast()
   const apiBase = resolveApiBase(props.apiBaseUrl)
@@ -929,9 +1061,7 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
   const calendarRef = useRef<FullCalendar | null>(null)
   const eventElementsRef = useRef<Map<string, Set<HTMLElement>>>(new Map())
   const eventDayCellsRef = useRef<Map<string, Set<HTMLElement>>>(new Map())
-  const eventStatusRef = useRef<
-    Map<string, {status?: CalendarDisplayStatus; color?: string; tint?: string; sourceColor?: string}>
-  >(new Map())
+  const eventStatusRef = useRef<Map<string, EventStatusMeta>>(new Map())
   const activeFetchRef = useRef<AbortController | null>(null)
   const fetchIdRef = useRef(0)
 
@@ -1102,6 +1232,9 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
           primaryKey,
           statusColor: accent.border,
           statusTint: accent.tint,
+          statusSurface: accent.surface,
+          statusBadge: accent.badge,
+          statusBadgeText: accent.badgeText,
           sourceColor,
         }
         results.push({
@@ -1326,12 +1459,27 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       const statusLabel = status ? DISPLAY_STATUS_LABELS[status] : undefined
       const accessibleParts = [statusLabel, fallbackTitle].filter(Boolean)
       const accessibleTitle = (accessibleParts.join(' · ') || fallbackTitle || 'Untitled event').trim()
+      const statusBadge = statusLabel ? (
+        <span
+          className="calendar-event-statusPill"
+          data-calendar-status-pill={status}
+          aria-hidden="true"
+          title={statusLabel}
+        >
+          {statusLabel}
+        </span>
+      ) : null
       if (!sourceEvent) {
         const timeLabel = !arg.event.allDay && baseTimeText ? baseTimeText : ''
         const displayText = fallbackTitle || 'Untitled event'
         return (
           <div className="calendar-event-content" title={accessibleTitle} aria-label={accessibleTitle}>
-            {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
+            {(timeLabel || statusBadge) && (
+              <div className="calendar-event-metaRow">
+                {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
+                {statusBadge}
+              </div>
+            )}
             <span className="calendar-event-title">{displayText}</span>
           </div>
         )
@@ -1355,7 +1503,12 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
             aria-label={accessibleTitle}
             data-calendar-source={sourceEvent.source}
           >
-            {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
+            {(timeLabel || statusBadge) && (
+              <div className="calendar-event-metaRow">
+                {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
+                {statusBadge}
+              </div>
+            )}
             <span className="calendar-event-listItemTitle">{displayTitle}</span>
             {locationText ? <span className="calendar-event-note">{locationText}</span> : null}
           </div>
@@ -1369,7 +1522,12 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
           aria-label={accessibleTitle}
           data-calendar-source={sourceEvent.source}
         >
-          {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
+          {(timeLabel || statusBadge) && (
+            <div className="calendar-event-metaRow">
+              {timeLabel ? <span className="calendar-event-time">{timeLabel}</span> : null}
+              {statusBadge}
+            </div>
+          )}
           <span className="calendar-event-title">{displayTitle}</span>
         </div>
       )
@@ -1444,6 +1602,21 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       } else {
         arg.el.style.removeProperty('--calendar-event-status-tint')
       }
+      if (extended?.statusSurface) {
+        arg.el.style.setProperty('--calendar-event-status-surface', extended.statusSurface)
+      } else {
+        arg.el.style.removeProperty('--calendar-event-status-surface')
+      }
+      if (extended?.statusBadge) {
+        arg.el.style.setProperty('--calendar-event-status-badge', extended.statusBadge)
+      } else {
+        arg.el.style.removeProperty('--calendar-event-status-badge')
+      }
+      if (extended?.statusBadgeText) {
+        arg.el.style.setProperty('--calendar-event-status-badge-text', extended.statusBadgeText)
+      } else {
+        arg.el.style.removeProperty('--calendar-event-status-badge-text')
+      }
       if (extended?.sourceColor) {
         arg.el.style.setProperty('--calendar-event-source-color', extended.sourceColor)
       } else {
@@ -1453,6 +1626,9 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         status: extended?.status,
         color: extended?.statusColor,
         tint: extended?.statusTint,
+        surface: extended?.statusSurface,
+        badge: extended?.statusBadge,
+        badgeText: extended?.statusBadgeText,
         sourceColor: extended?.sourceColor,
       })
       const dayCell = arg.el.closest('.fc-daygrid-day') as HTMLElement | null
@@ -1518,6 +1694,9 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
     if (!key) return
     arg.el.style.removeProperty('--calendar-event-status-color')
     arg.el.style.removeProperty('--calendar-event-status-tint')
+    arg.el.style.removeProperty('--calendar-event-status-surface')
+    arg.el.style.removeProperty('--calendar-event-status-badge')
+    arg.el.style.removeProperty('--calendar-event-status-badge-text')
     arg.el.style.removeProperty('--calendar-event-source-color')
     const elements = eventElementsRef.current.get(key)
     if (elements) {
@@ -1558,6 +1737,21 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
           element.style.setProperty('--calendar-event-status-tint', meta.tint)
         } else {
           element.style.removeProperty('--calendar-event-status-tint')
+        }
+        if (meta?.surface) {
+          element.style.setProperty('--calendar-event-status-surface', meta.surface)
+        } else {
+          element.style.removeProperty('--calendar-event-status-surface')
+        }
+        if (meta?.badge) {
+          element.style.setProperty('--calendar-event-status-badge', meta.badge)
+        } else {
+          element.style.removeProperty('--calendar-event-status-badge')
+        }
+        if (meta?.badgeText) {
+          element.style.setProperty('--calendar-event-status-badge-text', meta.badgeText)
+        } else {
+          element.style.removeProperty('--calendar-event-status-badge-text')
         }
         if (meta?.sourceColor) {
           element.style.setProperty('--calendar-event-source-color', meta.sourceColor)

--- a/sanity/plugins/calendarSyncTool/index.tsx
+++ b/sanity/plugins/calendarSyncTool/index.tsx
@@ -69,6 +69,9 @@ interface FormState {
 
 const DEFAULT_INTERNAL_COLOR = 'color-mix(in oklab, var(--brand-border) 70%, var(--brand-surface) 30%)'
 const DEFAULT_PUBLIC_COLOR = 'var(--brand-accent)'
+const EVENT_SELECTION_COLOR = '#2563eb'
+const EVENT_SELECTION_TINT = 'rgba(37, 99, 235, 0.32)'
+const EVENT_SELECTION_SURFACE = 'rgba(37, 99, 235, 0.2)'
 
 type CalendarDisplayStatus = 'published' | 'unpublished' | 'draft'
 
@@ -770,6 +773,9 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     .calendar-tool-root {
       --calendar-internal-color: ${internalColor};
       --calendar-public-color: ${publicColor};
+      --calendar-selected-color: ${EVENT_SELECTION_COLOR};
+      --calendar-selected-tint: ${EVENT_SELECTION_TINT};
+      --calendar-selected-surface: ${EVENT_SELECTION_SURFACE};
       --calendar-grid-border: color-mix(in srgb, var(--card-border-color) 82%, transparent 18%);
       --calendar-grid-surface: color-mix(in srgb, var(--card-bg-color) 90%, black 10%);
       --calendar-header-bg: color-mix(in srgb, var(--card-bg-color) 42%, black 58%);
@@ -868,6 +874,8 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       color: var(--card-fg-color);
       box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
+      overflow: hidden;
+      max-width: 100%;
     }
     .calendar-event::before {
       content: '';
@@ -900,11 +908,21 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     }
     .calendar-event-selected {
       transform: translateY(-1px);
+      background-color: color-mix(in srgb, var(--calendar-selected-surface, rgba(37, 99, 235, 0.2)) 78%, transparent 22%) !important;
+      border-color: color-mix(in srgb, var(--calendar-selected-color, #2563eb) 88%, transparent 12%) !important;
       box-shadow:
-        0 0 0 2px color-mix(in srgb, var(--calendar-event-status-color, var(--card-focus-ring-color)) 82%, white 18%),
-        0 0 0 12px var(--calendar-event-status-tint, rgba(59, 130, 246, 0.24)),
+        0 0 0 2px color-mix(in srgb, var(--calendar-selected-color, #2563eb) 90%, white 10%),
+        0 0 0 12px color-mix(in srgb, var(--calendar-selected-tint, rgba(37, 99, 235, 0.32)) 100%, transparent 0%),
         0 16px 40px rgba(0, 0, 0, 0.45);
       z-index: 3;
+    }
+    .calendar-event-selected::before {
+      background: color-mix(in srgb, var(--calendar-selected-color, #2563eb) 88%, transparent 12%);
+      box-shadow: 0 0 12px color-mix(in srgb, var(--calendar-selected-color, #2563eb) 72%, transparent 28%);
+    }
+    .calendar-event-selected::after {
+      opacity: 0.6;
+      background: linear-gradient(120deg, color-mix(in srgb, var(--calendar-selected-color, #2563eb) 62%, transparent 38%), transparent 72%);
     }
     .calendar-event-content {
       position: relative;
@@ -914,6 +932,8 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       font-size: 0.86rem;
       line-height: 1.35;
       max-width: 100%;
+      min-height: 0;
+      overflow: hidden;
       pointer-events: none;
     }
     .calendar-event-metaRow {
@@ -921,14 +941,23 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       align-items: center;
       gap: 0.5rem;
       min-width: 0;
+      overflow: hidden;
       font-size: 0.7rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
       color: color-mix(in srgb, var(--card-fg-color) 92%, white 8%);
     }
+    .calendar-event-metaRow > * {
+      min-width: 0;
+    }
+    .calendar-event-metaRow span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
     .calendar-event-time {
       font-weight: 600;
       white-space: nowrap;
+      flex-shrink: 0;
     }
     .calendar-event-statusIndicator {
       position: relative;
@@ -966,6 +995,34 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       word-break: break-word;
       overflow-wrap: anywhere;
     }
+    .calendar-event-title,
+    .calendar-event-listItemTitle,
+    .calendar-event-note {
+      overflow: hidden;
+    }
+    .calendar-event-title[data-calendar-overflow='true'],
+    .calendar-event-listItemTitle[data-calendar-overflow='true'] {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      text-overflow: ellipsis;
+      word-break: normal;
+      overflow-wrap: normal;
+    }
+    .fc-daygrid-event .calendar-event-title[data-calendar-overflow='true'] {
+      -webkit-line-clamp: 3;
+    }
+    .calendar-event-listItemTitle[data-calendar-overflow='true'] {
+      -webkit-line-clamp: 3;
+    }
+    .calendar-event-note[data-calendar-overflow='true'] {
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .calendar-event[data-calendar-overflow='true'] .calendar-event-content,
+    .calendar-event[data-calendar-overflow='true'] .calendar-event-listItem {
+      overflow: hidden;
+    }
     .fc-daygrid-event .calendar-event-content {
       gap: 0.32rem;
     }
@@ -986,6 +1043,8 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       gap: 0.35rem;
       font-size: 0.95rem;
       line-height: 1.35;
+      min-height: 0;
+      overflow: hidden;
     }
     .calendar-event-listItem .calendar-event-metaRow {
       margin-bottom: 0.1rem;
@@ -1018,7 +1077,7 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       position: absolute;
       inset: 3px;
       border-radius: 12px;
-      background: color-mix(in srgb, var(--calendar-day-selected-tint, rgba(59, 130, 246, 0.25)) 38%, transparent 62%);
+      background: color-mix(in srgb, var(--calendar-selected-tint, rgba(37, 99, 235, 0.28)) 52%, transparent 48%);
       pointer-events: none;
     }
     .fc-daygrid-day[data-calendar-selected='true'] .fc-daygrid-day-frame::after {
@@ -1026,12 +1085,12 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       position: absolute;
       inset: 3px;
       border-radius: 12px;
-      border: 2px solid color-mix(in srgb, var(--calendar-day-selected-color, var(--card-focus-ring-color)) 88%, white 12%);
-      box-shadow: 0 0 0 8px color-mix(in srgb, var(--calendar-day-selected-tint, rgba(59, 130, 246, 0.22)) 55%, transparent 45%);
+      border: 2px solid color-mix(in srgb, var(--calendar-selected-color, #2563eb) 88%, white 12%);
+      box-shadow: 0 0 0 8px color-mix(in srgb, var(--calendar-selected-tint, rgba(37, 99, 235, 0.24)) 65%, transparent 35%);
       pointer-events: none;
     }
     .fc-daygrid-day[data-calendar-selected='true'] .fc-daygrid-day-number {
-      color: color-mix(in srgb, var(--calendar-day-selected-color, var(--card-fg-color)) 92%, white 8%);
+      color: color-mix(in srgb, var(--calendar-selected-color, #2563eb) 92%, white 8%);
       font-weight: 700;
     }
     .calendar-slot-label {
@@ -1093,6 +1152,109 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
   const eventStatusRef = useRef<Map<string, EventStatusMeta>>(new Map())
   const activeFetchRef = useRef<AbortController | null>(null)
   const fetchIdRef = useRef(0)
+  const eventOverflowObserversRef = useRef<Map<HTMLElement, ResizeObserver>>(new Map())
+  const eventOverflowRafRef = useRef<Map<HTMLElement, number>>(new Map())
+
+  const clearOverflowState = useCallback((element: HTMLElement) => {
+    element.removeAttribute('data-calendar-overflow')
+    element
+      .querySelectorAll<HTMLElement>(
+        '.calendar-event-title[data-calendar-overflow], .calendar-event-listItemTitle[data-calendar-overflow], .calendar-event-note[data-calendar-overflow]',
+      )
+      .forEach((node) => {
+        node.removeAttribute('data-calendar-overflow')
+      })
+  }, [])
+
+  const updateEventOverflowState = useCallback(
+    (element: HTMLElement) => {
+      if (!element || !element.isConnected) return
+      const content = element.querySelector<HTMLElement>('.calendar-event-content, .calendar-event-listItem')
+      clearOverflowState(element)
+      if (!content) return
+      const title = content.querySelector<HTMLElement>('.calendar-event-title, .calendar-event-listItemTitle')
+      const note = content.querySelector<HTMLElement>('.calendar-event-note')
+      const checkOverflow = (node: HTMLElement) => {
+        const heightOverflow = Math.ceil(node.scrollHeight) - Math.ceil(node.clientHeight) > 1
+        const widthOverflow = Math.ceil(node.scrollWidth) - Math.ceil(node.clientWidth) > 1
+        return heightOverflow || widthOverflow
+      }
+      const contentOverflow = checkOverflow(content)
+      const titleOverflow = title ? checkOverflow(title) : false
+      const noteOverflow = note ? checkOverflow(note) : false
+      if (title && titleOverflow) {
+        title.setAttribute('data-calendar-overflow', 'true')
+      }
+      if (note && noteOverflow) {
+        note.setAttribute('data-calendar-overflow', 'true')
+      }
+      if (contentOverflow || titleOverflow || noteOverflow) {
+        element.setAttribute('data-calendar-overflow', 'true')
+      }
+    },
+    [clearOverflowState],
+  )
+
+  const scheduleOverflowMeasurement = useCallback(
+    (element: HTMLElement) => {
+      if (!element) return
+      const win = typeof window !== 'undefined' ? window : null
+      if (!win || typeof win.requestAnimationFrame !== 'function') {
+        updateEventOverflowState(element)
+        return
+      }
+      const existing = eventOverflowRafRef.current.get(element)
+      if (existing !== undefined) {
+        win.cancelAnimationFrame(existing)
+      }
+      const frame = win.requestAnimationFrame(() => {
+        eventOverflowRafRef.current.delete(element)
+        updateEventOverflowState(element)
+      })
+      eventOverflowRafRef.current.set(element, frame)
+    },
+    [updateEventOverflowState],
+  )
+
+  const attachOverflowObserver = useCallback(
+    (element: HTMLElement) => {
+      if (!element) return
+      scheduleOverflowMeasurement(element)
+      if (eventOverflowObserversRef.current.has(element)) return
+      const ObserverCtor = typeof ResizeObserver !== 'undefined' ? ResizeObserver : null
+      if (!ObserverCtor) return
+      const observer = new ObserverCtor(() => {
+        scheduleOverflowMeasurement(element)
+      })
+      observer.observe(element)
+      const content = element.querySelector<HTMLElement>('.calendar-event-content, .calendar-event-listItem')
+      if (content) {
+        observer.observe(content)
+      }
+      eventOverflowObserversRef.current.set(element, observer)
+    },
+    [scheduleOverflowMeasurement],
+  )
+
+  const detachOverflowObserver = useCallback(
+    (element: HTMLElement) => {
+      const observer = eventOverflowObserversRef.current.get(element)
+      if (observer) {
+        observer.disconnect()
+        eventOverflowObserversRef.current.delete(element)
+      }
+      const win = typeof window !== 'undefined' ? window : null
+      const frame = eventOverflowRafRef.current.get(element)
+      if (frame !== undefined) {
+        if (win && typeof win.cancelAnimationFrame === 'function') {
+          win.cancelAnimationFrame(frame)
+        }
+        eventOverflowRafRef.current.delete(element)
+      }
+      clearOverflowState(element)
+    },
+    [clearOverflowState],
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -1171,6 +1333,7 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       setLoading(false)
       eventElementsRef.current.forEach((elements) => {
         elements.forEach((element) => {
+          detachOverflowObserver(element)
           element.style.removeProperty('--calendar-event-status-color')
           element.style.removeProperty('--calendar-event-status-tint')
           element.style.removeProperty('--calendar-event-status-surface')
@@ -1185,19 +1348,19 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       eventDayCellsRef.current.forEach((cells) => {
         cells.forEach((cell) => {
           cell.removeAttribute('data-calendar-selected')
-          cell.removeAttribute('data-calendar-selected-status')
-          cell.style.removeProperty('--calendar-day-selected-color')
-          cell.style.removeProperty('--calendar-day-selected-tint')
         })
       })
       eventDayCellsRef.current.clear()
+      eventOverflowObserversRef.current.forEach((observer) => observer.disconnect())
+      eventOverflowObserversRef.current.clear()
+      eventOverflowRafRef.current.clear()
       eventStatusRef.current.clear()
       if (activeFetchRef.current) {
         activeFetchRef.current.abort()
         activeFetchRef.current = null
       }
     }
-  }, [accessState])
+  }, [accessState, detachOverflowObserver])
 
   const projectEvents = useCallback(
     (payload: CalendarSyncResponse): EventInput[] => {
@@ -1482,7 +1645,8 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
     (arg: EventContentArg) => {
       const extended = arg.event.extendedProps as CalendarEventExtendedProps
       const sourceEvent = extended?.event
-      const fallbackTitle = (extended?.displayTitle || arg.event.title || '').trim()
+      const rawFallbackTitle = (extended?.displayTitle || arg.event.title || '').trim()
+      const fallbackTitle = stripStatusTokens(rawFallbackTitle)
       const baseTimeText = arg.timeText?.trim()
       const status = extended?.status
       const statusLabel = status ? DISPLAY_STATUS_LABELS[status] : undefined
@@ -1675,29 +1839,19 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         arg.el.setAttribute('data-calendar-selected', 'true')
         if (dayCell) {
           dayCell.setAttribute('data-calendar-selected', 'true')
-          if (extended?.status) {
-            dayCell.setAttribute('data-calendar-selected-status', extended.status)
-          } else {
-            dayCell.removeAttribute('data-calendar-selected-status')
-          }
-          if (extended?.statusColor) {
-            dayCell.style.setProperty('--calendar-day-selected-color', extended.statusColor)
-          } else {
-            dayCell.style.removeProperty('--calendar-day-selected-color')
-          }
-          if (extended?.statusTint) {
-            dayCell.style.setProperty('--calendar-day-selected-tint', extended.statusTint)
-          } else {
-            dayCell.style.removeProperty('--calendar-day-selected-tint')
-          }
         }
       } else {
         arg.el.classList.remove('calendar-event-selected')
         arg.el.removeAttribute('aria-current')
         arg.el.removeAttribute('data-calendar-selected')
+        if (dayCell) {
+          dayCell.removeAttribute('data-calendar-selected')
+        }
       }
+      attachOverflowObserver(arg.el)
+      scheduleOverflowMeasurement(arg.el)
     },
-    [selectedKey],
+    [attachOverflowObserver, scheduleOverflowMeasurement, selectedKey],
   )
 
   const handleEventWillUnmount = useCallback((arg: EventMountArg) => {
@@ -1716,6 +1870,7 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
     arg.el.style.removeProperty('--calendar-event-status-surface')
     arg.el.style.removeProperty('--calendar-event-source-color')
     arg.el.style.backgroundColor = ''
+    detachOverflowObserver(arg.el)
     const elements = eventElementsRef.current.get(key)
     if (elements) {
       elements.delete(arg.el)
@@ -1733,14 +1888,11 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
         }
       }
       dayCell.removeAttribute('data-calendar-selected')
-      dayCell.removeAttribute('data-calendar-selected-status')
-      dayCell.style.removeProperty('--calendar-day-selected-color')
-      dayCell.style.removeProperty('--calendar-day-selected-tint')
     }
     if (!eventElementsRef.current.has(key) && !eventDayCellsRef.current.has(key)) {
       eventStatusRef.current.delete(key)
     }
-  }, [])
+  }, [detachOverflowObserver])
 
   useEffect(() => {
     eventElementsRef.current.forEach((elements, key) => {
@@ -1777,42 +1929,25 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
           element.removeAttribute('aria-current')
           element.removeAttribute('data-calendar-selected')
         }
+        scheduleOverflowMeasurement(element)
       })
     })
     eventDayCellsRef.current.forEach((cells, key) => {
-      const meta = eventStatusRef.current.get(key)
       cells.forEach((cell) => {
         if (key === selectedKey) {
           cell.setAttribute('data-calendar-selected', 'true')
-          if (meta?.status) {
-            cell.setAttribute('data-calendar-selected-status', meta.status)
-          } else {
-            cell.removeAttribute('data-calendar-selected-status')
-          }
-          if (meta?.color) {
-            cell.style.setProperty('--calendar-day-selected-color', meta.color)
-          } else {
-            cell.style.removeProperty('--calendar-day-selected-color')
-          }
-          if (meta?.tint) {
-            cell.style.setProperty('--calendar-day-selected-tint', meta.tint)
-          } else {
-            cell.style.removeProperty('--calendar-day-selected-tint')
-          }
         } else {
           cell.removeAttribute('data-calendar-selected')
-          cell.removeAttribute('data-calendar-selected-status')
-          cell.style.removeProperty('--calendar-day-selected-color')
-          cell.style.removeProperty('--calendar-day-selected-tint')
         }
       })
     })
-  }, [selectedKey])
+  }, [scheduleOverflowMeasurement, selectedKey])
 
   useEffect(() => {
     return () => {
       eventElementsRef.current.forEach((elements) => {
         elements.forEach((element) => {
+          detachOverflowObserver(element)
           element.style.removeProperty('--calendar-event-status-color')
           element.style.removeProperty('--calendar-event-status-tint')
           element.style.removeProperty('--calendar-event-source-color')
@@ -1825,15 +1960,15 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
       eventDayCellsRef.current.forEach((cells) => {
         cells.forEach((cell) => {
           cell.removeAttribute('data-calendar-selected')
-          cell.removeAttribute('data-calendar-selected-status')
-          cell.style.removeProperty('--calendar-day-selected-color')
-          cell.style.removeProperty('--calendar-day-selected-tint')
         })
       })
       eventDayCellsRef.current.clear()
+      eventOverflowObserversRef.current.forEach((observer) => observer.disconnect())
+      eventOverflowObserversRef.current.clear()
+      eventOverflowRafRef.current.clear()
       eventStatusRef.current.clear()
     }
-  }, [])
+  }, [detachOverflowObserver])
 
   const refresh = useCallback(() => {
     if (accessState !== 'authorized') return

--- a/sanity/plugins/calendarSyncTool/index.tsx
+++ b/sanity/plugins/calendarSyncTool/index.tsx
@@ -110,31 +110,31 @@ const DISPLAY_STATUS_BADGE_TONES: Record<CalendarDisplayStatus, BadgeTone> = {
 
 const STATUS_ACCENTS: Record<CalendarDisplayStatus, StatusAccent> = {
   published: {
-    primary: '#0ea5e9',
-    text: '#042f3d',
-    surface: 'rgba(14, 165, 233, 0.28)',
-    surfaceSoft: 'rgba(56, 189, 248, 0.12)',
-    halo: 'rgba(14, 165, 233, 0.45)',
-    border: 'rgba(14, 165, 233, 0.65)',
-    indicator: 'rgba(14, 165, 233, 0.95)',
+    primary: '#38bdf8',
+    text: '#02293b',
+    surface: 'rgba(56, 189, 248, 0.38)',
+    surfaceSoft: 'rgba(56, 189, 248, 0.18)',
+    halo: 'rgba(56, 189, 248, 0.5)',
+    border: 'rgba(14, 165, 233, 0.75)',
+    indicator: 'rgba(56, 189, 248, 0.95)',
   },
   unpublished: {
-    primary: '#f97316',
-    text: '#451a03',
-    surface: 'rgba(249, 115, 22, 0.32)',
-    surfaceSoft: 'rgba(251, 146, 60, 0.16)',
-    halo: 'rgba(249, 115, 22, 0.48)',
-    border: 'rgba(249, 115, 22, 0.65)',
-    indicator: 'rgba(249, 115, 22, 0.95)',
+    primary: '#fb7185',
+    text: '#4c0519',
+    surface: 'rgba(251, 113, 133, 0.42)',
+    surfaceSoft: 'rgba(252, 165, 179, 0.2)',
+    halo: 'rgba(251, 113, 133, 0.55)',
+    border: 'rgba(239, 68, 68, 0.72)',
+    indicator: 'rgba(251, 113, 133, 0.95)',
   },
   draft: {
     primary: '#facc15',
     text: '#422006',
-    surface: 'rgba(250, 204, 21, 0.32)',
+    surface: 'rgba(250, 204, 21, 0.36)',
     surfaceSoft: 'rgba(253, 224, 71, 0.18)',
     halo: 'rgba(250, 204, 21, 0.5)',
-    border: 'rgba(250, 204, 21, 0.65)',
-    indicator: 'rgba(250, 204, 21, 0.95)',
+    border: 'rgba(202, 138, 4, 0.72)',
+    indicator: 'rgba(252, 211, 77, 0.95)',
   },
 }
 
@@ -931,7 +931,7 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     .calendar-tool-calendarCard .fc-scrollgrid {
       border-radius: 18px;
       overflow: hidden;
-      border: 1px solid color-mix(in srgb, var(--card-border-color) 72%, transparent 28%);
+      border: 1px solid color-mix(in srgb, var(--card-border-color) 68%, transparent 32%);
       background: color-mix(in srgb, var(--card-bg-color) 92%, transparent 8%);
       box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--card-border-color) 45%, transparent 55%);
     }
@@ -972,127 +972,163 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     }
     .calendar-tool-calendarCard .fc-scrollgrid-section-header,
     .calendar-tool-calendarCard .fc-scrollgrid-section-header .fc-scroller {
-      background: color-mix(in srgb, var(--card-bg-color) 82%, var(--card-border-color) 18%);
-      backdrop-filter: blur(14px);
-      border-bottom: 1px solid color-mix(in srgb, var(--card-border-color) 70%, transparent 30%);
+      background: color-mix(in srgb, var(--card-bg-color) 80%, var(--card-border-color) 20%);
+      border-bottom: 1px solid color-mix(in srgb, var(--card-border-color) 72%, transparent 28%);
+      backdrop-filter: blur(16px);
+    }
+    [data-ui-color-scheme='dark'] .calendar-tool-calendarCard .fc-scrollgrid-section-header,
+    [data-ui-color-scheme='dark'] .calendar-tool-calendarCard thead.fc-col-header {
+      background: linear-gradient(180deg, rgba(15, 23, 42, 0.96) 0%, rgba(30, 41, 59, 0.82) 100%);
+      border-bottom-color: rgba(148, 163, 184, 0.45);
+      box-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.66);
+    }
+    [data-ui-color-scheme='dark'] .calendar-tool-calendarCard .fc-col-header-cell-cushion {
+      color: rgba(241, 245, 249, 0.96);
+      text-shadow: 0 2px 10px rgba(15, 23, 42, 0.9);
+    }
+    [data-ui-color-scheme='light'] .calendar-tool-calendarCard .fc-scrollgrid-section-header,
+    [data-ui-color-scheme='light'] .calendar-tool-calendarCard thead.fc-col-header {
+      background: linear-gradient(180deg, rgba(248, 250, 252, 0.95) 0%, rgba(226, 232, 240, 0.72) 100%);
+      border-bottom-color: rgba(148, 163, 184, 0.45);
+      box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.24);
+    }
+    [data-ui-color-scheme='light'] .calendar-tool-calendarCard .fc-col-header-cell-cushion {
+      color: rgba(30, 41, 59, 0.92);
+      text-shadow: 0 1px 1px rgba(255, 255, 255, 0.85);
     }
     .calendar-tool-calendarCard .fc-col-header-cell {
       border: none;
     }
     .calendar-tool-calendarCard .fc-col-header-cell-cushion {
-      color: var(--card-fg-color);
       font-size: 0.78rem;
       font-weight: 700;
       letter-spacing: 0.12em;
       text-transform: uppercase;
-      padding: 0.75rem 0.35rem;
-      text-shadow: 0 1px 2px color-mix(in srgb, var(--card-border-color) 35%, transparent 65%);
+      padding: 0.75rem 0.4rem;
+      transition: color 0.2s ease;
     }
     .calendar-tool-calendarCard .fc-daygrid-day-number {
       font-weight: 600;
-      transition: color 0.2s ease;
+      border-radius: 999px;
+      padding: 0.15rem 0.45rem;
+      transition: color 0.2s ease, background-color 0.2s ease;
     }
     .calendar-tool-calendarCard .fc-theme-standard td,
     .calendar-tool-calendarCard .fc-theme-standard th {
       border-color: color-mix(in srgb, var(--card-border-color) 70%, transparent 30%);
     }
     .calendar-tool-calendarCard .fc-daygrid-day-events {
-      margin: 0.35rem 0.45rem 0.55rem 0.45rem;
+      margin: 0.35rem 0.5rem 0.6rem 0.5rem;
       display: flex;
       flex-direction: column;
-      gap: 0.45rem;
+      gap: 0.55rem;
     }
     .calendar-tool-calendarCard .fc .fc-daygrid-event {
       margin: 0;
     }
     .calendar-tool-calendarCard .fc-daygrid-day-frame {
       position: relative;
-      border-radius: 14px;
-      padding: 0.55rem 0.5rem 0.75rem 0.5rem;
+      border-radius: 16px;
+      padding: 0.6rem 0.55rem 0.8rem 0.55rem;
       background: color-mix(in srgb, var(--card-bg-color) 94%, transparent 6%);
-      transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
-      border: 1px solid transparent;
+      border: 1px solid color-mix(in srgb, var(--card-border-color) 60%, transparent 40%);
+      transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
     }
     .calendar-tool-calendarCard .fc-daygrid-day:hover .fc-daygrid-day-frame {
-      box-shadow: 0 12px 28px rgba(15, 23, 42, 0.15);
+      box-shadow: 0 14px 32px rgba(15, 23, 42, 0.18);
     }
     .calendar-day-indicator {
       display: inline-flex;
       align-items: center;
-      gap: 4px;
-      padding-inline-start: 0.35rem;
+      gap: 6px;
+      padding-inline-start: 0.4rem;
     }
     .calendar-day-indicatorChip {
-      width: 8px;
-      height: 8px;
+      width: 10px;
+      height: 10px;
       border-radius: 999px;
-      box-shadow: 0 0 0 1px color-mix(in srgb, var(--card-bg-color) 70%, transparent 30%);
+      box-shadow: 0 0 0 1px color-mix(in srgb, var(--card-bg-color) 65%, transparent 35%);
     }
     .calendar-event {
       position: relative;
       display: flex;
       flex-direction: column;
-      gap: 0.4rem;
+      gap: 0.45rem;
       box-sizing: border-box;
-      padding: 0.65rem 0.85rem 0.75rem 0.95rem;
-      border-radius: 14px;
-      border: 1px solid transparent;
-      background: color-mix(in srgb, var(--card-bg-color) 92%, transparent 8%);
-      color: var(--card-fg-color);
-      box-shadow: 0 10px 28px rgba(15, 23, 42, 0.18);
-      transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+      padding: 0.75rem 1rem 0.9rem 1.15rem;
+      border-radius: 16px;
+      border: 1px solid var(--calendar-event-outline, color-mix(in srgb, var(--card-border-color) 68%, transparent 32%));
+      background: var(--calendar-event-fill, color-mix(in srgb, var(--card-bg-color) 90%, transparent 10%));
+      color: var(--calendar-event-ink, var(--card-fg-color));
+      box-shadow: var(--calendar-event-shadow, ${DEFAULT_EVENT_SHADOW});
       cursor: pointer;
       min-height: 0;
       overflow: hidden;
       isolation: isolate;
+      transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+    }
+    .calendar-event::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 14px;
+      background: var(--calendar-event-sheen, linear-gradient(135deg, rgba(148, 163, 184, 0.18) 0%, rgba(148, 163, 184, 0.08) 100%));
+      pointer-events: none;
+      z-index: 0;
     }
     .calendar-event::after {
       content: '';
       position: absolute;
-      inset: 3px;
-      border-radius: 11px;
-      pointer-events: none;
-      border: 2px solid transparent;
-      box-shadow: none;
-      opacity: 0;
-      transition: opacity 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-    .calendar-event.calendar-event-selected::after {
-      opacity: 1;
-      border-color: var(--calendar-selected-color);
-      box-shadow: 0 0 0 3px color-mix(in srgb, var(--calendar-selected-color) 32%, transparent 68%);
+      top: 12px;
+      bottom: 12px;
+      left: 12px;
+      width: 6px;
+      border-radius: 999px;
+      background: var(--calendar-event-accent, var(--calendar-selected-color));
+      box-shadow: 0 0 14px color-mix(in srgb, var(--calendar-event-accent, var(--calendar-selected-color)) 42%, transparent 58%);
+      opacity: 0.9;
+      z-index: 1;
     }
     .calendar-event:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 32px rgba(15, 23, 42, 0.22);
+      transform: translateY(-1px);
+      box-shadow: var(--calendar-event-hover-shadow, 0 24px 42px rgba(15, 23, 42, 0.22));
     }
     .calendar-event:active {
+      transform: translateY(0);
+    }
+    .calendar-event[data-calendar-selected='true'] {
       transform: translateY(-1px);
     }
+    .calendar-event[data-calendar-selected='true']::after {
+      opacity: 1;
+      box-shadow: 0 0 18px color-mix(in srgb, var(--calendar-event-accent, var(--calendar-selected-color)) 55%, transparent 45%);
+    }
     .calendar-event-content {
+      position: relative;
+      z-index: 2;
       display: flex;
       flex-direction: column;
       gap: 0.35rem;
-      font-size: 0.9rem;
-      line-height: 1.36;
+      font-size: 0.92rem;
+      line-height: 1.4;
       pointer-events: none;
       min-height: 0;
     }
     .calendar-event-statusIndicator {
-      width: 0.65rem;
-      height: 0.65rem;
+      width: 0.72rem;
+      height: 0.72rem;
       border-radius: 999px;
-      border: 2px solid transparent;
-      background: rgba(255, 255, 255, 0.22);
-      box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.18);
+      background: var(--calendar-event-indicator, rgba(148, 163, 184, 0.85));
+      border: 1px solid color-mix(in srgb, var(--calendar-event-indicator, rgba(148, 163, 184, 0.85)) 65%, transparent 35%);
+      box-shadow: 0 0 0 5px color-mix(in srgb, var(--calendar-event-indicator, rgba(148, 163, 184, 0.85)) 22%, transparent 78%);
       flex-shrink: 0;
     }
     .calendar-event-time {
-      font-size: 0.8rem;
+      font-size: 0.75rem;
       font-weight: 600;
-      letter-spacing: 0.02em;
+      letter-spacing: 0.04em;
       text-transform: uppercase;
-      color: var(--card-muted-fg-color);
+      color: var(--calendar-event-time, color-mix(in srgb, var(--calendar-event-ink, var(--card-fg-color)) 70%, transparent 30%));
     }
     .calendar-event-metaRow {
       display: flex;
@@ -1130,24 +1166,37 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     .calendar-event-note[data-calendar-overflow='true'] {
       white-space: nowrap;
     }
-    .calendar-event-selected {
-      transform: translateY(-2px);
-    }
     .calendar-event-listItem {
       display: flex;
       flex-direction: column;
       gap: 0.35rem;
-      padding: 0.8rem;
-      border-radius: 12px;
-      border: 1px solid transparent;
+      padding: 0.9rem 1rem;
+      border-radius: 14px;
+      border: 1px solid color-mix(in srgb, var(--card-border-color) 65%, transparent 35%);
       background: color-mix(in srgb, var(--card-bg-color) 92%, transparent 8%);
       box-shadow: 0 10px 26px rgba(15, 23, 42, 0.18);
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
     }
-    .calendar-event-listItem[data-calendar-source='internal'] {
-      border-left: 4px solid var(--calendar-internal-color);
+    .calendar-event-listItem::before {
+      content: '';
+      position: absolute;
+      top: 10px;
+      bottom: 10px;
+      left: 10px;
+      width: 4px;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--card-border-color) 75%, transparent 25%);
+      box-shadow: 0 0 8px rgba(15, 23, 42, 0.25);
     }
-    .calendar-event-listItem[data-calendar-source='public'] {
-      border-left: 4px solid var(--calendar-public-color);
+    .calendar-event-listItem[data-calendar-source='internal']::before {
+      background: var(--calendar-internal-color);
+      box-shadow: 0 0 14px color-mix(in srgb, var(--calendar-internal-color) 48%, transparent 52%);
+    }
+    .calendar-event-listItem[data-calendar-source='public']::before {
+      background: var(--calendar-public-color);
+      box-shadow: 0 0 14px color-mix(in srgb, var(--calendar-public-color) 48%, transparent 52%);
     }
     .calendar-event-listItemTitle[data-calendar-overflow='true'] {
       display: -webkit-box;
@@ -1157,7 +1206,7 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
     .calendar-slot-label {
       font-size: 0.75rem;
       font-weight: 600;
-      color: var(--card-muted-fg-color);
+      color: color-mix(in srgb, var(--card-muted-fg-color) 80%, var(--card-fg-color) 20%);
     }
     .fc .fc-timegrid-slot-label-cushion {
       padding: 0.25rem 0.5rem;
@@ -1318,92 +1367,136 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
   const applyEventVisualState = useCallback(
     (element: HTMLElement, meta: EventStatusMeta | undefined, isSelected: boolean) => {
       const accent = meta?.accent
-      const accentPrimary = accent?.primary || ''
-      const fallbackColor = meta?.sourceColor || ''
-      const baseColor = accentPrimary || fallbackColor
-      if (accent) {
-        const gradient = `linear-gradient(135deg, ${
-          tintColor(accent.primary, 0.32) || accent.surface
-        } 0%, ${tintColor(accent.primary, 0.12) || accent.surfaceSoft} 100%)`
-        element.style.background = gradient
-        element.style.borderColor = tintColor(accent.primary, 0.55) || accent.border
-        element.style.color = accent.text
-      } else if (baseColor) {
-        element.style.background = `linear-gradient(135deg, ${mixColor(baseColor, 0.28)} 0%, ${mixColor(
-          baseColor,
-          0.08,
-          'var(--card-bg-color)',
-        )} 100%)`
-        element.style.borderColor = mixColor(baseColor, 0.48, 'transparent')
-        element.style.color = ''
+      const fallbackColor = (meta?.sourceColor || '').trim()
+      const accentPrimary = (accent?.primary || '').trim()
+      const baseColor = accentPrimary || fallbackColor || 'rgba(148, 163, 184, 0.85)'
+      const baseFill = accent ? accent.surface : mixColor(baseColor, 0.18, 'var(--card-bg-color)')
+      const sheen = accent
+        ? `linear-gradient(135deg, ${
+            tintColor(accent.primary, 0.4) || accent.surface
+          } 0%, ${tintColor(accent.primary, 0.16) || accent.surfaceSoft} 100%)`
+        : `linear-gradient(135deg, ${mixColor(baseColor, 0.32, 'transparent')} 0%, ${mixColor(
+            baseColor,
+            0.12,
+            'transparent',
+          )} 100%)`
+      const outline = accent ? accent.border : mixColor(baseColor, 0.52, 'transparent')
+      const glow = accent ? accent.halo : mixColor(baseColor, 0.35, 'rgba(15, 23, 42, 0.35)')
+      const indicator = accent ? accent.indicator : mixColor(baseColor, 0.76, '#ffffff')
+      const baseShadow = accent
+        ? `0 20px 36px ${tintColor(accent.primary, 0.4) || accent.halo}`
+        : fallbackColor
+        ? `0 18px 34px ${mixColor(baseColor, 0.24, 'rgba(15, 23, 42, 0.28)')}`
+        : DEFAULT_EVENT_SHADOW
+      const hoverShadow = accent
+        ? `0 26px 46px ${tintColor(accent.primary, 0.48) || accent.halo}`
+        : `0 24px 40px ${mixColor(baseColor, 0.26, 'rgba(15, 23, 42, 0.28)')}`
+      const textColor = accent?.text || ''
+      const timeColor = accent
+        ? tintColor(accent.primary, 0.92) || accent.primary
+        : mixColor(baseColor, 0.7, 'var(--card-muted-fg-color)')
+
+      element.style.background = ''
+      element.style.borderColor = ''
+      element.style.color = ''
+      element.style.boxShadow = ''
+      element.style.transform = ''
+
+      element.style.setProperty('--calendar-event-accent', baseColor)
+      element.style.setProperty('--calendar-event-fill', baseFill)
+      element.style.setProperty('--calendar-event-sheen', sheen)
+      element.style.setProperty('--calendar-event-outline', outline)
+      element.style.setProperty('--calendar-event-glow', glow)
+      element.style.setProperty('--calendar-event-shadow', baseShadow)
+      element.style.setProperty('--calendar-event-hover-shadow', hoverShadow)
+      element.style.setProperty('--calendar-event-indicator', indicator)
+
+      if (textColor) {
+        element.style.setProperty('--calendar-event-ink', textColor)
       } else {
-        element.style.background = `color-mix(in srgb, var(--card-bg-color) 92%, transparent 8%)`
-        element.style.borderColor = 'transparent'
-        element.style.color = ''
+        element.style.removeProperty('--calendar-event-ink')
       }
-      const boxShadows: string[] = []
-      if (baseColor) {
-        const accentEdge = accentPrimary
-          ? tintColor(accentPrimary, 0.95) || accentPrimary
-          : mixColor(baseColor, 0.78)
-        boxShadows.push(`inset 4px 0 0 0 ${accentEdge}`)
-      }
-      if (accent) {
-        boxShadows.push(`0 14px 32px ${tintColor(accent.primary, 0.46) || accent.halo}`)
-      } else if (baseColor) {
-        boxShadows.push(`0 14px 30px ${mixColor(baseColor, 0.24, 'rgba(15, 23, 42, 0.28)')}`)
+
+      if (timeColor) {
+        element.style.setProperty('--calendar-event-time', timeColor)
       } else {
-        boxShadows.push(DEFAULT_EVENT_SHADOW)
+        element.style.removeProperty('--calendar-event-time')
       }
-      element.style.boxShadow = boxShadows.join(', ')
-      element.style.transform = isSelected ? 'translateY(-2px)' : ''
-      if (isSelected) {
-        element.classList.add('calendar-event-selected')
-        element.setAttribute('aria-current', 'true')
-        element.setAttribute('data-calendar-selected', 'true')
-      } else {
-        element.classList.remove('calendar-event-selected')
-        element.removeAttribute('aria-current')
-        element.removeAttribute('data-calendar-selected')
-      }
+
       if (meta?.status) {
         element.setAttribute('data-calendar-status', meta.status)
       } else {
         element.removeAttribute('data-calendar-status')
       }
+
       const statusIndicator = element.querySelector<HTMLElement>('.calendar-event-statusIndicator')
       if (statusIndicator) {
-        if (accent) {
-          statusIndicator.style.background = tintColor(accent.primary, 0.3) || accent.surfaceSoft
-          statusIndicator.style.borderColor = tintColor(accent.primary, 0.58) || accent.border
-          statusIndicator.style.boxShadow = `0 0 0 4px ${
-            tintColor(accent.primary, 0.2) || accent.surfaceSoft
-          }`
-        } else if (baseColor) {
-          statusIndicator.style.background = mixColor(baseColor, 0.32)
-          statusIndicator.style.borderColor = mixColor(baseColor, 0.6, 'transparent')
-          statusIndicator.style.boxShadow = `0 0 0 4px ${mixColor(baseColor, 0.18)}`
-        } else {
-          statusIndicator.style.background = 'rgba(148, 163, 184, 0.45)'
-          statusIndicator.style.borderColor = 'rgba(148, 163, 184, 0.75)'
-          statusIndicator.style.boxShadow = '0 0 0 2px rgba(15, 23, 42, 0.28)'
-        }
+        statusIndicator.style.background = ''
+        statusIndicator.style.borderColor = ''
+        statusIndicator.style.boxShadow = ''
       }
       const timeEl = element.querySelector<HTMLElement>('.calendar-event-time')
       if (timeEl) {
-        if (accent) {
-          timeEl.style.color = tintColor(accent.primary, 0.92) || accent.primary
-        } else if (baseColor) {
-          timeEl.style.color = mixColor(baseColor, 0.7, 'var(--card-muted-fg-color)')
-        } else {
-          timeEl.style.color = ''
-        }
+        timeEl.style.color = ''
+      }
+
+      if (isSelected) {
+        element.classList.add('calendar-event-selected')
+        element.setAttribute('aria-current', 'true')
+        element.setAttribute('data-calendar-selected', 'true')
+        element.style.setProperty('--calendar-event-accent', EVENT_SELECTION_COLOR)
+        element.style.setProperty('--calendar-event-indicator', EVENT_SELECTION_COLOR)
+        element.style.setProperty(
+          '--calendar-event-fill',
+          `color-mix(in oklab, ${EVENT_SELECTION_COLOR} 28%, var(--card-bg-color) 72%)`,
+        )
+        element.style.setProperty(
+          '--calendar-event-sheen',
+          `linear-gradient(135deg, ${tintColor(EVENT_SELECTION_COLOR, 0.5)} 0%, ${tintColor(
+            EVENT_SELECTION_COLOR,
+            0.2,
+          )} 100%)`,
+        )
+        element.style.setProperty('--calendar-event-outline', EVENT_SELECTION_COLOR)
+        element.style.setProperty(
+          '--calendar-event-glow',
+          tintColor(EVENT_SELECTION_COLOR, 0.45) || EVENT_SELECTION_TINT,
+        )
+        element.style.setProperty(
+          '--calendar-event-shadow',
+          `0 26px 48px ${tintColor(EVENT_SELECTION_COLOR, 0.4) || EVENT_SELECTION_TINT}`,
+        )
+        element.style.setProperty(
+          '--calendar-event-hover-shadow',
+          `0 30px 54px ${tintColor(EVENT_SELECTION_COLOR, 0.5) || EVENT_SELECTION_TINT}`,
+        )
+        element.style.setProperty('--calendar-event-ink', '#f8fafc')
+        element.style.setProperty('--calendar-event-time', '#e2e8f0')
+      } else {
+        element.classList.remove('calendar-event-selected')
+        element.removeAttribute('aria-current')
+        element.removeAttribute('data-calendar-selected')
       }
     },
     [],
   )
 
   const clearEventVisualState = useCallback((element: HTMLElement) => {
+    const customProps = [
+      '--calendar-event-accent',
+      '--calendar-event-fill',
+      '--calendar-event-sheen',
+      '--calendar-event-outline',
+      '--calendar-event-ink',
+      '--calendar-event-glow',
+      '--calendar-event-shadow',
+      '--calendar-event-hover-shadow',
+      '--calendar-event-indicator',
+      '--calendar-event-time',
+    ]
+    customProps.forEach((prop) => {
+      element.style.removeProperty(prop)
+    })
     element.style.background = ''
     element.style.borderColor = ''
     element.style.color = ''
@@ -1460,22 +1553,25 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
           if (gradient) {
             frame.style.background = gradient
           }
-          frame.style.borderColor = tintColor(colors[0], 0.45) || colors[0]
-          frame.style.boxShadow = `inset 0 0 0 1px ${tintColor(colors[0], 0.25) || colors[0]}`
+          const accentColor = colors[0]
+          frame.style.borderColor = tintColor(accentColor, 0.58) || accentColor
+          frame.style.boxShadow = `inset 0 0 0 1px ${
+            tintColor(accentColor, 0.32) || accentColor
+          }, 0 12px 26px ${tintColor(accentColor, 0.24) || 'rgba(15, 23, 42, 0.22)'}`
         } else {
           frame.style.background = ''
-          frame.style.borderColor = ''
+          frame.style.borderColor = 'color-mix(in srgb, var(--card-border-color) 62%, transparent 38%)'
           frame.style.boxShadow = ''
         }
         if (isSelected) {
           frame.style.background = `linear-gradient(135deg, ${tintColor(
             EVENT_SELECTION_COLOR,
-            0.22,
-          )} 0%, ${tintColor(EVENT_SELECTION_COLOR, 0.08)} 100%)`
+            0.28,
+          )} 0%, ${tintColor(EVENT_SELECTION_COLOR, 0.12)} 100%)`
           frame.style.borderColor = EVENT_SELECTION_COLOR
-          frame.style.boxShadow = `inset 0 0 0 2px ${EVENT_SELECTION_COLOR}, 0 12px 28px ${tintColor(
+          frame.style.boxShadow = `inset 0 0 0 2px ${EVENT_SELECTION_COLOR}, 0 18px 36px ${tintColor(
             EVENT_SELECTION_COLOR,
-            0.35,
+            0.32,
           )}`
         }
       }
@@ -1531,29 +1627,25 @@ function CalendarSyncToolComponent(props: CalendarSyncToolOptions) {
     const scheme = resolveColorScheme(element)
     if (scheme === 'dark') {
       element.style.background =
-        'color-mix(in oklab, rgba(15, 23, 42, 0.92) 72%, var(--card-bg-color) 28%)'
-      element.style.borderBottom =
-        '1px solid color-mix(in oklab, rgba(15, 23, 42, 0.78) 58%, transparent 42%)'
-      element.style.boxShadow =
-        'inset 0 -1px 0 color-mix(in oklab, rgba(15, 23, 42, 0.88) 36%, transparent 64%)'
-      element.style.color = 'rgba(241, 245, 249, 0.94)'
+        'linear-gradient(180deg, rgba(12, 20, 38, 0.98) 0%, rgba(17, 24, 39, 0.88) 100%)'
+      element.style.borderBottom = '1px solid rgba(94, 114, 140, 0.55)'
+      element.style.boxShadow = 'inset 0 -1px 0 rgba(8, 13, 26, 0.7)'
+      element.style.color = 'rgba(241, 245, 249, 0.98)'
     } else {
       element.style.background =
-        'color-mix(in oklab, var(--card-bg-color) 75%, rgba(226, 232, 240, 0.94) 25%)'
-      element.style.borderBottom =
-        '1px solid color-mix(in oklab, rgba(148, 163, 184, 0.7) 55%, transparent 45%)'
-      element.style.boxShadow =
-        'inset 0 -1px 0 color-mix(in oklab, rgba(148, 163, 184, 0.5) 35%, transparent 65%)'
+        'linear-gradient(180deg, rgba(248, 250, 252, 0.96) 0%, rgba(226, 232, 240, 0.78) 100%)'
+      element.style.borderBottom = '1px solid rgba(148, 163, 184, 0.48)'
+      element.style.boxShadow = 'inset 0 -1px 0 rgba(203, 213, 225, 0.6)'
       element.style.color = 'rgba(30, 41, 59, 0.9)'
     }
     const cushion = element.querySelector<HTMLElement>('.fc-col-header-cell-cushion')
     if (cushion) {
       if (scheme === 'dark') {
-        cushion.style.color = 'rgba(241, 245, 249, 0.96)'
-        cushion.style.textShadow = '0 1px 2px rgba(15, 23, 42, 0.9)'
+        cushion.style.color = 'rgba(248, 250, 252, 0.98)'
+        cushion.style.textShadow = '0 2px 10px rgba(8, 13, 26, 0.85)'
       } else {
-        cushion.style.color = 'rgba(30, 41, 59, 0.9)'
-        cushion.style.textShadow = '0 1px 1px rgba(255, 255, 255, 0.85)'
+        cushion.style.color = 'rgba(17, 24, 39, 0.88)'
+        cushion.style.textShadow = '0 1px 1px rgba(255, 255, 255, 0.9)'
       }
     }
   }, [])

--- a/sanity/plugins/calendarSyncTool/index.tsx
+++ b/sanity/plugins/calendarSyncTool/index.tsx
@@ -1002,9 +1002,6 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       flex-direction: column;
       gap: 0.45rem;
     }
-    .calendar-tool-calendarCard .fc .fc-daygrid-event-harness {
-      display: contents;
-    }
     .calendar-tool-calendarCard .fc .fc-daygrid-event {
       margin: 0;
     }
@@ -1036,6 +1033,7 @@ function buildCustomCalendarStyles(internalColor: string, publicColor: string) {
       display: flex;
       flex-direction: column;
       gap: 0.4rem;
+      box-sizing: border-box;
       padding: 0.65rem 0.85rem 0.75rem 0.95rem;
       border-radius: 14px;
       border: 1px solid transparent;


### PR DESCRIPTION
## Summary
- restyle the calendar tool header and toolbar for better contrast in dark mode
- introduce badge-driven status accents with new CSS variables and per-event metadata
- render status pills in calendar events and highlight the selected event and day cell more prominently

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf14a2a7a8832c977e1e247502a7a9