### PR TITLE
Add Meet the Pastor page and CMS schema

### DIFF
--- a/app/about/meet-the-pastor/page.tsx
+++ b/app/about/meet-the-pastor/page.tsx
@@ -1,0 +1,492 @@
+import Image from "next/image";
+import { PortableText } from "@portabletext/react";
+import type { PortableTextBlock } from "sanity";
+import type { PortableTextComponents } from "@portabletext/react";
+
+import {
+  meetPastorPage,
+  type MeetPastorData,
+  type MeetPastorSection,
+  type MeetPastorMediaItem,
+  type MeetPastorContactMethod,
+  type MeetPastorTimelineEntry,
+  type MeetPastorTestimonial,
+} from "@/lib/queries";
+
+export const metadata = { title: "Meet the Pastor" };
+
+const portableComponents: PortableTextComponents = {
+  block: {
+    normal: ({ children }) => (
+      <p className="mt-4 text-lg leading-relaxed text-[var(--brand-fg)] first:mt-0">{children}</p>
+    ),
+    h3: ({ children }) => (
+      <h3 className="mt-8 text-2xl font-semibold tracking-tight text-[var(--brand-alt)] first:mt-0">
+        {children}
+      </h3>
+    ),
+    blockquote: ({ children }) => (
+      <blockquote className="mt-6 border-l-4 border-[var(--brand-accent)] pl-4 text-xl italic text-[var(--brand-alt)] first:mt-0">
+        {children}
+      </blockquote>
+    ),
+  },
+  list: {
+    bullet: ({ children }) => (
+      <ul className="mt-4 list-disc space-y-2 pl-6 text-lg leading-relaxed text-[var(--brand-fg)] first:mt-0">
+        {children}
+      </ul>
+    ),
+    number: ({ children }) => (
+      <ol className="mt-4 list-decimal space-y-2 pl-6 text-lg leading-relaxed text-[var(--brand-fg)] first:mt-0">
+        {children}
+      </ol>
+    ),
+  },
+};
+
+function RichText({ value }: { value?: PortableTextBlock[] }) {
+  if (!value || value.length === 0) {
+    return null;
+  }
+  return (
+    <div className="text-lg leading-relaxed">
+      <PortableText value={value} components={portableComponents} />
+    </div>
+  );
+}
+
+type QuickFact = NonNullable<MeetPastorData["quickFacts"]>[number];
+
+function QuickFacts({ facts, className }: { facts?: QuickFact[]; className?: string }) {
+  const items = facts
+    ?.map((fact) => ({
+      label: fact?.label?.trim(),
+      value: fact?.value?.trim(),
+    }))
+    .filter((fact) => fact.label || fact.value);
+
+  if (!items || items.length === 0) {
+    return null;
+  }
+
+  return (
+    <aside
+      className={`rounded-3xl border border-[var(--brand-border)] p-6 shadow-xl ${className ?? ""}`}
+      style={{
+        backgroundColor: "color-mix(in oklab, var(--brand-surface) 82%, transparent)",
+      }}
+    >
+      <h2 className="text-xl font-semibold uppercase tracking-[0.2em] text-[var(--brand-muted)]">
+        Quick Facts
+      </h2>
+      <dl className="mt-4 space-y-4">
+        {items.map((fact, index) => (
+          <div
+            key={`${fact?.label ?? fact?.value ?? index}`}
+            className="border-t border-[var(--brand-border)] pt-4 first:border-t-0 first:pt-0"
+          >
+            {fact.label && (
+              <dt className="text-xs uppercase tracking-[0.3em] text-[var(--brand-muted)]">
+                {fact.label}
+              </dt>
+            )}
+            {fact.value && (
+              <dd className="mt-1 text-lg font-semibold text-[var(--brand-alt)]">{fact.value}</dd>
+            )}
+          </div>
+        ))}
+      </dl>
+    </aside>
+  );
+}
+
+function QuoteCard({ text, attribution }: { text: string; attribution?: string }) {
+  return (
+    <section
+      className="rounded-3xl border border-[var(--brand-border)] p-8 text-center shadow-xl"
+      style={{
+        background: "linear-gradient(135deg, color-mix(in oklab, var(--brand-surface) 90%, transparent) 0%, color-mix(in oklab, var(--brand-overlay) 70%, transparent) 100%)",
+      }}
+    >
+      <p className="text-2xl font-semibold leading-snug text-[var(--brand-alt)]">
+        &ldquo;{text}&rdquo;
+      </p>
+      {attribution && (
+        <p className="mt-4 text-xs uppercase tracking-[0.3em] text-[var(--brand-muted)]">
+          &mdash; {attribution}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function InfoSection({
+  section,
+  defaultHeading,
+  listKey,
+  listTitle,
+  reverse,
+}: {
+  section?: MeetPastorSection | null;
+  defaultHeading: string;
+  listKey?: "values" | "highlights";
+  listTitle?: string;
+  reverse?: boolean;
+}) {
+  if (!section) {
+    return null;
+  }
+  const hasBody = section.body && section.body.length > 0;
+  const hasImage = Boolean(section.image);
+  const list = listKey
+    ? ((section[listKey] as string[] | undefined)
+        ?.map((item) => item?.trim())
+        .filter((item): item is string => Boolean(item)) ?? [])
+    : [];
+  const hasList = list.length > 0;
+  const hasQuote = Boolean(section.quote?.text);
+  const hasHeading = Boolean(section.heading ?? defaultHeading);
+
+  if (!hasHeading && !hasBody && !hasImage && !hasList && !hasQuote) {
+    return null;
+  }
+
+  return (
+    <section className={`grid gap-8 ${hasImage ? "lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] lg:items-start" : ""}`}>
+      <div className={`${hasImage && reverse ? "lg:order-2" : ""} space-y-6`}>
+        {hasHeading && (
+          <div>
+            <h2 className="text-3xl font-semibold tracking-tight text-[var(--brand-alt)]">
+              {section.heading ?? defaultHeading}
+            </h2>
+          </div>
+        )}
+        {hasBody && <RichText value={section.body} />}
+        {hasList && (
+          <div className="rounded-2xl border border-[var(--brand-border)] p-6 shadow-lg">
+            {listTitle && (
+              <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-muted)]">
+                {listTitle}
+              </h3>
+            )}
+            <ul className="mt-3 space-y-2 text-lg leading-relaxed text-[var(--brand-alt)]">
+              {list.map((item, index) => (
+                <li key={`${item}-${index}`}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {hasQuote && section.quote?.text && (
+          <blockquote className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 text-lg italic text-[var(--brand-alt)] shadow-lg">
+            <p>&ldquo;{section.quote.text}&rdquo;</p>
+            {section.quote.attribution && (
+              <footer className="mt-4 text-xs uppercase tracking-[0.3em] text-[var(--brand-muted)]">
+                &mdash; {section.quote.attribution}
+              </footer>
+            )}
+          </blockquote>
+        )}
+      </div>
+      {hasImage && section.image && (
+        <div
+          className={`${reverse ? "lg:order-1" : ""} relative overflow-hidden rounded-3xl border border-[var(--brand-border)] bg-[var(--brand-surface)] shadow-xl`}
+        >
+          <Image
+            src={section.image}
+            alt={section.imageAlt || section.heading || defaultHeading}
+            fill
+            className="object-cover"
+            sizes="(min-width: 1024px) 40vw, 100vw"
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function MediaSection({
+  heading,
+  intro,
+  items,
+}: {
+  heading?: string;
+  intro?: PortableTextBlock[];
+  items?: MeetPastorMediaItem[];
+}) {
+  const mediaItems = items?.filter((item) => item && (item.title || item.description || item.url));
+  if (!heading && (!mediaItems || mediaItems.length === 0) && (!intro || intro.length === 0)) {
+    return null;
+  }
+  return (
+    <section className="space-y-6">
+      {(heading || "Media & Resources") && (
+        <h2 className="text-3xl font-semibold tracking-tight text-[var(--brand-alt)]">
+          {heading ?? "Media & Resources"}
+        </h2>
+      )}
+      <RichText value={intro} />
+      {mediaItems && mediaItems.length > 0 && (
+        <div className="grid gap-6 md:grid-cols-2">
+          {mediaItems.map((item) => (
+            <article
+              key={item._key}
+              className="flex h-full flex-col justify-between rounded-3xl border border-[var(--brand-border)] p-6 shadow-xl"
+              style={{
+                backgroundColor: "color-mix(in oklab, var(--brand-surface) 88%, transparent)",
+              }}
+            >
+              <div className="space-y-3">
+                {item.label && (
+                  <span className="inline-flex items-center rounded-full border border-[var(--brand-border)] px-3 py-1 text-xs uppercase tracking-[0.3em] text-[var(--brand-muted)]">
+                    {item.label}
+                  </span>
+                )}
+                {item.title && (
+                  <h3 className="text-2xl font-semibold text-[var(--brand-alt)]">{item.title}</h3>
+                )}
+                {item.description && (
+                  <p className="text-base leading-relaxed text-[var(--brand-fg)]">{item.description}</p>
+                )}
+              </div>
+              {item.url && (
+                <a
+                  href={item.url}
+                  className="mt-6 inline-flex items-center gap-2 self-start rounded-full bg-[var(--brand-accent)] px-5 py-2 text-sm font-semibold text-[var(--brand-ink)] shadow transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-accent)]"
+                >
+                  View resource
+                  <span aria-hidden="true">→</span>
+                </a>
+              )}
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ConnectSection({
+  heading,
+  body,
+  cta,
+  contactMethods,
+}: {
+  heading?: string;
+  body?: PortableTextBlock[];
+  cta?: { label?: string; href?: string };
+  contactMethods?: MeetPastorContactMethod[];
+}) {
+  const methods = contactMethods
+    ?.map((method) => ({
+      ...method,
+      label: method?.label?.trim(),
+      value: method?.value?.trim(),
+      href: method?.href?.trim(),
+    }))
+    .filter((method) => method && (method.label || method.value || method.href));
+  if (!heading && (!body || body.length === 0) && (!cta?.label || !cta?.href) && (!methods || methods.length === 0)) {
+    return null;
+  }
+  return (
+    <section className="rounded-3xl border border-[var(--brand-border)] p-8 shadow-2xl">
+      {(heading || "Connect") && (
+        <h2 className="text-3xl font-semibold tracking-tight text-[var(--brand-alt)]">
+          {heading ?? "Connect"}
+        </h2>
+      )}
+      <div className="mt-4 space-y-6">
+        <RichText value={body} />
+        {cta?.label && cta.href && (
+          <a
+            href={cta.href}
+            className="inline-flex items-center gap-2 rounded-full bg-[var(--brand-accent)] px-6 py-2 text-base font-semibold text-[var(--brand-ink)] shadow transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-accent)]"
+          >
+            {cta.label}
+            <span aria-hidden="true">→</span>
+          </a>
+        )}
+        {methods && methods.length > 0 && (
+          <div className="space-y-3">
+            {methods.map((method) => (
+              <div
+                key={method._key}
+                className="rounded-2xl border border-[var(--brand-border)] px-4 py-3 text-sm text-[var(--brand-alt)]"
+              >
+                {method.label && (
+                  <div className="text-xs uppercase tracking-[0.3em] text-[var(--brand-muted)]">{method.label}</div>
+                )}
+                {method.href ? (
+                  <a
+                    href={method.href}
+                    className="mt-1 inline-flex items-center gap-1 text-lg text-[var(--brand-alt)] underline decoration-[var(--brand-accent)] underline-offset-4 hover:opacity-90"
+                  >
+                    {method.value ?? method.href}
+                  </a>
+                ) : (
+                  method.value && <div className="mt-1 text-lg">{method.value}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function TimelineSection({ entries }: { entries?: MeetPastorTimelineEntry[] }) {
+  const timelineEntries = entries?.filter((entry) => entry && (entry.date || entry.title || entry.description));
+  if (!timelineEntries || timelineEntries.length === 0) {
+    return null;
+  }
+  return (
+    <section className="space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight text-[var(--brand-alt)]">Ministry Timeline</h2>
+      <ol className="relative space-y-8 border-l border-[var(--brand-border)] pl-6">
+        {timelineEntries.map((entry) => (
+          <li key={entry._key} className="relative">
+            <span className="absolute -left-[11px] top-1 flex h-3 w-3 items-center justify-center rounded-full bg-[var(--brand-accent)]" />
+            <div className="space-y-2">
+              {entry.date && (
+                <p className="text-sm uppercase tracking-[0.3em] text-[var(--brand-muted)]">{entry.date}</p>
+              )}
+              {entry.title && (
+                <h3 className="text-xl font-semibold text-[var(--brand-alt)]">{entry.title}</h3>
+              )}
+              {entry.description && (
+                <p className="text-base leading-relaxed text-[var(--brand-fg)]">{entry.description}</p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function TestimonialsSection({ testimonials }: { testimonials?: MeetPastorTestimonial[] }) {
+  const items = testimonials?.filter((testimonial) => testimonial?.quote);
+  if (!items || items.length === 0) {
+    return null;
+  }
+  return (
+    <section className="space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight text-[var(--brand-alt)]">Voices from the Congregation</h2>
+      <div className="grid gap-6 md:grid-cols-2">
+        {items.map((testimonial) => (
+          <figure
+            key={testimonial._key}
+            className="rounded-3xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 shadow-xl"
+          >
+            <blockquote className="text-lg italic leading-relaxed text-[var(--brand-alt)]">
+              &ldquo;{testimonial.quote}&rdquo;
+            </blockquote>
+            {(testimonial.name || testimonial.role) && (
+              <figcaption className="mt-4 text-xs uppercase tracking-[0.3em] text-[var(--brand-muted)]">
+                {testimonial.name}
+                {testimonial.role ? `, ${testimonial.role}` : ""}
+              </figcaption>
+            )}
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default async function Page() {
+  const data = await meetPastorPage();
+
+  const heroTitle = data?.hero?.title ?? "Meet the Pastor";
+  const heroSubtitle = data?.hero?.subtitle;
+  const heroTagline = data?.hero?.tagline;
+  const heroImage = data?.hero?.image;
+  const heroAlt = data?.hero?.imageAlt ?? heroTitle;
+  const quickFacts = data?.quickFacts as QuickFact[] | undefined;
+
+  return (
+    <div className="space-y-16">
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:items-stretch">
+        <div className="relative overflow-hidden rounded-3xl border border-[var(--brand-border)] bg-[var(--brand-surface)] shadow-2xl">
+          {heroImage && (
+            <Image
+              src={heroImage}
+              alt={heroAlt}
+              fill
+              priority
+              sizes="(min-width: 1024px) 70vw, 100vw"
+              className="object-cover"
+            />
+          )}
+          <div
+            className="relative z-10 flex h-full flex-col justify-end gap-4 p-8 sm:p-12"
+            style={
+              heroImage
+                ? {
+                    background:
+                      "linear-gradient(180deg, color-mix(in oklab, var(--brand-overlay-muted) 55%, transparent) 0%, color-mix(in oklab, var(--brand-overlay) 85%, transparent) 100%)",
+                  }
+                : { backgroundColor: "var(--brand-surface)" }
+            }
+          >
+            {heroTagline && (
+              <span className="inline-flex max-w-max items-center rounded-full border border-[var(--brand-border)] px-4 py-1 text-xs uppercase tracking-[0.3em] text-[var(--brand-accent)]">
+                {heroTagline}
+              </span>
+            )}
+            <h1 className="text-4xl font-bold tracking-tight text-[var(--brand-alt)] sm:text-5xl">
+              {heroTitle}
+            </h1>
+            {heroSubtitle && (
+              <p className="max-w-2xl text-lg leading-relaxed text-[var(--brand-muted)]">{heroSubtitle}</p>
+            )}
+          </div>
+        </div>
+        <QuickFacts facts={quickFacts} className="lg:self-end" />
+      </section>
+
+      {data?.highlightQuote?.text && (
+        <QuoteCard text={data.highlightQuote.text} attribution={data.highlightQuote.attribution} />
+      )}
+
+      <InfoSection
+        section={data?.biographySection}
+        defaultHeading="Biography & Ministry Journey"
+        reverse
+      />
+
+      <InfoSection
+        section={data?.visionSection}
+        defaultHeading="Vision & Values"
+        listKey="values"
+        listTitle="Core Values"
+      />
+
+      <InfoSection
+        section={data?.personalSection}
+        defaultHeading="Personal Life"
+        listKey="highlights"
+        listTitle="Highlights"
+        reverse
+      />
+
+      <MediaSection
+        heading={data?.mediaSection?.heading}
+        intro={data?.mediaSection?.intro}
+        items={data?.mediaSection?.items}
+      />
+
+      <TimelineSection entries={data?.timeline} />
+
+      <TestimonialsSection testimonials={data?.testimonials} />
+
+      <ConnectSection
+        heading={data?.connectSection?.heading}
+        body={data?.connectSection?.body}
+        cta={data?.connectSection?.cta}
+        contactMethods={data?.connectSection?.contactMethods}
+      />
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,6 +67,15 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
               role="menu"
             >
               <Link
+                href="/about/meet-the-pastor"
+                className={`block rounded px-2 py-1 cursor-pointer border border-transparent ${linkClasses(pathname === "/about/meet-the-pastor")} hover:border-[var(--brand-alt)] focus-visible:ring-1 focus-visible:ring-[var(--brand-alt)]`}
+                aria-current={pathname === "/about/meet-the-pastor" ? "page" : undefined}
+                role="menuitem"
+              >
+                Meet the Pastor
+              </Link>
+              <div className="my-1 border-t border-[var(--brand-border)]" role="separator" />
+              <Link
                 href="/about/staff"
                 className={`block rounded px-2 py-1 cursor-pointer border border-transparent ${linkClasses(pathname === "/about/staff")} hover:border-[var(--brand-alt)] focus-visible:ring-1 focus-visible:ring-[var(--brand-alt)]`}
                 aria-current={pathname === "/about/staff" ? "page" : undefined}

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -111,6 +111,14 @@ function MobileMenuInner({ nav }: MobileMenuProps, ref: React.Ref<MobileMenuHand
                       >
                         <Disclosure.Panel className="ml-4 mt-2 flex flex-col gap-2">
                           <Link
+                            href="/about/meet-the-pastor"
+                            className={linkClasses(pathname === "/about/meet-the-pastor")}
+                            aria-current={pathname === "/about/meet-the-pastor" ? "page" : undefined}
+                            onClick={handleClose}
+                          >
+                            Meet the Pastor
+                          </Link>
+                          <Link
                             href="/about/staff"
                             className={linkClasses(pathname === "/about/staff")}
                             aria-current={pathname === "/about/staff" ? "page" : undefined}

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,4 +1,5 @@
 import groq from 'groq';
+import type {PortableTextBlock} from 'sanity';
 import {sanity} from './sanity';
 
 export interface HeroSlide {
@@ -146,6 +147,146 @@ export const missionStatement = () =>
       tagline,
       "backgroundImage": backgroundImage.asset->url,
       message
+    }`
+  );
+
+export interface MeetPastorQuote {
+  text?: string;
+  attribution?: string;
+}
+
+export interface MeetPastorSection {
+  heading?: string;
+  body?: PortableTextBlock[];
+  image?: string;
+  imageAlt?: string;
+  values?: string[];
+  highlights?: string[];
+  quote?: MeetPastorQuote;
+}
+
+export interface MeetPastorMediaItem {
+  _key: string;
+  title?: string;
+  description?: string;
+  label?: string;
+  url?: string;
+}
+
+export interface MeetPastorContactMethod {
+  _key: string;
+  label?: string;
+  value?: string;
+  href?: string;
+}
+
+export interface MeetPastorTimelineEntry {
+  _key: string;
+  date?: string;
+  title?: string;
+  description?: string;
+}
+
+export interface MeetPastorTestimonial {
+  _key: string;
+  quote?: string;
+  name?: string;
+  role?: string;
+}
+
+export interface MeetPastorData {
+  hero?: {
+    title?: string;
+    subtitle?: string;
+    tagline?: string;
+    image?: string;
+    imageAlt?: string;
+  };
+  quickFacts?: { label?: string; value?: string }[];
+  highlightQuote?: MeetPastorQuote;
+  biographySection?: MeetPastorSection;
+  visionSection?: MeetPastorSection;
+  personalSection?: MeetPastorSection;
+  mediaSection?: {
+    heading?: string;
+    intro?: PortableTextBlock[];
+    items?: MeetPastorMediaItem[];
+  };
+  connectSection?: {
+    heading?: string;
+    body?: PortableTextBlock[];
+    cta?: { label?: string; href?: string };
+    contactMethods?: MeetPastorContactMethod[];
+  };
+  timeline?: MeetPastorTimelineEntry[];
+  testimonials?: MeetPastorTestimonial[];
+}
+
+export const meetPastorPage = () =>
+  sanity.fetch<MeetPastorData | null>(
+    groq`*[_type == "meetPastor"][0]{
+      "hero": hero{
+        title,
+        subtitle,
+        tagline,
+        "image": image.asset->url,
+        imageAlt
+      },
+      "quickFacts": quickFacts[]{label, value},
+      "highlightQuote": highlightQuote{ text, attribution },
+      "biographySection": biographySection{
+        heading,
+        body,
+        "image": image.asset->url,
+        imageAlt
+      },
+      "visionSection": visionSection{
+        heading,
+        body,
+        values,
+        quote{ text, attribution }
+      },
+      "personalSection": personalSection{
+        heading,
+        body,
+        "image": image.asset->url,
+        imageAlt,
+        highlights
+      },
+      "mediaSection": mediaSection{
+        heading,
+        intro,
+        items[]{
+          _key,
+          title,
+          description,
+          label,
+          url
+        }
+      },
+      "connectSection": connectSection{
+        heading,
+        body,
+        cta{ label, href },
+        contactMethods[]{
+          _key,
+          label,
+          value,
+          href
+        }
+      },
+      "timeline": timeline[]{
+        _key,
+        date,
+        title,
+        description
+      },
+      "testimonials": testimonials[]{
+        _key,
+        quote,
+        name,
+        role
+      }
     }`
   );
 

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -11,6 +11,7 @@ import staff from './sanity/schemas/staff'
 import ministry from './sanity/schemas/ministry'
 import heroSlide from './sanity/schemas/heroSlide'
 import missionStatement from './sanity/schemas/missionStatement'
+import meetPastor from './sanity/schemas/meetPastor'
 import eventDetail from './sanity/schemas/eventDetail'
 import heroSection from './sanity/schemas/sections/heroSection'
 import gallerySection from './sanity/schemas/sections/gallerySection'
@@ -84,7 +85,7 @@ export default defineConfig({
     projectId,
     dataset,
     schema: {
-        types: [announcement, siteSettings, staff, ministry, heroSlide, missionStatement, eventDetail, heroSection, gallerySection, subscriptionSection, mapSection, linkSection, chatbot, calendarSyncMapping, formSettings, page],
+        types: [announcement, siteSettings, staff, ministry, heroSlide, missionStatement, meetPastor, eventDetail, heroSection, gallerySection, subscriptionSection, mapSection, linkSection, chatbot, calendarSyncMapping, formSettings, page],
     },
     plugins: [
         structureTool({

--- a/sanity/deskStructure.ts
+++ b/sanity/deskStructure.ts
@@ -19,5 +19,10 @@ export const structure = (S: any) =>
         ),
       S.documentTypeListItem('formSettings').title('Form Settings'),
       S.documentTypeListItem('staff').title('Staff'),
+      S.listItem()
+        .title('Meet the Pastor')
+        .child(
+          S.document().schemaType('meetPastor').documentId('meetPastor')
+        ),
       S.documentTypeListItem('missionStatement').title('Mission Statement'),
     ])

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -6,6 +6,7 @@ import ministry from './schemas/ministry';
 import heroSlide from './schemas/heroSlide';
 import chatbot from './schemas/chatbot';
 import missionStatement from './schemas/missionStatement';
+import meetPastor from './schemas/meetPastor';
 import eventDetail from './schemas/eventDetail';
 import heroSection from './schemas/sections/heroSection';
 import gallerySection from './schemas/sections/gallerySection';
@@ -23,6 +24,7 @@ export const schemaTypes = [
   ministry,
   heroSlide,
   missionStatement,
+  meetPastor,
   eventDetail,
   heroSection,
   gallerySection,

--- a/sanity/schemas/meetPastor.ts
+++ b/sanity/schemas/meetPastor.ts
@@ -1,0 +1,286 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'meetPastor',
+  title: 'Meet the Pastor',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'hero',
+      title: 'Hero',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'title',
+          title: 'Title',
+          type: 'string',
+          validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+          name: 'subtitle',
+          title: 'Subtitle',
+          type: 'string',
+        }),
+        defineField({
+          name: 'tagline',
+          title: 'Tagline',
+          type: 'string',
+          description: 'Short phrase to overlay on the hero image.',
+        }),
+        defineField({
+          name: 'image',
+          title: 'Image',
+          type: 'image',
+          options: { hotspot: true },
+        }),
+        defineField({
+          name: 'imageAlt',
+          title: 'Image Alt Text',
+          type: 'string',
+          description: 'Accessible description for the hero image.',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'quickFacts',
+      title: 'Quick Facts',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'fact',
+          fields: [
+            defineField({ name: 'label', title: 'Label', type: 'string' }),
+            defineField({ name: 'value', title: 'Value', type: 'string' }),
+          ],
+          preview: {
+            select: { title: 'label', subtitle: 'value' },
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'highlightQuote',
+      title: 'Highlight Quote',
+      type: 'object',
+      fields: [
+        defineField({ name: 'text', title: 'Quote', type: 'text' }),
+        defineField({ name: 'attribution', title: 'Attribution', type: 'string' }),
+      ],
+    }),
+    defineField({
+      name: 'biographySection',
+      title: 'Biography & Ministry Journey',
+      type: 'object',
+      fields: [
+        defineField({ name: 'heading', title: 'Heading', type: 'string' }),
+        defineField({
+          name: 'body',
+          title: 'Body',
+          type: 'array',
+          of: [{ type: 'block' }],
+        }),
+        defineField({
+          name: 'image',
+          title: 'Image',
+          type: 'image',
+          options: { hotspot: true },
+        }),
+        defineField({
+          name: 'imageAlt',
+          title: 'Image Alt Text',
+          type: 'string',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'visionSection',
+      title: 'Vision & Values',
+      type: 'object',
+      fields: [
+        defineField({ name: 'heading', title: 'Heading', type: 'string' }),
+        defineField({
+          name: 'body',
+          title: 'Body',
+          type: 'array',
+          of: [{ type: 'block' }],
+        }),
+        defineField({
+          name: 'values',
+          title: 'Values / Pillars',
+          type: 'array',
+          of: [{ type: 'string' }],
+        }),
+        defineField({
+          name: 'quote',
+          title: 'Quote',
+          type: 'object',
+          fields: [
+            defineField({ name: 'text', title: 'Quote', type: 'text' }),
+            defineField({ name: 'attribution', title: 'Attribution', type: 'string' }),
+          ],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'personalSection',
+      title: 'Personal & Family',
+      type: 'object',
+      fields: [
+        defineField({ name: 'heading', title: 'Heading', type: 'string' }),
+        defineField({
+          name: 'body',
+          title: 'Body',
+          type: 'array',
+          of: [{ type: 'block' }],
+        }),
+        defineField({
+          name: 'image',
+          title: 'Image',
+          type: 'image',
+          options: { hotspot: true },
+        }),
+        defineField({
+          name: 'imageAlt',
+          title: 'Image Alt Text',
+          type: 'string',
+        }),
+        defineField({
+          name: 'highlights',
+          title: 'Highlights',
+          type: 'array',
+          of: [{ type: 'string' }],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'mediaSection',
+      title: 'Media & Resources',
+      type: 'object',
+      fields: [
+        defineField({ name: 'heading', title: 'Heading', type: 'string' }),
+        defineField({
+          name: 'intro',
+          title: 'Intro',
+          type: 'array',
+          of: [{ type: 'block' }],
+        }),
+        defineField({
+          name: 'items',
+          title: 'Items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'mediaItem',
+              fields: [
+                defineField({ name: 'title', title: 'Title', type: 'string' }),
+                defineField({ name: 'description', title: 'Description', type: 'text' }),
+                defineField({
+                  name: 'label',
+                  title: 'Label',
+                  type: 'string',
+                  description: 'Optional tag such as Book, Sermon, Podcast.',
+                }),
+                defineField({
+                  name: 'url',
+                  title: 'URL',
+                  type: 'url',
+                  validation: (Rule) => Rule.uri({ scheme: ['http', 'https'] }),
+                }),
+              ],
+              preview: {
+                select: { title: 'title', subtitle: 'label' },
+              },
+            },
+          ],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'connectSection',
+      title: 'Call to Connect',
+      type: 'object',
+      fields: [
+        defineField({ name: 'heading', title: 'Heading', type: 'string' }),
+        defineField({
+          name: 'body',
+          title: 'Body',
+          type: 'array',
+          of: [{ type: 'block' }],
+        }),
+        defineField({
+          name: 'cta',
+          title: 'Primary CTA',
+          type: 'object',
+          fields: [
+            defineField({ name: 'label', title: 'Label', type: 'string' }),
+            defineField({ name: 'href', title: 'Link', type: 'url' }),
+          ],
+        }),
+        defineField({
+          name: 'contactMethods',
+          title: 'Contact Methods',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'contactMethod',
+              fields: [
+                defineField({ name: 'label', title: 'Label', type: 'string' }),
+                defineField({ name: 'value', title: 'Value', type: 'string' }),
+                defineField({
+                  name: 'href',
+                  title: 'Link',
+                  type: 'string',
+                  description: 'Optional link such as mailto:, tel:, or a URL.',
+                }),
+              ],
+              preview: {
+                select: { title: 'label', subtitle: 'value' },
+              },
+            },
+          ],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'timeline',
+      title: 'Timeline',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'timelineEntry',
+          fields: [
+            defineField({ name: 'date', title: 'Date', type: 'string' }),
+            defineField({ name: 'title', title: 'Title', type: 'string' }),
+            defineField({ name: 'description', title: 'Description', type: 'text' }),
+          ],
+          preview: {
+            select: { title: 'title', subtitle: 'date' },
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'testimonials',
+      title: 'Testimonials',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'testimonial',
+          fields: [
+            defineField({ name: 'quote', title: 'Quote', type: 'text' }),
+            defineField({ name: 'name', title: 'Name', type: 'string' }),
+            defineField({ name: 'role', title: 'Role', type: 'string' }),
+          ],
+          preview: {
+            select: { title: 'name', subtitle: 'role' },
+          },
+        },
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- add a Meet the Pastor route that renders hero, quick facts, biography, vision, personal, media, timeline, testimonials, and call-to-connect sections populated via Portable Text content
- introduce a dedicated `meetPastor` Sanity document with hero, section, media, connect, timeline, and testimonial fields and expose it through new queries
- surface the new page in the About navigation for desktop and mobile and register the schema in the studio desk structure

## Testing
- `npm run lint`
- `npm test` *(fails: Brand color violation in components/Assistant.tsx, pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6e9376d8832c83f045e7a45dbcc9