### PR TITLE
Update chatbot test branding

### DIFF
--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -57,7 +57,7 @@ export default function Assistant() {
     );
     const parts = text.split(regex).filter(Boolean);
     const accentLinkClass =
-      'underline text-[#f4f4f5] decoration-[#f4f4f5] hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f4f4f5]';
+      'underline text-neutral-50 decoration-neutral-50 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-50';
     return parts.map((part, idx) => {
       if (/^https?:\/\//.test(part)) {
         const trimmed = stripInvisibleCharacters(part);
@@ -323,7 +323,7 @@ export default function Assistant() {
                       <div className="mt-1 text-sm">
                         <button
                           type="button"
-                          className="underline text-[#f4f4f5] decoration-[#f4f4f5] hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-[#f4f4f5] cursor-pointer bg-transparent p-0 font-normal"
+                          className="underline text-neutral-50 decoration-neutral-50 hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-neutral-50 cursor-pointer bg-transparent p-0 font-normal"
                           onClick={() => {
                             const pct = Math.max(
                               0,

--- a/lib/chatbot.test.ts
+++ b/lib/chatbot.test.ts
@@ -76,7 +76,7 @@ async function testBuildSiteContext() {
   const ctxJson = await buildSiteContext({
     siteSettings: async () =>
       ({
-        title: 'Test GPT',
+        title: 'Greater Pentecostal Temple',
         address: '123 Street',
         serviceTimes: 'Sun 10am',
         email: 'info@example.com',
@@ -131,7 +131,7 @@ async function testBuildSiteContext() {
 
   assert.ok(ctxJson);
   const parsed = JSON.parse(ctxJson);
-  assert.strictEqual(parsed.st.t, 'Test GPT');
+  assert.strictEqual(parsed.st.t, 'Greater Pentecostal Temple');
   assert.strictEqual(parsed.st.addr, '123 Street');
   assert.strictEqual(parsed.st.svc, 'Sun 10am');
   assert.strictEqual(parsed.st.email, 'info@example.com');


### PR DESCRIPTION
## Summary
- update the chatbot test fixture and assertions to use the Greater Pentecostal Temple name
- replace hard-coded hex link styles in the assistant component with neutral palette classes to satisfy the brand check

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf73dce934832c9e0f0b96d847975c