### PR TITLE
Add interactive FAQ experience

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -14,8 +14,8 @@ export default async function FaqPage() {
   ]);
 
   const events = rawEvents.map((event) => {
-    const link = detailLinks.find((detail) => detail.calendarEventId === event.id);
-    const href = link ? `/events/${link.slug}` : event.htmlLink;
+    const detailLink = detailLinks.find((detail) => detail.calendarEventId === event.id);
+    const href = detailLink ? `/events/${detailLink.slug}` : "/events";
     const formattedDate = new Date(event.start).toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
@@ -25,7 +25,7 @@ export default async function FaqPage() {
       id: event.id,
       title: event.title,
       dateLabel: formattedDate,
-      href: href ?? undefined,
+      href,
     };
   });
 
@@ -108,16 +108,12 @@ export default async function FaqPage() {
                         <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--brand-muted)]">
                           {event.dateLabel}
                         </span>
-                        {event.href ? (
-                          <Link
-                            href={event.href}
-                            className="text-sm font-medium underline decoration-[var(--brand-alt)] underline-offset-4 hover:opacity-85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]"
-                          >
-                            {event.title}
-                          </Link>
-                        ) : (
-                          <span className="text-sm font-medium">{event.title}</span>
-                        )}
+                        <Link
+                          href={event.href}
+                          className="text-sm font-medium underline decoration-[var(--brand-alt)] underline-offset-4 hover:opacity-85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]"
+                        >
+                          {event.title}
+                        </Link>
                       </div>
                     </li>
                   ))}

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,148 @@
+import Link from "next/link";
+import FaqAccordion from "@/components/FaqAccordion";
+import FaqAssistantChip from "@/components/FaqAssistantChip";
+import { faqsAll, eventDetailLinks } from "@/lib/queries";
+import { getUpcomingEvents } from "@/lib/googleCalendar";
+
+export const metadata = { title: "FAQ" };
+
+export default async function FaqPage() {
+  const [faqs, rawEvents, detailLinks] = await Promise.all([
+    faqsAll(),
+    getUpcomingEvents(4),
+    eventDetailLinks(),
+  ]);
+
+  const events = rawEvents.map((event) => {
+    const link = detailLinks.find((detail) => detail.calendarEventId === event.id);
+    const href = link ? `/events/${link.slug}` : event.htmlLink;
+    const formattedDate = new Date(event.start).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+    return {
+      id: event.id,
+      title: event.title,
+      dateLabel: formattedDate,
+      href: href ?? undefined,
+    };
+  });
+
+  const trending = faqs.filter((faq) => faq.isTrending).slice(0, 4);
+  const hasTrending = trending.length > 0;
+  const hasEvents = events.length > 0;
+
+  return (
+    <div className="space-y-12">
+      <header className="mx-auto max-w-3xl space-y-4 text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.35em] text-[var(--brand-muted)]">
+          Discover & Learn
+        </p>
+        <h1 className="text-3xl font-semibold text-[var(--brand-alt)] sm:text-4xl">
+          Frequently Asked Questions
+        </h1>
+        <p className="text-base text-[color:color-mix(in_oklab,var(--brand-alt)_85%,transparent)]">
+          Explore quick answers to the most common GPTWeb questions, and launch the assistant whenever you need a deeper dive.
+        </p>
+      </header>
+
+      {(hasTrending || hasEvents) && (
+        <section className="relative overflow-hidden rounded-3xl border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface)_85%,black_15%)] p-6 shadow-xl">
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute -top-16 -right-16 h-48 w-48 rounded-full bg-[color:color-mix(in_oklab,var(--brand-primary)_45%,transparent)] blur-3xl opacity-50"
+          />
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute -bottom-20 -left-12 h-44 w-44 rounded-full bg-[color:color-mix(in_oklab,var(--brand-accent)_45%,transparent)] blur-3xl opacity-40"
+          />
+          <div className="relative grid gap-6 md:grid-cols-2">
+            <div className="space-y-3">
+              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-[var(--brand-muted)]">
+                <span aria-hidden="true" className="text-xl">🔥</span>
+                Trending Questions
+              </div>
+              {hasTrending ? (
+                <ul className="space-y-3">
+                  {trending.map((faq) => {
+                    const prompt =
+                      faq.assistantPrompt?.trim() ||
+                      `I'd like more detail about the FAQ titled \"${faq.question}\".`;
+                    return (
+                      <li
+                        key={faq._id}
+                        className="flex items-center justify-between gap-4 rounded-2xl border border-[color:color-mix(in_oklab,var(--brand-border)_60%,transparent)] bg-[color:color-mix(in_oklab,var(--brand-primary)_25%,transparent)] px-4 py-3 shadow-sm backdrop-blur-sm"
+                      >
+                        <span className="flex-1 text-sm font-medium text-[var(--brand-alt)]/95">
+                          {faq.question}
+                        </span>
+                        <FaqAssistantChip
+                          prompt={prompt}
+                          label="Ask"
+                          className="px-3 py-1 text-xs"
+                        />
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <p className="rounded-2xl border border-dashed border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface)_92%,white_8%)] px-4 py-3 text-sm text-[var(--brand-alt)]/85">
+                  Check back soon for the most popular conversations people are starting with the assistant.
+                </p>
+              )}
+            </div>
+            <div className="space-y-3">
+              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-[var(--brand-muted)]">
+                <span aria-hidden="true" className="text-xl">📅</span>
+                Upcoming Events
+              </div>
+              {hasEvents ? (
+                <ul className="space-y-3">
+                  {events.map((event) => (
+                    <li
+                      key={event.id}
+                      className="rounded-2xl border border-[color:color-mix(in_oklab,var(--brand-border)_60%,transparent)] bg-[color:color-mix(in_oklab,var(--brand-alt)_18%,var(--brand-surface)_82%)] px-4 py-3 shadow-sm"
+                    >
+                      <div className="flex flex-col gap-1 text-[var(--brand-alt)]/90">
+                        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--brand-muted)]">
+                          {event.dateLabel}
+                        </span>
+                        {event.href ? (
+                          <Link
+                            href={event.href}
+                            className="text-sm font-medium underline decoration-[var(--brand-alt)] underline-offset-4 hover:opacity-85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]"
+                          >
+                            {event.title}
+                          </Link>
+                        ) : (
+                          <span className="text-sm font-medium">{event.title}</span>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="rounded-2xl border border-dashed border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface)_92%,white_8%)] px-4 py-3 text-sm text-[var(--brand-alt)]/85">
+                  No upcoming events are on the calendar yet, but our assistant is happy to help you plan ahead.
+                </p>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-6">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-muted)]">
+            Browse Answers
+          </p>
+          <p className="max-w-2xl text-sm text-[color:color-mix(in_oklab,var(--brand-alt)_80%,transparent)]">
+            Expand any card for guidance, resources, and quick ways to spin up a follow-up conversation with the assistant.
+          </p>
+        </div>
+        <FaqAccordion faqs={faqs} />
+      </section>
+    </div>
+  );
+}

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -74,6 +74,21 @@
     background-color: var(--brand-overlay-muted);
   }
 
+  .assistant-chip {
+    @apply inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-wide transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-surface)];
+    background-color: color-mix(in oklab, var(--brand-alt) 78%, var(--brand-primary) 22%);
+    color: var(--brand-ink);
+    border-color: color-mix(in oklab, var(--brand-border) 70%, transparent);
+    box-shadow:
+      0 6px 14px -10px color-mix(in oklab, var(--brand-primary) 65%, transparent),
+      0 0 0 1px color-mix(in oklab, var(--brand-border) 30%, transparent);
+  }
+
+  .assistant-chip:hover,
+  .assistant-chip:focus-visible {
+    transform: translateY(-1px) scale(1.03);
+  }
+
 }
 
 @layer utilities {
@@ -289,6 +304,51 @@
     will-change: box-shadow;
   }
 
+  @keyframes assistant-chip-glow {
+    0%,
+    100% {
+      box-shadow:
+        0 6px 14px -10px color-mix(in oklab, var(--brand-primary) 45%, transparent),
+        0 0 0 1px color-mix(in oklab, var(--brand-border) 28%, transparent);
+    }
+    50% {
+      box-shadow:
+        0 8px 24px -10px color-mix(in oklab, var(--brand-primary) 72%, transparent),
+        0 0 18px 4px color-mix(in oklab, var(--brand-accent) 45%, transparent);
+    }
+  }
+
+  @keyframes assistant-chip-rock {
+    0%,
+    100% {
+      transform: translateY(0) rotate(0deg);
+    }
+    20% {
+      transform: translateY(-1px) rotate(-2deg);
+    }
+    40% {
+      transform: translateY(1px) rotate(2deg);
+    }
+    60% {
+      transform: translateY(-1px) rotate(-1.5deg);
+    }
+    80% {
+      transform: translateY(1px) rotate(1deg);
+    }
+  }
+
+  .assistant-chip-animate {
+    animation:
+      assistant-chip-glow 4800ms ease-in-out infinite,
+      assistant-chip-rock 5200ms ease-in-out infinite;
+    will-change: transform, box-shadow;
+  }
+
+  .assistant-chip-animate:hover,
+  .assistant-chip-animate:focus-visible {
+    animation-play-state: paused;
+  }
+
   /* Shake nudge animation */
   @keyframes nudge-shake {
     0% { transform: translateX(0) rotate(0); }
@@ -412,7 +472,8 @@
     .shimmer-text,
     .shimmer-text-slow,
     .glow-text,
-    .glow-text-hover {
+    .glow-text-hover,
+    .assistant-chip-animate {
       animation: none;
       opacity: 1 !important;
       transform: none !important;

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -28,6 +28,8 @@ export default function Assistant() {
   const logRef = useRef<HTMLDivElement>(null);
   const baseBottom = 24;
   const [viewportOffset, setViewportOffset] = useState(0);
+  const openTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const ANIM_MS = 1000;
 
   useEffect(() => {
     const viewport = window.visualViewport;
@@ -57,7 +59,7 @@ export default function Assistant() {
     );
     const parts = text.split(regex).filter(Boolean);
     const accentLinkClass =
-      'underline text-[#f4f4f5] decoration-[#f4f4f5] hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f4f4f5]';
+      'underline text-[var(--brand-alt)] decoration-[var(--brand-alt)] hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]';
     return parts.map((part, idx) => {
       if (/^https?:\/\//.test(part)) {
         const trimmed = stripInvisibleCharacters(part);
@@ -142,10 +144,10 @@ export default function Assistant() {
     }, timeout);
   }, []);
 
-  function resetNudge() {
+  const resetNudge = useCallback(() => {
     setNudge(false);
     if (!openRef.current) scheduleNudge();
-  }
+  }, [scheduleNudge]);
 
   useEffect(() => {
     const id = setTimeout(() => {
@@ -239,7 +241,7 @@ export default function Assistant() {
     ]);
   }
 
-  function dock() {
+  const dock = useCallback(() => {
     const el = containerRef.current;
     const header = document.querySelector('header');
     if (!el || !header) return;
@@ -251,15 +253,58 @@ export default function Assistant() {
     setOffset({ x: targetX - rect.left, y: targetY - rect.top });
     setDocked(true);
     resetNudge();
-  }
+  }, [resetNudge]);
 
-  function undock() {
+  const undock = useCallback(() => {
     setOffset({ x: 0, y: 0 });
     setDocked(false);
     resetNudge();
-  }
+  }, [resetNudge]);
 
-  const ANIM_MS = 1000;
+  const openAssistant = useCallback(
+    (prompt?: string) => {
+      if (prompt !== undefined) {
+        setInput(prompt);
+      }
+      const doOpen = () => {
+        setOpen(true);
+      };
+      resetNudge();
+      if (openTimeoutRef.current) {
+        clearTimeout(openTimeoutRef.current);
+        openTimeoutRef.current = null;
+      }
+      if (docked) {
+        undock();
+        openTimeoutRef.current = setTimeout(() => {
+          doOpen();
+          openTimeoutRef.current = null;
+        }, ANIM_MS);
+      } else {
+        doOpen();
+      }
+    },
+    [docked, resetNudge, undock]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (openTimeoutRef.current) {
+        clearTimeout(openTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ prompt?: string }>).detail || {};
+      openAssistant(detail.prompt);
+    };
+    window.addEventListener('assistant:open', handler as EventListener);
+    return () => {
+      window.removeEventListener('assistant:open', handler as EventListener);
+    };
+  }, [openAssistant]);
 
   return (
     <div
@@ -323,7 +368,7 @@ export default function Assistant() {
                       <div className="mt-1 text-sm">
                         <button
                           type="button"
-                          className="underline text-[#f4f4f5] decoration-[#f4f4f5] hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-[#f4f4f5] cursor-pointer bg-transparent p-0 font-normal"
+                          className="underline text-[var(--brand-alt)] decoration-[var(--brand-alt)] hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-[var(--brand-alt)] cursor-pointer bg-transparent p-0 font-normal"
                           onClick={() => {
                             const pct = Math.max(
                               0,
@@ -500,15 +545,7 @@ export default function Assistant() {
         <button
           type="button"
           aria-label="Open assistant"
-          onClick={() => {
-            resetNudge();
-            if (docked) {
-              undock();
-              setTimeout(() => setOpen(true), ANIM_MS);
-            } else {
-              setOpen(true);
-            }
-          }}
+          onClick={() => openAssistant()}
           className={`flex h-14 w-14 items-center justify-center rounded-full shadow-lg cursor-pointer border hover:opacity-90 ${nudge ? 'animate-shake' : ''}`}
           style={{
             backgroundColor: 'var(--brand-accent)',

--- a/components/FaqAccordion.tsx
+++ b/components/FaqAccordion.tsx
@@ -40,14 +40,14 @@ const portableTextComponents: PortableTextComponents = {
     link: ({
       children,
       value,
-    }: PortableTextMarkComponentProps<{ href?: string }>) => {
+    }: PortableTextMarkComponentProps<{ _type: "link"; href?: string }>) => {
       const href = value?.href;
       const isExternal = href?.startsWith("http");
       if (!href) return <>{children}</>;
       return (
         <a
           href={href}
-          className="underline decoration-[var(--brand-alt)] underline-offset-2 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]"
+          className="underline decoration-[var(--brand-alt)] underline-offset-2 hover:opacity-80 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]"
           target={isExternal ? "_blank" : undefined}
           rel={isExternal ? "noreferrer" : undefined}
         >

--- a/components/FaqAccordion.tsx
+++ b/components/FaqAccordion.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { PortableText } from "@portabletext/react";
-import { type ReactNode, useMemo, useState } from "react";
+import type {
+  PortableTextComponents,
+  PortableTextMarkComponentProps,
+} from "@portabletext/react";
+import { useMemo, useState } from "react";
 import type { FaqItem } from "@/lib/queries";
 import FaqAssistantChip from "./FaqAssistantChip";
 
@@ -9,37 +13,34 @@ interface FaqAccordionProps {
   faqs: FaqItem[];
 }
 
-const portableTextComponents = {
+const portableTextComponents: PortableTextComponents = {
   block: {
-    normal: ({ children }: { children: ReactNode }) => (
+    normal: ({ children }) => (
       <p className="text-sm leading-relaxed text-[var(--brand-alt)]/90">{children}</p>
     ),
-    h4: ({ children }: { children: ReactNode }) => (
+    h4: ({ children }) => (
       <h4 className="text-base font-semibold text-[var(--brand-alt)]">{children}</h4>
     ),
   },
   list: {
-    bullet: ({ children }: { children: ReactNode }) => (
+    bullet: ({ children }) => (
       <ul className="ml-4 list-disc space-y-1 text-sm text-[var(--brand-alt)]/90">{children}</ul>
     ),
-    number: ({ children }: { children: ReactNode }) => (
+    number: ({ children }) => (
       <ol className="ml-4 list-decimal space-y-1 text-sm text-[var(--brand-alt)]/90">{children}</ol>
     ),
   },
   marks: {
-    strong: ({ children }: { children: ReactNode }) => (
+    strong: ({ children }) => (
       <strong className="font-semibold text-[var(--brand-alt)]">{children}</strong>
     ),
-    em: ({ children }: { children: ReactNode }) => (
+    em: ({ children }) => (
       <em className="italic text-[var(--brand-alt)]/95">{children}</em>
     ),
     link: ({
       children,
       value,
-    }: {
-      children: ReactNode;
-      value: { href?: string };
-    }) => {
+    }: PortableTextMarkComponentProps<{ href?: string }>) => {
       const href = value?.href;
       const isExternal = href?.startsWith("http");
       if (!href) return <>{children}</>;

--- a/components/FaqAccordion.tsx
+++ b/components/FaqAccordion.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { PortableText } from "@portabletext/react";
+import { type ReactNode, useMemo, useState } from "react";
+import type { FaqItem } from "@/lib/queries";
+import FaqAssistantChip from "./FaqAssistantChip";
+
+interface FaqAccordionProps {
+  faqs: FaqItem[];
+}
+
+const portableTextComponents = {
+  block: {
+    normal: ({ children }: { children: ReactNode }) => (
+      <p className="text-sm leading-relaxed text-[var(--brand-alt)]/90">{children}</p>
+    ),
+    h4: ({ children }: { children: ReactNode }) => (
+      <h4 className="text-base font-semibold text-[var(--brand-alt)]">{children}</h4>
+    ),
+  },
+  list: {
+    bullet: ({ children }: { children: ReactNode }) => (
+      <ul className="ml-4 list-disc space-y-1 text-sm text-[var(--brand-alt)]/90">{children}</ul>
+    ),
+    number: ({ children }: { children: ReactNode }) => (
+      <ol className="ml-4 list-decimal space-y-1 text-sm text-[var(--brand-alt)]/90">{children}</ol>
+    ),
+  },
+  marks: {
+    strong: ({ children }: { children: ReactNode }) => (
+      <strong className="font-semibold text-[var(--brand-alt)]">{children}</strong>
+    ),
+    em: ({ children }: { children: ReactNode }) => (
+      <em className="italic text-[var(--brand-alt)]/95">{children}</em>
+    ),
+    link: ({
+      children,
+      value,
+    }: {
+      children: ReactNode;
+      value: { href?: string };
+    }) => {
+      const href = value?.href;
+      const isExternal = href?.startsWith("http");
+      if (!href) return <>{children}</>;
+      return (
+        <a
+          href={href}
+          className="underline decoration-[var(--brand-alt)] underline-offset-2 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]"
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noreferrer" : undefined}
+        >
+          {children}
+        </a>
+      );
+    },
+  },
+};
+
+export default function FaqAccordion({ faqs }: FaqAccordionProps) {
+  const [openItems, setOpenItems] = useState<string[]>([]);
+
+  const groupedFaqs = useMemo(() => {
+    const groups = new Map<string, FaqItem[]>();
+    faqs.forEach((faq) => {
+      const key = faq.category?.trim() || "General";
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key)!.push(faq);
+    });
+    return Array.from(groups.entries());
+  }, [faqs]);
+
+  const toggle = (id: string) => {
+    setOpenItems((prev) =>
+      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
+    );
+  };
+
+  if (faqs.length === 0) {
+    return (
+      <div className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 text-center text-[var(--brand-alt)]">
+        We update our frequently asked questions often. Please check back soon.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      {groupedFaqs.map(([category, items]) => (
+        <section key={category} aria-labelledby={`faq-category-${category}`} className="space-y-4">
+          <div className="flex items-baseline justify-between gap-3">
+            <h2
+              id={`faq-category-${category}`}
+              className="text-xl font-semibold text-[var(--brand-alt)]"
+            >
+              {category}
+            </h2>
+            <span className="text-xs uppercase tracking-widest text-[var(--brand-muted)]">
+              {items.length} {items.length === 1 ? "topic" : "topics"}
+            </span>
+          </div>
+          <div className="space-y-4">
+            {items.map((faq) => {
+              const isOpen = openItems.includes(faq._id);
+              const contentId = `faq-answer-${faq._id}`;
+              const prompt =
+                faq.assistantPrompt?.trim() ||
+                `Can you help me with the FAQ titled \"${faq.question}\"?`;
+
+              return (
+                <article
+                  key={faq._id}
+                  className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-4 shadow-sm transition-transform duration-300 hover:translate-y-[-2px] hover:shadow-lg"
+                >
+                  <div className="flex flex-col gap-3">
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between gap-4 text-left"
+                      onClick={() => toggle(faq._id)}
+                      aria-expanded={isOpen}
+                      aria-controls={contentId}
+                    >
+                      <span className="text-base font-semibold text-[var(--brand-alt)]">
+                        {faq.question}
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        className={`transition-transform duration-300 ${
+                          isOpen ? "rotate-180" : "rotate-0"
+                        }`}
+                      >
+                        <svg
+                          className="h-5 w-5 text-[var(--brand-alt)]"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <span className="rounded-full bg-[color:color-mix(in_oklab,var(--brand-primary)_30%,transparent)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[var(--brand-alt)]/90">
+                        {category}
+                      </span>
+                      <FaqAssistantChip prompt={prompt} />
+                    </div>
+                  </div>
+                  <div
+                    id={contentId}
+                    className={`grid overflow-hidden transition-[grid-template-rows] duration-300 ease-out ${
+                      isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                    }`}
+                  >
+                    <div className="mt-3 space-y-3 overflow-hidden">
+                      <PortableText value={faq.answer} components={portableTextComponents} />
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/components/FaqAssistantChip.tsx
+++ b/components/FaqAssistantChip.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback } from "react";
+
+interface FaqAssistantChipProps {
+  prompt?: string;
+  label?: string;
+  className?: string;
+}
+
+const EVENT_NAME = "assistant:open";
+
+export default function FaqAssistantChip({
+  prompt,
+  label = "Ask the Assistant",
+  className = "",
+}: FaqAssistantChipProps) {
+  const handleClick = useCallback(() => {
+    const detail = prompt ? { prompt } : {};
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail }));
+    }
+  }, [prompt]);
+
+  return (
+    <button
+      type="button"
+      className={`assistant-chip assistant-chip-animate ${className}`.trim()}
+      onClick={handleClick}
+    >
+      <span aria-hidden="true" className="text-lg">💬</span>
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,8 +19,8 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
     { href: "/ministries", label: "Ministries" },
     { href: "/events", label: "Events" },
     { href: "/livestreams", label: "Livestreams" },
-    { href: "/faq", label: "FAQ" },
     { href: "/giving", label: "Giving" },
+    { href: "/faq", label: "FAQ" },
   ];
 
   const linkClasses = (active: boolean) =>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -15,13 +15,13 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
   const givingRef = useRef<HTMLAnchorElement>(null);
   const shouldNudgeGiving = useNudge(givingRef);
 
-  const nav: { href: string; label: string }[] = [
+  const primaryNav: { href: string; label: string }[] = [
     { href: "/ministries", label: "Ministries" },
     { href: "/events", label: "Events" },
     { href: "/livestreams", label: "Livestreams" },
     { href: "/giving", label: "Giving" },
-    { href: "/faq", label: "FAQ" },
   ];
+  const trailingNav: { href: string; label: string }[] = [{ href: "/faq", label: "FAQ" }];
 
   const linkClasses = (active: boolean) =>
     `${active ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)]`;
@@ -87,7 +87,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
             </div>
           </div>
 
-          {nav.map((item) => (
+          {primaryNav.map((item) => (
             <Link
               key={item.href}
               href={item.href}
@@ -141,6 +141,17 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
               </Link>
             </div>
           </div>
+
+          {trailingNav.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={linkClasses(pathname.startsWith(item.href))}
+              aria-current={pathname.startsWith(item.href) ? "page" : undefined}
+            >
+              {item.label}
+            </Link>
+          ))}
         </nav>
 
         <button
@@ -160,7 +171,11 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
         </button>
       </div>
 
-      <MobileMenu ref={mobileMenuRef} nav={nav} />
+      <MobileMenu
+        ref={mobileMenuRef}
+        primaryNav={primaryNav}
+        trailingNav={trailingNav}
+      />
     </header>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,6 +19,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
     { href: "/ministries", label: "Ministries" },
     { href: "/events", label: "Events" },
     { href: "/livestreams", label: "Livestreams" },
+    { href: "/faq", label: "FAQ" },
     { href: "/giving", label: "Giving" },
   ];
 

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -16,7 +16,8 @@ export type MobileMenuHandle = {
 };
 
 interface MobileMenuProps {
-  nav: NavItem[];
+  primaryNav: NavItem[];
+  trailingNav: NavItem[];
 }
 
 function linkClasses(active: boolean) {
@@ -24,7 +25,7 @@ function linkClasses(active: boolean) {
 }
 
 
-function MobileMenuInner({ nav }: MobileMenuProps, ref: React.Ref<MobileMenuHandle>) {
+function MobileMenuInner({ primaryNav, trailingNav }: MobileMenuProps, ref: React.Ref<MobileMenuHandle>) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
 
@@ -135,7 +136,7 @@ function MobileMenuInner({ nav }: MobileMenuProps, ref: React.Ref<MobileMenuHand
                     </div>
                   )}
                 </Disclosure>
-                {nav.map((item) => (
+                {primaryNav.map((item) => (
                   <Link
                     key={item.href}
                     href={item.href}
@@ -197,6 +198,18 @@ function MobileMenuInner({ nav }: MobileMenuProps, ref: React.Ref<MobileMenuHand
                     </div>
                   )}
                 </Disclosure>
+
+                {trailingNav.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={linkClasses(pathname.startsWith(item.href))}
+                    aria-current={pathname.startsWith(item.href) ? "page" : undefined}
+                    onClick={handleClose}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
               </nav>
             </Dialog.Panel>
           </Transition.Child>

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,4 +1,5 @@
 import groq from 'groq';
+import type {PortableTextBlock} from 'sanity';
 import {sanity} from './sanity';
 
 export interface HeroSlide {
@@ -146,6 +147,29 @@ export const missionStatement = () =>
       tagline,
       "backgroundImage": backgroundImage.asset->url,
       message
+    }`
+  );
+
+export interface FaqItem {
+  _id: string;
+  question: string;
+  answer: PortableTextBlock[];
+  category?: string;
+  position?: number;
+  isTrending?: boolean;
+  assistantPrompt?: string;
+}
+
+export const faqsAll = () =>
+  sanity.fetch<FaqItem[]>(
+    groq`*[_type == "faq"] | order(coalesce(position, 9999) asc, question asc){
+      _id,
+      question,
+      answer,
+      category,
+      position,
+      isTrending,
+      assistantPrompt
     }`
   );
 

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -21,6 +21,7 @@ import chatbot from './sanity/schemas/chatbot'
 import calendarSyncMapping from './sanity/schemas/calendarSyncMapping'
 import formSettings from './sanity/schemas/formSettings'
 import page from './sanity/schemas/page'
+import faq from './sanity/schemas/faq'
 
 // Desk structure
 import {structure} from './sanity/deskStructure'
@@ -84,7 +85,7 @@ export default defineConfig({
     projectId,
     dataset,
     schema: {
-        types: [announcement, siteSettings, staff, ministry, heroSlide, missionStatement, eventDetail, heroSection, gallerySection, subscriptionSection, mapSection, linkSection, chatbot, calendarSyncMapping, formSettings, page],
+        types: [announcement, siteSettings, staff, ministry, heroSlide, missionStatement, eventDetail, heroSection, gallerySection, subscriptionSection, mapSection, linkSection, chatbot, calendarSyncMapping, formSettings, faq, page],
     },
     plugins: [
         structureTool({

--- a/sanity/deskStructure.ts
+++ b/sanity/deskStructure.ts
@@ -7,6 +7,7 @@ export const structure = (S: any) =>
       S.documentTypeListItem('ministry').title('Ministries'),
       S.documentTypeListItem('heroSlide').title('Hero Slides'),
       S.documentTypeListItem('eventDetail').title('Event Details'),
+      S.documentTypeListItem('faq').title('FAQs'),
       S.listItem()
         .title('Site Settings')
         .child(

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -7,6 +7,7 @@ import heroSlide from './schemas/heroSlide';
 import chatbot from './schemas/chatbot';
 import missionStatement from './schemas/missionStatement';
 import eventDetail from './schemas/eventDetail';
+import faq from './schemas/faq';
 import heroSection from './schemas/sections/heroSection';
 import gallerySection from './schemas/sections/gallerySection';
 import subscriptionSection from './schemas/sections/subscriptionSection';
@@ -32,4 +33,5 @@ export const schemaTypes = [
   chatbot,
   page,
   calendarSyncMapping,
+  faq,
 ];

--- a/sanity/schemas/faq.ts
+++ b/sanity/schemas/faq.ts
@@ -1,0 +1,64 @@
+import {defineField, defineType} from 'sanity';
+
+export default defineType({
+  name: 'faq',
+  title: 'FAQ Entry',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'question',
+      title: 'Question',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'answer',
+      title: 'Answer',
+      type: 'array',
+      of: [{type: 'block'}],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      description: 'Used to group questions on the FAQ page.',
+    }),
+    defineField({
+      name: 'position',
+      title: 'Sort Order',
+      type: 'number',
+      description: 'Lower numbers appear first on the FAQ page.',
+    }),
+    defineField({
+      name: 'isTrending',
+      title: 'Trending Highlight',
+      type: 'boolean',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'assistantPrompt',
+      title: 'Assistant Follow-up Prompt',
+      type: 'text',
+      rows: 3,
+      description:
+        'Optional prompt that will prefill the assistant when launched from this FAQ entry.',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'question',
+      subtitle: 'category',
+    },
+  },
+  orderings: [
+    {
+      title: 'Sort Order',
+      name: 'positionAsc',
+      by: [
+        {field: 'position', direction: 'asc'},
+        {field: 'question', direction: 'asc'},
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- add a dedicated FAQ page that surfaces trending questions, upcoming events, and assistant follow-ups sourced from Sanity
- implement reusable accordion and assistant chip components with animated styling for the FAQ experience
- extend Sanity schema/queries and navigation to support the new FAQ content

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2be43dd4832c8abfc4b33227dc2c