### PR TITLE
Add desktop action guidance to social CTA

### DIFF
--- a/components/SocialCTA.tsx
+++ b/components/SocialCTA.tsx
@@ -41,7 +41,14 @@ function parseSmsHref(href: string): { number: string; body: string } | null {
   const decodedNumber = rawNumber ? decodeURIComponent(rawNumber) : "";
   const firstNumber = decodedNumber.split(/[;,]/)[0]?.trim() ?? "";
   const params = new URLSearchParams(rawQuery);
-  const bodyParam = params.get("body") ?? params.get("text") ?? "";
+  let bodyParam = "";
+  for (const [key, value] of params.entries()) {
+    const normalizedKey = key.trim().toLowerCase();
+    if (normalizedKey === "body" || normalizedKey === "text") {
+      bodyParam = value;
+      break;
+    }
+  }
   const body = bodyParam.replace(/\s+/g, " ").trim();
   return { number: firstNumber, body };
 }
@@ -152,7 +159,7 @@ export default async function SocialCTA() {
 
   const socials: SocialItem[] = (settings?.socialLinks ?? [])
     .map(({ label, href, description = "", icon }) => {
-      const Icon = SocialIcons[icon];
+      const Icon = icon ? SocialIcons[icon] ?? SocialIcons[icon.toLowerCase()] : undefined;
       if (!Icon || !href) return null;
       return {
         label,


### PR DESCRIPTION
## Summary
- derive a descriptive action for SMS-based social links so desktop visitors know how to respond
- format extracted phone numbers and enrich social cards with conditional descriptions and aria labels

## Testing
- npm run lint
- npm run test *(fails: Brand color violation in sanity/plugins/calendarSyncTool/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d086318e98832c83c02e986b17b853