### PR TITLE
Rename event slug field to Event URL

### DIFF
--- a/sanity/components/EventPreviewPane.tsx
+++ b/sanity/components/EventPreviewPane.tsx
@@ -74,7 +74,13 @@ export default function EventPreviewPane({document}: Props) {
     return () => { ignore = true; sub.unsubscribe() }
   }, [client, slug])
 
-  if (!slug) return <p style={{padding:16, textAlign:'center'}}>Enter a slug to see a preview.</p>
+  if (!slug) {
+    return (
+      <p style={{padding:16, textAlign:'center'}}>
+        Enter an event URL to see a preview.
+      </p>
+    )
+  }
   if (!data) return <p style={{padding:16, textAlign:'center'}}>Loading…</p>
 
   const sel = pickPalette(data.palette, theme)

--- a/sanity/schemas/eventDetail.ts
+++ b/sanity/schemas/eventDetail.ts
@@ -13,8 +13,9 @@ export default defineType({
     }),
     defineField({
       name: 'slug',
-      title: 'Slug',
+      title: 'Event URL',
       type: 'slug',
+      description: 'This controls the URL path for the event page.',
       options: {
         source: 'title',
         maxLength: 96,


### PR DESCRIPTION
## Summary
- rename the Event Detail slug field to display as "Event URL" and clarify its purpose
- update the preview pane message to prompt for the Event URL instead of a slug

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6447004c832cbef82024295fe521