### PR TITLE
Add newsletter signup handler and footer client form

### DIFF
--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,0 +1,94 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getImpersonationAddress, sendEmail } from "@/lib/gmail";
+
+const headerSanitizer = /[\r\n]+/g;
+
+const sanitizeHeader = (value: unknown) => String(value ?? "").replace(headerSanitizer, " ").trim();
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const safeEmail = (value: unknown): string | null => {
+  const sanitized = sanitizeHeader(value);
+  return emailRegex.test(sanitized) ? sanitized : null;
+};
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+export async function POST(req: Request) {
+  try {
+    const contentType = req.headers.get("content-type") ?? "";
+    let submittedEmail: string | null = null;
+
+    if (contentType.includes("application/json")) {
+      const body = await req.json().catch(() => null);
+      if (body && typeof body.email === "string") {
+        submittedEmail = body.email;
+      }
+    } else if (contentType.includes("application/x-www-form-urlencoded") || contentType.includes("multipart/form-data")) {
+      const formData = await req.formData();
+      const emailField = formData.get("email");
+      if (typeof emailField === "string") {
+        submittedEmail = emailField;
+      }
+    } else {
+      // Attempt to parse as JSON by default
+      const body = await req.json().catch(() => null);
+      if (body && typeof body.email === "string") {
+        submittedEmail = body.email;
+      }
+    }
+
+    const email = safeEmail(submittedEmail);
+    if (!email) {
+      return NextResponse.json({ error: "Please provide a valid email address." }, { status: 400 });
+    }
+
+    const targetEmail = sanitizeHeader(process.env.NEWSLETTER_TARGET_EMAIL);
+    if (!targetEmail) {
+      console.error("NEWSLETTER_TARGET_EMAIL is not configured.");
+      return NextResponse.json(
+        { error: "Newsletter signups are not available right now. Please try again later." },
+        { status: 500 },
+      );
+    }
+
+    const impersonationAddress = getImpersonationAddress();
+    const subject = sanitizeHeader(process.env.NEWSLETTER_FORWARD_SUBJECT ?? "New newsletter subscription");
+
+    const submittedAt = new Date();
+    const tz = process.env.TZ || "UTC";
+    const formatter = new Intl.DateTimeFormat("en-US", { timeZone: tz, dateStyle: "medium", timeStyle: "short" });
+    const submittedAtText = formatter.format(submittedAt);
+
+    const textBody = `Please add ${email} to the newsletter mailing list.\nRequested at ${submittedAtText} (${tz}).`;
+    const htmlBody = `<div style="font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:14px;">` +
+      `<p style="margin:0 0 12px 0;">Please add <strong>${escapeHtml(email)}</strong> to the newsletter mailing list.</p>` +
+      `<p style="margin:0;">Requested at ${escapeHtml(submittedAtText)} (${escapeHtml(tz)}).</p>` +
+      `</div>`;
+
+    await sendEmail({
+      from: impersonationAddress,
+      to: targetEmail,
+      subject,
+      text: textBody,
+      html: htmlBody,
+      replyTo: email,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Newsletter signup failed", error);
+    return NextResponse.json(
+      { error: "We couldn't complete your subscription right now. Please try again later." },
+      { status: 500 },
+    );
+  }
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import NewsletterSignupForm from "./NewsletterSignupForm";
 import { siteSettings } from "@/lib/queries";
 
 export default async function Footer() {
@@ -102,19 +103,7 @@ export default async function Footer() {
 
           <div>
             <h4 className="mb-2 font-semibold text-[var(--brand-surface-contrast)]">Newsletter</h4>
-            <form className="flex w-full flex-col gap-2 sm:flex-row sm:items-center">
-              <input
-                type="email"
-                placeholder="Email address"
-                className="flex-1 rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] px-2 py-1 text-[var(--brand-fg)] placeholder-[var(--brand-muted)] focus:border-[var(--brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-primary)]"
-              />
-              <button
-                type="submit"
-                className="rounded cursor-pointer border border-[var(--brand-primary)] bg-[var(--brand-alt)] px-3 py-1 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-primary)] hover:text-[var(--brand-primary-contrast)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--brand-accent)] dark:bg-[var(--brand-primary)] dark:text-[var(--brand-ink)] dark:hover:bg-[var(--brand-alt)] dark:hover:text-[var(--brand-primary)]"
-              >
-                Subscribe
-              </button>
-            </form>
+            <NewsletterSignupForm />
           </div>
         </div>
         <div className="mt-4 flex flex-col items-center justify-between gap-2 border-t border-[var(--brand-border)] pt-3 text-sm text-[var(--brand-muted)] md:flex-row md:justify-center md:gap-8">

--- a/components/NewsletterSignupForm.tsx
+++ b/components/NewsletterSignupForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { FormEvent, useId, useState } from "react";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+type NewsletterSignupFormProps = {
+  className?: string;
+};
+
+export default function NewsletterSignupForm({ className }: NewsletterSignupFormProps) {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [message, setMessage] = useState("");
+  const feedbackId = useId();
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail) {
+      setStatus("error");
+      setMessage("Please enter an email address.");
+      return;
+    }
+
+    if (!emailRegex.test(trimmedEmail)) {
+      setStatus("error");
+      setMessage("Please enter a valid email address.");
+      return;
+    }
+
+    setStatus("loading");
+    setMessage("");
+
+    try {
+      const response = await fetch("/api/newsletter", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email: trimmedEmail }),
+        cache: "no-store",
+      });
+
+      if (response.ok) {
+        setStatus("success");
+        setMessage("Thanks for subscribing! Please check your inbox for updates.");
+        setEmail("");
+      } else {
+        const data = await response.json().catch(() => null);
+        const errorMessage =
+          data && typeof data.error === "string"
+            ? data.error
+            : "We couldn't add you to the newsletter right now. Please try again.";
+        setStatus("error");
+        setMessage(errorMessage);
+      }
+    } catch (error) {
+      console.error("Newsletter signup request failed", error);
+      setStatus("error");
+      setMessage("We couldn't reach the server. Please try again soon.");
+    }
+  };
+
+  const isSubmitting = status === "loading";
+  const feedbackMessage = message ? (
+    <p
+      id={feedbackId}
+      role={status === "error" ? "alert" : "status"}
+      className={`text-sm ${
+        status === "error"
+          ? "text-[color-mix(in_oklab,_var(--brand-primary-contrast)_85%,_var(--brand-accent)_15%)]"
+          : "text-[var(--brand-accent)]"
+      } sm:order-3 sm:basis-full sm:pt-1`}
+    >
+      {message}
+    </p>
+  ) : null;
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={`flex w-full flex-col gap-2 sm:flex-row sm:items-center${className ? ` ${className}` : ""}`}
+      noValidate
+    >
+      <input
+        type="email"
+        name="email"
+        placeholder="Email address"
+        className="flex-1 rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] px-2 py-1 text-[var(--brand-fg)] placeholder-[var(--brand-muted)] focus:border-[var(--brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-primary)]"
+        autoComplete="email"
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+        disabled={isSubmitting}
+        aria-describedby={message ? feedbackId : undefined}
+        aria-invalid={status === "error" ? "true" : undefined}
+        required
+      />
+      <button
+        type="submit"
+        className="cursor-pointer rounded border border-[var(--brand-primary)] bg-[var(--brand-alt)] px-3 py-1 text-sm font-medium text-[var(--brand-primary)] transition hover:bg-[var(--brand-primary)] hover:text-[var(--brand-primary-contrast)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--brand-accent)] disabled:cursor-not-allowed disabled:opacity-70 dark:bg-[var(--brand-primary)] dark:text-[var(--brand-ink)] dark:hover:bg-[var(--brand-alt)] dark:hover:text-[var(--brand-primary)]"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? "Submitting…" : "Subscribe"}
+      </button>
+      {feedbackMessage}
+    </form>
+  );
+}

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -1,0 +1,22 @@
+# Manual Testing – Newsletter Signup
+
+These steps verify the new newsletter signup handler and footer form wiring.
+
+## Prerequisites
+
+- Ensure the Gmail service account configuration used elsewhere in the project is valid so that `sendEmail` can send mail.
+- Set `NEWSLETTER_TARGET_EMAIL` (and optionally `NEWSLETTER_FORWARD_SUBJECT`) in your environment before starting the Next.js dev server. The address should be a mailbox you control for verification.
+
+## Test Steps
+
+1. Run the development server with `npm run dev`.
+2. Visit `http://localhost:3000` in a browser and scroll to the footer.
+3. Enter a valid email address (for example, `subscriber@example.com`) and submit the form.
+   - The button is disabled while the request is processed.
+   - A green success message appears when the API responds with `200 OK`.
+   - An email is delivered to the configured `NEWSLETTER_TARGET_EMAIL` inbox containing the subscriber address and timestamp.
+4. Refresh the page and submit the form with an empty field to confirm client-side validation shows an inline error.
+5. Submit the form with an invalid value such as `not-an-email` and verify the red error message appears without making a network request.
+6. Temporarily remove or change `NEWSLETTER_TARGET_EMAIL` so the API returns an error, then submit a valid email again and confirm a red error message informs the user of the failure.
+
+Document the test results in your release notes or issue tracker so future regressions can be caught quickly.


### PR DESCRIPTION
## Summary
- add a `/api/newsletter` endpoint that validates submitted emails and forwards them through the existing Gmail helper
- replace the footer newsletter form with a client component that calls the new endpoint and surfaces inline success/error messaging
- capture newsletter signup manual test steps so regressions can be checked quickly

## Testing
- npm run lint
- npm test *(fails: existing brand color violation in `sanity/plugins/calendarSyncTool/index.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68d089619e74832c8d06e695184e6fd1