### PR TITLE
Default event detail palette and subscribe button handling

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -38,6 +38,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
   const colorMap: Record<string, string> = {
     purple: "rgb(92,48,166)",
+    purpleLt: "rgb(177,156,217)",
     gold: "rgb(214,175,54)",
     ink: "rgb(18,18,18)",
     white: "rgb(255,255,255)",
@@ -86,7 +87,8 @@ export default async function Page({ params }: { params: { slug: string } }) {
     !!s && s._type === "subscriptionSection";
 
   const subscription = detail.sections?.find(isSubscriptionSection);
-  const subscribeUrl = subscription?.showSubscribe !== false ? calendar?.htmlLink : undefined;
+  const subscribeUrl =
+    subscription && subscription.showSubscribe !== false ? calendar?.htmlLink : undefined;
 
   return (
     <>

--- a/sanity/components/EventPreviewPane.tsx
+++ b/sanity/components/EventPreviewPane.tsx
@@ -18,6 +18,7 @@ interface EventDetail {
 
 const colorMap: Record<string, string> = {
   purple: 'rgb(92,48,166)',
+  purpleLt: 'rgb(177,156,217)',
   gold: 'rgb(214,175,54)',
   ink: 'rgb(18,18,18)',
   white: 'rgb(255,255,255)',
@@ -109,7 +110,7 @@ export default function EventPreviewPane({document}: Props) {
 
   const hasHero = Array.isArray(data.sections) && data.sections.some(s => s._type === 'heroSection')
   const subscription = data.sections?.find(s => s._type === 'subscriptionSection')
-  const showSubscribe = subscription?.showSubscribe !== false
+  const showSubscribe = subscription ? subscription.showSubscribe !== false : false
 
   return (
     <div style={{display:'flex', flexDirection:'column', height:'100%'}}>

--- a/sanity/schemas/eventDetail.ts
+++ b/sanity/schemas/eventDetail.ts
@@ -36,6 +36,10 @@ export default defineType({
       name: 'palette',
       title: 'Palette',
       type: 'object',
+      initialValue: {
+        light: { primary: 'purple', accent: 'gold', contrast: 'white' },
+        dark: { primary: 'purpleLt', accent: 'gold', contrast: 'gold' },
+      },
       fields: [
         defineField({
           name: 'light',

--- a/sanity/schemas/eventDetail.ts
+++ b/sanity/schemas/eventDetail.ts
@@ -1,6 +1,47 @@
 import { defineType, defineField } from 'sanity';
 import CalendarEventIdInput from '../components/CalendarEventIdInput';
 
+const lightPrimaryOptions = [
+  { title: 'Purple', value: 'purple' },
+  { title: 'Gold', value: 'gold' },
+  { title: 'White', value: 'white' },
+];
+
+const lightAccentOptions = [
+  { title: 'Gold', value: 'gold' },
+  { title: 'Purple', value: 'purple' },
+  { title: 'Purple Light', value: 'purpleLt' },
+  { title: 'Ink (Dark Text)', value: 'ink' },
+  { title: 'White', value: 'white' },
+];
+
+const lightContrastOptions = [
+  { title: 'Ink (Dark Text)', value: 'ink' },
+  { title: 'White', value: 'white' },
+  { title: 'Purple', value: 'purple' },
+];
+
+const darkPrimaryOptions = [
+  { title: 'Purple', value: 'purple' },
+  { title: 'Purple Light', value: 'purpleLt' },
+  { title: 'Black', value: 'black' },
+  { title: 'Gray', value: 'gray' },
+  { title: 'Dark Red', value: 'darkred' },
+];
+
+const darkAccentOptions = [
+  { title: 'Gold', value: 'gold' },
+  { title: 'Purple', value: 'purple' },
+  { title: 'Purple Light', value: 'purpleLt' },
+  { title: 'White', value: 'white' },
+];
+
+const darkContrastOptions = [
+  { title: 'Gold', value: 'gold' },
+  { title: 'White', value: 'white' },
+  { title: 'Purple Light', value: 'purpleLt' },
+];
+
 export default defineType({
   name: 'eventDetail',
   title: 'Event Detail',
@@ -46,9 +87,24 @@ export default defineType({
           title: 'Light Mode',
           type: 'object',
           fields: [
-            { name: 'primary', type: 'string' },
-            { name: 'accent', type: 'string' },
-            { name: 'contrast', type: 'string' },
+            defineField({
+              name: 'primary',
+              title: 'Primary',
+              type: 'string',
+              options: { list: lightPrimaryOptions },
+            }),
+            defineField({
+              name: 'accent',
+              title: 'Accent',
+              type: 'string',
+              options: { list: lightAccentOptions },
+            }),
+            defineField({
+              name: 'contrast',
+              title: 'Contrast',
+              type: 'string',
+              options: { list: lightContrastOptions },
+            }),
           ],
         }),
         defineField({
@@ -56,9 +112,24 @@ export default defineType({
           title: 'Dark Mode',
           type: 'object',
           fields: [
-            { name: 'primary', type: 'string' },
-            { name: 'accent', type: 'string' },
-            { name: 'contrast', type: 'string' },
+            defineField({
+              name: 'primary',
+              title: 'Primary',
+              type: 'string',
+              options: { list: darkPrimaryOptions },
+            }),
+            defineField({
+              name: 'accent',
+              title: 'Accent',
+              type: 'string',
+              options: { list: darkAccentOptions },
+            }),
+            defineField({
+              name: 'contrast',
+              title: 'Contrast',
+              type: 'string',
+              options: { list: darkContrastOptions },
+            }),
           ],
         }),
       ],


### PR DESCRIPTION
## Summary
- default the event detail palette fields to the site's purple and gold theme in Sanity
- add support for the purpleLt token in event detail rendering and previews
- only expose the subscribe button when a subscription section is present

## Testing
- npm run lint *(warnings only from existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf64c9929c832cbe340a0da6cee781