### PR TITLE
Add detailed privacy and terms of use pages

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,10 +1,103 @@
-export const metadata = { title: "Privacy Policy" };
+export const metadata = {
+  title: "Privacy Policy",
+  description:
+    "Learn how we collect, use, and protect the personal information you share with our church.",
+};
+
+const LAST_UPDATED = "September 21, 2025";
 
 export default function Page() {
   return (
-    <section className="space-y-4">
-      <h1 className="text-2xl font-semibold">Privacy Policy</h1>
-      <p>Our privacy practices are being finalized. Please check back soon.</p>
+    <section className="space-y-12">
+      <header className="space-y-4">
+        <h1 className="text-3xl font-semibold">Privacy Policy</h1>
+        <p className="text-sm text-[var(--brand-muted)]">
+          Last updated: {LAST_UPDATED}
+        </p>
+        <p>
+          We are committed to protecting your privacy and being transparent about
+          how we collect, use, and safeguard the information you share with our
+          church through this website and our connected digital channels
+          (collectively, the &ldquo;Services&rdquo;). This policy explains what data we
+          collect, why we collect it, and the choices available to you.
+        </p>
+      </header>
+
+      <div className="space-y-8">
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Information We Collect</h2>
+          <p>
+            We collect the information you choose to share when you submit
+            contact, prayer, volunteer, or event forms, subscribe to updates, or
+            request resources. This may include your name, contact details,
+            communication preferences, and the message you provide. We also
+            gather limited technical data, such as browser type, device
+            characteristics, and approximate location based on your IP address,
+            to help us understand how people use the Services.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">How We Use and Share Information</h2>
+          <p>
+            We use your information to respond to your requests, coordinate
+            ministry opportunities, send updates you have asked to receive, keep
+            the Services secure, and comply with applicable laws. We do not sell
+            or rent your personal information.
+          </p>
+          <p>
+            Access to your information is limited to staff and trusted
+            volunteers who need it to support our ministries. We may share data
+            with service providers who assist us with technology or event tools
+            (under agreements that protect your information), comply with legal
+            obligations, or provide aggregated insights that do not identify you
+            personally.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Data Retention and Security</h2>
+          <p>
+            We retain personal information only as long as needed for the
+            purposes described in this policy or as required by law. We employ
+            administrative, technical, and physical safeguards to help protect
+            your information, while recognizing that no system can be guaranteed
+            completely secure.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Your Choices</h2>
+          <p>
+            You may contact us to update or correct your details, and every
+            email we send includes an unsubscribe link so you can opt out of
+            future messages. You can also adjust browser settings to manage
+            cookies or other tracking tools, though doing so may affect how the
+            Services function on your device.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Children and Policy Updates</h2>
+          <p>
+            The Services are not directed to children under 13. If we learn that
+            information from a child has been provided without verifiable
+            parental consent, we will delete it. We may update this policy to
+            reflect new practices or requirements, and we will revise the
+            &ldquo;Last updated&rdquo; date above whenever that occurs.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Contact Us</h2>
+          <p>
+            If you have questions about this policy or how your information is
+            handled, please reach out through our contact page or by using the
+            communication method that is most convenient for you. We are happy
+            to clarify our practices and address any concerns.
+          </p>
+        </div>
+      </div>
     </section>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,10 +1,96 @@
-export const metadata = { title: "Terms of Use" };
+export const metadata = {
+  title: "Terms of Use",
+  description:
+    "Understand the guidelines that govern how you use our website, online content, and digital ministries.",
+};
+
+const LAST_UPDATED = "September 21, 2025";
 
 export default function Page() {
   return (
-    <section className="space-y-4">
-      <h1 className="text-2xl font-semibold">Terms of Use</h1>
-      <p>Our terms are being prepared. Please visit again later.</p>
+    <section className="space-y-12">
+      <header className="space-y-4">
+        <h1 className="text-3xl font-semibold">Terms of Use</h1>
+        <p className="text-sm text-[var(--brand-muted)]">
+          Last updated: {LAST_UPDATED}
+        </p>
+        <p>
+          These Terms of Use (&ldquo;Terms&rdquo;) explain the rules that apply to your
+          access to and use of this website and any related online experiences
+          provided by our church (collectively, the &ldquo;Services&rdquo;). By visiting or
+          using the Services, you agree to abide by these Terms. If you do not
+          agree, please discontinue use of the Services.
+        </p>
+      </header>
+
+      <div className="space-y-8">
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Acceptance and Scope</h2>
+          <p>
+            By accessing the Services, you agree to these Terms and our Privacy
+            Policy. The Services are offered to help people engage with our
+            church community and are intended for individuals who are at least
+            13 years old or who are using them with the involvement of a parent
+            or guardian. If you disagree with any part of these Terms, please do
+            not use the Services.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Community Expectations</h2>
+          <p>
+            We ask every visitor to help maintain a respectful, lawful, and
+            secure environment. You agree not to:
+          </p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>Share content that is unlawful, harassing, or harmful.</li>
+            <li>Disrupt, damage, or attempt to gain unauthorized access to the Services.</li>
+            <li>Provide false information or misuse any registrations, forms, or credentials.</li>
+          </ul>
+          <p>
+            When you submit information, please keep it accurate and up to date.
+            You are responsible for safeguarding any login details provided to
+            you and for activity that occurs under your credentials.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Content and Third-Party Resources</h2>
+          <p>
+            Unless otherwise noted, the materials on the Services belong to the
+            church. You may access them for personal, non-commercial use and
+            need our written permission for any other use. We may include links
+            to third-party websites or tools for your convenience. Those
+            resources are governed by their own terms and policies, which we do
+            not control.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Disclaimers and Limitation of Liability</h2>
+          <p>
+            The Services are provided on an &ldquo;as is&rdquo; and &ldquo;as available&rdquo; basis.
+            We do our best to offer accurate, helpful information, but we make no
+            warranties about the Services and disclaim all implied warranties to
+            the fullest extent permitted by law. To the extent allowed, the
+            church, its staff, volunteers, and agents are not liable for indirect
+            or consequential damages, and any direct liability is limited to the
+            amount you paid us, if any, to use the Services in the twelve months
+            before the claim.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Changes and Contact</h2>
+          <p>
+            We may update these Terms from time to time and will revise the
+            &ldquo;Last updated&rdquo; date above when we do. Continued use of the Services
+            after changes are posted means you accept the revised Terms. If you
+            have questions, please reach out through our contact page or by
+            calling the church office.
+          </p>
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- streamline the privacy policy while preserving key sections on data practices, user choices, and contact details, and refresh the last updated date to September 21, 2025
- condense the terms of use into core guidance on acceptable use, content ownership, disclaimers, and update procedures with the new September 21, 2025 effective date

## Testing
- npm run lint
- npm test *(fails: Brand color violation in sanity/plugins/calendarSyncTool/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d085f48e6c832c895dcc069245d3fd