### PR TITLE
Refactor theme tokens for refreshed palette

### DIFF
--- a/app/about/staff/page.tsx
+++ b/app/about/staff/page.tsx
@@ -7,8 +7,8 @@ export default async function Page() {
   const staff = await staffAll();
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Staff</h1>
-      <p className="text-lg text-[var(--brand-muted)]">
+      <h1 className="text-2xl font-semibold text-[var(--brand-heading-primary)]">Staff</h1>
+      <p className="text-lg text-[var(--brand-body-primary)]">
         Our ministry team is dedicated to serving the congregation with love and
         humility. Meet the people who help lead our church community.
       </p>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
           Get in touch with us using the contact form below.
         </p>
       </div>
-      <div className="mx-auto max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] p-6 shadow-xl">
+      <div className="mx-auto max-w-3xl rounded-3xl bg-[var(--brand-bg)] p-6 shadow-xl">
         <ContactForm
           pageId={formSettings?.pageId}
           formId={formSettings?.formId}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
           Get in touch with us using the contact form below.
         </p>
       </div>
-      <div className="mx-auto max-w-3xl rounded-3xl bg-[var(--brand-bg)] p-6 shadow-xl">
+      <div className="mx-auto max-w-3xl">
         <ContactForm
           pageId={formSettings?.pageId}
           formId={formSettings?.formId}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -6,17 +6,19 @@ export default async function Page() {
   const formSettings = await contactFormSettings();
 
   return (
-    <div>
-      <div className="text-center">
-        <h1 className="text-2xl font-semibold">Contact</h1>
-        <p className="mt-2 text-sm text-[var(--brand-muted)]">
+    <div className="space-y-8">
+      <div className="text-center space-y-3">
+        <h1 className="text-3xl font-semibold text-[var(--brand-heading-primary)]">Contact</h1>
+        <p className="mx-auto max-w-2xl text-base text-[var(--brand-body-primary)]">
           Get in touch with us using the contact form below.
         </p>
       </div>
-      <ContactForm
-        pageId={formSettings?.pageId}
-        formId={formSettings?.formId}
-      />
+      <div className="mx-auto max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] p-6 shadow-xl">
+        <ContactForm
+          pageId={formSettings?.pageId}
+          formId={formSettings?.formId}
+        />
+      </div>
     </div>
   );
 }

--- a/app/contact/prayer-requests/page.tsx
+++ b/app/contact/prayer-requests/page.tsx
@@ -7,15 +7,21 @@ export default async function Page() {
   const formSettings = await prayerRequestFormSettings();
 
   return (
-    <div className="max-w-md mx-auto p-4">
-      <h1 className="text-3xl font-semibold text-center animate-slide-in-from-top">
-        Prayer Requests
-      </h1>
-
-      <PrayerRequestForm
-        pageId={formSettings?.pageId}
-        formId={formSettings?.formId}
-      />
+    <div className="space-y-8">
+      <div className="mx-auto max-w-2xl space-y-3 text-center">
+        <h1 className="text-3xl font-semibold text-[var(--brand-heading-primary)] animate-slide-in-from-top">
+          Prayer Requests
+        </h1>
+        <p className="text-base text-[var(--brand-body-primary)]">
+          Share your prayer needs and our team will partner with you in prayer.
+        </p>
+      </div>
+      <div className="mx-auto max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] p-6 shadow-xl">
+        <PrayerRequestForm
+          pageId={formSettings?.pageId}
+          formId={formSettings?.formId}
+        />
+      </div>
     </div>
   );
 }

--- a/app/contact/prayer-requests/page.tsx
+++ b/app/contact/prayer-requests/page.tsx
@@ -16,7 +16,7 @@ export default async function Page() {
           Share your prayer needs and our team will partner with you in prayer.
         </p>
       </div>
-      <div className="mx-auto max-w-3xl rounded-3xl bg-[var(--brand-bg)] p-6 shadow-xl">
+      <div className="mx-auto max-w-3xl">
         <PrayerRequestForm
           pageId={formSettings?.pageId}
           formId={formSettings?.formId}

--- a/app/contact/prayer-requests/page.tsx
+++ b/app/contact/prayer-requests/page.tsx
@@ -16,7 +16,7 @@ export default async function Page() {
           Share your prayer needs and our team will partner with you in prayer.
         </p>
       </div>
-      <div className="mx-auto max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] p-6 shadow-xl">
+      <div className="mx-auto max-w-3xl rounded-3xl bg-[var(--brand-bg)] p-6 shadow-xl">
         <PrayerRequestForm
           pageId={formSettings?.pageId}
           formId={formSettings?.formId}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -16,7 +16,7 @@ export default async function Page() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-center text-[var(--brand-accent)]">
+      <h1 className="text-2xl font-semibold text-center text-[var(--brand-heading-primary)]">
         Events
       </h1>
       <section className="w-full">

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -36,30 +36,22 @@ export default async function FaqPage() {
   return (
     <div className="space-y-12">
       <header className="mx-auto max-w-3xl space-y-4 text-center">
-        <p className="text-sm font-semibold uppercase tracking-[0.35em] text-[var(--brand-muted)]">
+        <p className="text-sm font-semibold uppercase tracking-[0.35em] text-[var(--brand-body-primary)]">
           Discover & Learn
         </p>
-        <h1 className="text-3xl font-semibold text-[var(--brand-alt)] sm:text-4xl">
+        <h1 className="text-3xl font-semibold text-[var(--brand-heading-primary)] sm:text-4xl">
           Frequently Asked Questions
         </h1>
-        <p className="text-base text-[color:color-mix(in_oklab,var(--brand-alt)_85%,transparent)]">
+        <p className="text-base text-[var(--brand-body-primary)]">
           Explore quick answers to the most common GPTWeb questions, and launch the assistant whenever you need a deeper dive.
         </p>
       </header>
 
       {(hasTrending || hasEvents) && (
-        <section className="relative overflow-hidden rounded-3xl border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface)_85%,black_15%)] p-6 shadow-xl">
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute -top-16 -right-16 h-48 w-48 rounded-full bg-[color:color-mix(in_oklab,var(--brand-primary)_45%,transparent)] blur-3xl opacity-50"
-          />
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute -bottom-20 -left-12 h-44 w-44 rounded-full bg-[color:color-mix(in_oklab,var(--brand-accent)_45%,transparent)] blur-3xl opacity-40"
-          />
-          <div className="relative grid gap-6 md:grid-cols-2">
+        <section className="brand-surface rounded-3xl border-2 border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 shadow-xl">
+          <div className="grid gap-6 md:grid-cols-2">
             <div className="space-y-3">
-              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-[var(--brand-muted)]">
+              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-[var(--brand-body-secondary)]">
                 <span aria-hidden="true" className="text-xl">🔥</span>
                 Trending Questions
               </div>
@@ -68,13 +60,13 @@ export default async function FaqPage() {
                   {trending.map((faq) => {
                     const prompt =
                       faq.assistantPrompt?.trim() ||
-                      `I'd like more detail about the FAQ titled \"${faq.question}\".`;
+                      `I'd like more detail about the FAQ titled "${faq.question}".`;
                     return (
                       <li
                         key={faq._id}
-                        className="flex items-center justify-between gap-4 rounded-2xl border border-[color:color-mix(in_oklab,var(--brand-border)_60%,transparent)] bg-[color:color-mix(in_oklab,var(--brand-primary)_25%,transparent)] px-4 py-3 shadow-sm backdrop-blur-sm"
+                        className="flex items-center justify-between gap-4 rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 py-3 shadow-sm"
                       >
-                        <span className="flex-1 text-sm font-medium text-[var(--brand-alt)]/95">
+                        <span className="flex-1 text-sm font-medium text-[var(--brand-heading-secondary)]">
                           {faq.question}
                         </span>
                         <FaqAssistantChip
@@ -87,13 +79,13 @@ export default async function FaqPage() {
                   })}
                 </ul>
               ) : (
-                <p className="rounded-2xl border border-dashed border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface)_92%,white_8%)] px-4 py-3 text-sm text-[var(--brand-alt)]/85">
+                <p className="rounded-2xl border-2 border-dashed border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 py-3 text-sm text-[var(--brand-body-secondary)]">
                   Check back soon for the most popular conversations people are starting with the assistant.
                 </p>
               )}
             </div>
             <div className="space-y-3">
-              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-[var(--brand-muted)]">
+              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-[var(--brand-body-secondary)]">
                 <span aria-hidden="true" className="text-xl">📅</span>
                 Upcoming Events
               </div>
@@ -102,15 +94,15 @@ export default async function FaqPage() {
                   {events.map((event) => (
                     <li
                       key={event.id}
-                      className="rounded-2xl border border-[color:color-mix(in_oklab,var(--brand-border)_60%,transparent)] bg-[color:color-mix(in_oklab,var(--brand-alt)_18%,var(--brand-surface)_82%)] px-4 py-3 shadow-sm"
+                      className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 py-3 shadow-sm"
                     >
-                      <div className="flex flex-col gap-1 text-[var(--brand-alt)]/90">
-                        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--brand-muted)]">
+                      <div className="flex flex-col gap-1 text-[var(--brand-body-secondary)]">
+                        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--brand-body-secondary)]">
                           {event.dateLabel}
                         </span>
                         <Link
                           href={event.href}
-                          className="text-sm font-medium underline decoration-[var(--brand-alt)] underline-offset-4 hover:opacity-85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]"
+                          className="text-sm font-medium text-[var(--brand-heading-secondary)] underline decoration-[var(--brand-heading-secondary)] underline-offset-4 hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-heading-secondary)]"
                         >
                           {event.title}
                         </Link>
@@ -119,7 +111,7 @@ export default async function FaqPage() {
                   ))}
                 </ul>
               ) : (
-                <p className="rounded-2xl border border-dashed border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface)_92%,white_8%)] px-4 py-3 text-sm text-[var(--brand-alt)]/85">
+                <p className="rounded-2xl border-2 border-dashed border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 py-3 text-sm text-[var(--brand-body-secondary)]">
                   No upcoming events are on the calendar yet, but our assistant is happy to help you plan ahead.
                 </p>
               )}
@@ -130,10 +122,10 @@ export default async function FaqPage() {
 
       <section className="space-y-6">
         <div className="flex flex-col items-center gap-3 text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-muted)]">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-body-primary)]">
             Browse Answers
           </p>
-          <p className="max-w-2xl text-sm text-[color:color-mix(in_oklab,var(--brand-alt)_80%,transparent)]">
+          <p className="max-w-2xl text-sm text-[var(--brand-body-primary)]">
             Expand any card for guidance, resources, and quick ways to spin up a follow-up conversation with the assistant.
           </p>
         </div>

--- a/app/giving/page.tsx
+++ b/app/giving/page.tsx
@@ -100,8 +100,8 @@ function OptionCard({ option, delay }: { option: Option; delay: string }) {
       style={{ animationDelay: delay }}
     >
       <div className="flex items-center gap-3">
-        <Icon className="h-8 w-8 text-[var(--brand-accent)] transition-transform group-hover:rotate-6" />
-        <h2 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">
+        <Icon className="h-8 w-8 text-[var(--brand-heading-secondary)] transition-transform group-hover:rotate-6" />
+        <h2 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">
           {option.title}
         </h2>
       </div>
@@ -110,12 +110,12 @@ function OptionCard({ option, delay }: { option: Option; delay: string }) {
           href={option.href}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-[var(--brand-accent)] underline decoration-[var(--brand-accent)] underline-offset-2 hover:text-[var(--brand-primary-contrast)]"
+          className="text-[var(--brand-body-secondary)] underline decoration-[var(--brand-body-secondary)] underline-offset-2 hover:text-[var(--brand-heading-secondary)]"
         >
           {option.content}
         </a>
       ) : (
-        <p className="text-[var(--brand-accent)]">{option.content}</p>
+        <p className="text-[var(--brand-body-secondary)]">{option.content}</p>
       )}
     </div>
   );
@@ -130,8 +130,8 @@ export default async function Page() {
   return (
     <div className="w-full space-y-8">
       <div className="space-y-2">
-        <h1 className="text-2xl font-semibold text-[var(--brand-primary-contrast)]">Online Contributions</h1>
-        <p className="text-sm text-[var(--brand-accent)]">Donations are Tax Deductible</p>
+        <h1 className="text-2xl font-semibold text-[var(--brand-heading-primary)]">Online Contributions</h1>
+        <p className="text-sm text-[var(--brand-body-primary)]">Donations are Tax Deductible</p>
       </div>
       <div className="grid gap-6 sm:grid-cols-2">
         {options.map((opt, idx) => (

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,16 +81,20 @@ img {
   --brand-primary-contrast: #FFFFFF;
   --brand-accent: #D6AF36; /* warm gold highlight */
   --brand-ink: #121212; /* neutral contrast for light surfaces */
-  --brand-alt: color-mix(in oklab, var(--brand-primary) 45%, var(--brand-ink) 55%); /* elevated headings/links */
+  --brand-alt: color-mix(in oklab, var(--brand-primary) 55%, var(--brand-ink) 45%); /* elevated headings/links */
 
   --brand-bg: #FFFFFF; /* default page surface */
   --brand-fg: var(--brand-ink);
-  --brand-muted: color-mix(in oklab, var(--brand-ink) 55%, white 45%);
-  --brand-border: color-mix(in oklab, var(--brand-ink) 18%, white 82%);
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 6%, white 94%);
-  --brand-surface-contrast: var(--brand-ink);
-  --brand-overlay: color-mix(in oklab, var(--brand-ink) 25%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 12%, transparent);
+  --brand-muted: color-mix(in oklab, var(--brand-ink) 50%, white 50%);
+  --brand-border: color-mix(
+    in oklab,
+    color-mix(in oklab, var(--brand-ink) 16%, white 84%),
+    var(--brand-primary) 22%
+  );
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 10%, white 90%);
+  --brand-surface-contrast: color-mix(in oklab, var(--brand-ink) 92%, var(--brand-primary) 8%);
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 20%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 8%, transparent);
 
   /* Layout and component variables (defaults) */
   --layout-max-width: 90vw;
@@ -108,30 +112,30 @@ img {
   :root {
     /* Dark mode overrides */
     --brand-primary: #B19CD9;
-    --brand-bg: color-mix(in oklab, var(--brand-primary) 12%, black);
-    --brand-surface: color-mix(in oklab, var(--brand-primary) 24%, black);
-    --brand-fg: color-mix(in oklab, white 90%, var(--brand-accent) 10%);
-    --brand-muted: color-mix(in oklab, var(--brand-accent) 55%, var(--brand-fg) 45%);
-    --brand-border: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
-    --brand-surface-contrast: color-mix(in oklab, white 94%, var(--brand-accent) 6%);
-    --brand-alt: color-mix(in oklab, var(--brand-accent) 75%, white 25%);
-    --brand-overlay: color-mix(in oklab, black 45%, transparent);
-    --brand-overlay-muted: color-mix(in oklab, black 65%, transparent);
+    --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
+    --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
+    --brand-fg: var(--brand-accent);
+    --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
+    --brand-border: var(--brand-accent);
+    --brand-surface-contrast: var(--brand-primary-contrast);
+    --brand-alt: #FFFFFF;
+    --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
+    --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
   }
 }
 
 [data-theme="dark"],
 html[data-theme="dark"] {
   --brand-primary: #B19CD9;
-  --brand-bg: color-mix(in oklab, var(--brand-primary) 12%, black);
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 24%, black);
-  --brand-fg: color-mix(in oklab, white 90%, var(--brand-accent) 10%);
-  --brand-muted: color-mix(in oklab, var(--brand-accent) 55%, var(--brand-fg) 45%);
-  --brand-border: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
-  --brand-surface-contrast: color-mix(in oklab, white 94%, var(--brand-accent) 6%);
-  --brand-alt: color-mix(in oklab, var(--brand-accent) 75%, white 25%);
-  --brand-overlay: color-mix(in oklab, black 45%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, black 65%, transparent);
+  --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
+  --brand-fg: var(--brand-accent);
+  --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
+  --brand-border: var(--brand-accent);
+  --brand-surface-contrast: var(--brand-primary-contrast);
+  --brand-alt: #FFFFFF;
+  --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
 }
 
 
@@ -142,15 +146,19 @@ html {
   --brand-primary-contrast: #FFFFFF;
   --brand-accent: #D6AF36;
   --brand-ink: #121212;
-  --brand-alt: color-mix(in oklab, var(--brand-primary) 45%, var(--brand-ink) 55%);
+  --brand-alt: color-mix(in oklab, var(--brand-primary) 55%, var(--brand-ink) 45%);
   --brand-bg: #FFFFFF;
   --brand-fg: var(--brand-ink);
-  --brand-muted: color-mix(in oklab, var(--brand-ink) 55%, white 45%);
-  --brand-border: color-mix(in oklab, var(--brand-ink) 18%, white 82%);
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 6%, white 94%);
-  --brand-surface-contrast: var(--brand-ink);
-  --brand-overlay: color-mix(in oklab, var(--brand-ink) 25%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 12%, transparent);
+  --brand-muted: color-mix(in oklab, var(--brand-ink) 50%, white 50%);
+  --brand-border: color-mix(
+    in oklab,
+    color-mix(in oklab, var(--brand-ink) 16%, white 84%),
+    var(--brand-primary) 22%
+  );
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 10%, white 90%);
+  --brand-surface-contrast: color-mix(in oklab, var(--brand-ink) 92%, var(--brand-primary) 8%);
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 20%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 8%, transparent);
 
   /* Font variable fallbacks (overridden by next/font classes on <html>) */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/app/globals.css
+++ b/app/globals.css
@@ -77,21 +77,20 @@ img {
 :root {
   /* Light mode defaults */
   --watermark-url: none;
-  --brand-primary: #5C30A6; /* purple */
+  --brand-primary: #5C30A6; /* rich GPT purple */
   --brand-primary-contrast: #FFFFFF;
-  --brand-accent: #D6AF36; /* gold */
-  --brand-alt: #FFFFFF; /* alt is white in all modes */
-  --brand-ink: #121212; /* deep ink for overlays */
+  --brand-accent: #D6AF36; /* warm gold highlight */
+  --brand-ink: #121212; /* neutral contrast for light surfaces */
+  --brand-alt: color-mix(in oklab, var(--brand-primary) 45%, var(--brand-ink) 55%); /* elevated headings/links */
 
-  /* Set the entire page background to brand purple and ensure strong contrast */
-  --brand-bg: #5C30A6; /* brand purple page background */
-  --brand-fg: #FFFFFF; /* white text for contrast on purple */
-  --brand-muted: var(--brand-accent); /* prefer accent over gray */
-  --brand-border: #8C6A15; /* deep gold border for contrast on purple */
-  --brand-surface: #4A258E; /* deeper purple surface panels */
-  --brand-surface-contrast: #FFFFFF; /* white for headings on surface */
-  --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
+  --brand-bg: #FFFFFF; /* default page surface */
+  --brand-fg: var(--brand-ink);
+  --brand-muted: color-mix(in oklab, var(--brand-ink) 55%, white 45%);
+  --brand-border: color-mix(in oklab, var(--brand-ink) 18%, white 82%);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 6%, white 94%);
+  --brand-surface-contrast: var(--brand-ink);
+  --brand-overlay: color-mix(in oklab, var(--brand-ink) 25%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 12%, transparent);
 
   /* Layout and component variables (defaults) */
   --layout-max-width: 90vw;
@@ -108,27 +107,31 @@ img {
 @media (prefers-color-scheme: dark) {
   :root {
     /* Dark mode overrides */
-    --brand-primary: #B19CD9; /* lighter purple for dark for contrast */
-    --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
-    --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
-    /* Revert body text to brand accent (gold) in dark mode per preference */
-    --brand-fg: var(--brand-accent);
-    /* Make muted text distinct from main fg in dark mode */
-    --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
-    --brand-border: var(--brand-accent);
-    --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 60%, transparent);
+    --brand-primary: #B19CD9;
+    --brand-bg: color-mix(in oklab, var(--brand-primary) 12%, black);
+    --brand-surface: color-mix(in oklab, var(--brand-primary) 24%, black);
+    --brand-fg: color-mix(in oklab, white 90%, var(--brand-accent) 10%);
+    --brand-muted: color-mix(in oklab, var(--brand-accent) 55%, var(--brand-fg) 45%);
+    --brand-border: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
+    --brand-surface-contrast: color-mix(in oklab, white 94%, var(--brand-accent) 6%);
+    --brand-alt: color-mix(in oklab, var(--brand-accent) 75%, white 25%);
+    --brand-overlay: color-mix(in oklab, black 45%, transparent);
+    --brand-overlay-muted: color-mix(in oklab, black 65%, transparent);
   }
 }
 
 [data-theme="dark"],
 html[data-theme="dark"] {
   --brand-primary: #B19CD9;
-  --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
-  --brand-fg: var(--brand-accent);
-  --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
-  --brand-border: var(--brand-accent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 60%, transparent);
+  --brand-bg: color-mix(in oklab, var(--brand-primary) 12%, black);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 24%, black);
+  --brand-fg: color-mix(in oklab, white 90%, var(--brand-accent) 10%);
+  --brand-muted: color-mix(in oklab, var(--brand-accent) 55%, var(--brand-fg) 45%);
+  --brand-border: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
+  --brand-surface-contrast: color-mix(in oklab, white 94%, var(--brand-accent) 6%);
+  --brand-alt: color-mix(in oklab, var(--brand-accent) 75%, white 25%);
+  --brand-overlay: color-mix(in oklab, black 45%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, black 65%, transparent);
 }
 
 
@@ -138,16 +141,16 @@ html {
   --brand-primary: #5C30A6;
   --brand-primary-contrast: #FFFFFF;
   --brand-accent: #D6AF36;
-  --brand-alt: #FFFFFF; /* alt is white in all modes */
-  --brand-ink: #121212; /* deep ink for overlays */
-  --brand-bg: #5C30A6;
-  --brand-fg: #FFFFFF; /* white on purple */
-  --brand-muted: var(--brand-accent); /* accent for low-contrast text */
-  --brand-border: #8C6A15; /* deep gold */
-  --brand-surface: #4A258E; /* deeper purple */
-  --brand-surface-contrast: #FFFFFF; /* white */
-  --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
+  --brand-ink: #121212;
+  --brand-alt: color-mix(in oklab, var(--brand-primary) 45%, var(--brand-ink) 55%);
+  --brand-bg: #FFFFFF;
+  --brand-fg: var(--brand-ink);
+  --brand-muted: color-mix(in oklab, var(--brand-ink) 55%, white 45%);
+  --brand-border: color-mix(in oklab, var(--brand-ink) 18%, white 82%);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 6%, white 94%);
+  --brand-surface-contrast: var(--brand-ink);
+  --brand-overlay: color-mix(in oklab, var(--brand-ink) 25%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 12%, transparent);
 
   /* Font variable fallbacks (overridden by next/font classes on <html>) */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/app/globals.css
+++ b/app/globals.css
@@ -88,13 +88,13 @@ img {
   --brand-muted: color-mix(in oklab, var(--brand-ink) 50%, white 50%);
   --brand-border: color-mix(
     in oklab,
-    color-mix(in oklab, var(--brand-ink) 16%, white 84%),
-    var(--brand-primary) 22%
+    color-mix(in oklab, white 78%, var(--brand-ink) 22%),
+    var(--brand-primary) 38%
   );
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 10%, white 90%);
-  --brand-surface-contrast: color-mix(in oklab, var(--brand-ink) 92%, var(--brand-primary) 8%);
-  --brand-overlay: color-mix(in oklab, var(--brand-primary) 20%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 8%, transparent);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
+  --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 92%, var(--brand-accent) 8%);
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 42%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 18%, transparent);
 
   /* Layout and component variables (defaults) */
   --layout-max-width: 90vw;
@@ -112,30 +112,30 @@ img {
   :root {
     /* Dark mode overrides */
     --brand-primary: #B19CD9;
-    --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
-    --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
+    --brand-bg: color-mix(in oklab, black 78%, var(--brand-primary) 22%);
+    --brand-surface: color-mix(in oklab, black 64%, var(--brand-primary) 36%);
     --brand-fg: var(--brand-accent);
-    --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
-    --brand-border: var(--brand-accent);
-    --brand-surface-contrast: var(--brand-primary-contrast);
+    --brand-muted: color-mix(in oklab, var(--brand-accent) 58%, #2d1a4c 42%);
+    --brand-border: color-mix(in oklab, var(--brand-accent) 65%, var(--brand-primary) 35%);
+    --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 85%, var(--brand-accent) 15%);
     --brand-alt: #FFFFFF;
-    --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
-    --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
+    --brand-overlay: color-mix(in oklab, var(--brand-primary) 38%, transparent);
+    --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 22%, transparent);
   }
 }
 
 [data-theme="dark"],
 html[data-theme="dark"] {
   --brand-primary: #B19CD9;
-  --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
+  --brand-bg: color-mix(in oklab, black 78%, var(--brand-primary) 22%);
+  --brand-surface: color-mix(in oklab, black 64%, var(--brand-primary) 36%);
   --brand-fg: var(--brand-accent);
-  --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
-  --brand-border: var(--brand-accent);
-  --brand-surface-contrast: var(--brand-primary-contrast);
+  --brand-muted: color-mix(in oklab, var(--brand-accent) 58%, #2d1a4c 42%);
+  --brand-border: color-mix(in oklab, var(--brand-accent) 65%, var(--brand-primary) 35%);
+  --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 85%, var(--brand-accent) 15%);
   --brand-alt: #FFFFFF;
-  --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 30%, transparent);
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 38%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 22%, transparent);
 }
 
 
@@ -152,13 +152,13 @@ html {
   --brand-muted: color-mix(in oklab, var(--brand-ink) 50%, white 50%);
   --brand-border: color-mix(
     in oklab,
-    color-mix(in oklab, var(--brand-ink) 16%, white 84%),
-    var(--brand-primary) 22%
+    color-mix(in oklab, white 78%, var(--brand-ink) 22%),
+    var(--brand-primary) 38%
   );
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 10%, white 90%);
-  --brand-surface-contrast: color-mix(in oklab, var(--brand-ink) 92%, var(--brand-primary) 8%);
-  --brand-overlay: color-mix(in oklab, var(--brand-primary) 20%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 8%, transparent);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
+  --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 92%, var(--brand-accent) 8%);
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 42%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 18%, transparent);
 
   /* Font variable fallbacks (overridden by next/font classes on <html>) */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,6 +17,19 @@ body {
   @apply antialiased transition-colors;
 }
 
+/* Ensure secondary surfaces default to white copy for readability */
+[class*="brand-surface"] {
+  color: var(--brand-surface-contrast) !important;
+}
+
+[class*="brand-surface"] * {
+  color: var(--brand-surface-contrast) !important;
+}
+
+[class*="brand-surface"] a {
+  color: var(--brand-surface-contrast) !important;
+}
+
 h1,
 h2,
 h3,
@@ -81,21 +94,17 @@ img {
   --brand-primary-contrast: #FFFFFF;
   --brand-accent: #D6AF36; /* warm gold highlight */
   --brand-ink: #121212; /* neutral contrast for light surfaces */
-  --brand-alt: color-mix(in oklab, var(--brand-primary) 55%, var(--brand-ink) 45%); /* elevated headings/links */
+  --brand-alt: color-mix(in oklab, var(--brand-primary) 40%, var(--brand-accent) 60%);
 
   --brand-bg: #FFFFFF; /* default page surface */
-  --brand-fg: var(--brand-ink);
-  --brand-muted: color-mix(in oklab, var(--brand-ink) 50%, white 50%);
-  --brand-border: color-mix(
-    in oklab,
-    color-mix(in oklab, white 78%, var(--brand-ink) 22%),
-    var(--brand-primary) 38%
-  );
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 75%, white 25%);
-  --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
-  --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 92%, var(--brand-accent) 8%);
-  --brand-overlay: color-mix(in oklab, var(--brand-primary) 52%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 24%, transparent);
+  --brand-fg: var(--brand-accent);
+  --brand-muted: color-mix(in oklab, var(--brand-accent) 45%, white 55%);
+  --brand-border: var(--brand-accent);
+  --brand-surface: var(--brand-primary);
+  --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
+  --brand-surface-contrast: #FFFFFF;
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 60%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 35%, transparent);
 
   /* Layout and component variables (defaults) */
   --layout-max-width: 90vw;
@@ -113,9 +122,9 @@ img {
   :root {
     /* Dark mode overrides */
     --brand-primary: #B19CD9; /* lighter purple for dark for contrast */
-    --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
-    --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
-    --brand-primary-muted: var(--brand-primary);
+    --brand-bg: color-mix(in oklab, #080211 85%, var(--brand-primary) 15%);
+    --brand-surface: color-mix(in oklab, #120322 65%, var(--brand-primary) 35%);
+    --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 55%, white 45%);
     --brand-fg: var(--brand-accent);
     /* Make muted text distinct from main fg in dark mode */
     --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
@@ -150,20 +159,16 @@ html {
   --brand-primary-contrast: #FFFFFF;
   --brand-accent: #D6AF36;
   --brand-ink: #121212;
-  --brand-alt: color-mix(in oklab, var(--brand-primary) 55%, var(--brand-ink) 45%);
+  --brand-alt: color-mix(in oklab, var(--brand-primary) 40%, var(--brand-accent) 60%);
   --brand-bg: #FFFFFF;
-  --brand-fg: var(--brand-ink);
-  --brand-muted: color-mix(in oklab, var(--brand-ink) 50%, white 50%);
-  --brand-border: color-mix(
-    in oklab,
-    color-mix(in oklab, white 78%, var(--brand-ink) 22%),
-    var(--brand-primary) 38%
-  );
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 75%, white 25%);
-  --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
-  --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 92%, var(--brand-accent) 8%);
-  --brand-overlay: color-mix(in oklab, var(--brand-primary) 52%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 24%, transparent);
+  --brand-fg: var(--brand-accent);
+  --brand-muted: color-mix(in oklab, var(--brand-accent) 45%, white 55%);
+  --brand-border: var(--brand-accent);
+  --brand-surface: var(--brand-primary);
+  --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
+  --brand-surface-contrast: #FFFFFF;
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 60%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 35%, transparent);
 
   /* Font variable fallbacks (overridden by next/font classes on <html>) */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,23 +11,16 @@
 body {
   /* Base typography colors and background driven by tokens */
   background-color: var(--brand-bg);
-  color: var(--brand-fg);
+  color: var(--surface-body-color);
   position: relative;
   font-family: var(--font-body), sans-serif;
   @apply antialiased transition-colors;
 }
 
-/* Ensure secondary surfaces default to white copy for readability */
-[class*="brand-surface"] {
-  color: var(--brand-surface-contrast) !important;
-}
-
-[class*="brand-surface"] * {
-  color: var(--brand-surface-contrast) !important;
-}
-
-[class*="brand-surface"] a {
-  color: var(--brand-surface-contrast) !important;
+/* Establish default surface-aware typography tokens */
+:root {
+  --surface-heading-color: var(--brand-heading-primary);
+  --surface-body-color: var(--brand-body-primary);
 }
 
 h1,
@@ -36,7 +29,40 @@ h3,
 h4,
 h5,
 h6 {
+  color: var(--surface-heading-color);
   font-family: var(--font-header), serif;
+}
+
+p,
+li,
+span,
+label,
+small,
+input,
+textarea {
+  color: inherit;
+}
+
+/* Secondary surfaces inherit their own typography palette */
+[class*="brand-surface"] {
+  --surface-heading-color: var(--brand-heading-secondary);
+  --surface-body-color: var(--brand-body-secondary);
+  --brand-muted: color-mix(in oklab, var(--brand-body-secondary) 65%, var(--brand-heading-secondary) 35%);
+  --brand-fg: var(--surface-body-color);
+  color: var(--surface-body-color);
+}
+
+[class*="brand-surface"] h1,
+[class*="brand-surface"] h2,
+[class*="brand-surface"] h3,
+[class*="brand-surface"] h4,
+[class*="brand-surface"] h5,
+[class*="brand-surface"] h6 {
+  color: var(--surface-heading-color);
+}
+
+[class*="brand-surface"] a {
+  color: inherit;
 }
 
 button,
@@ -96,15 +122,23 @@ img {
   --brand-ink: #121212; /* neutral contrast for light surfaces */
   --brand-alt: color-mix(in oklab, var(--brand-primary) 40%, var(--brand-accent) 60%);
 
+  --brand-heading-primary: color-mix(in oklab, var(--brand-accent) 85%, black 15%);
+  --brand-heading-secondary: #FFFFFF;
+  --brand-body-primary: var(--brand-ink);
+  --brand-body-secondary: color-mix(in oklab, var(--brand-accent) 92%, white 8%);
+
   --brand-bg: #FFFFFF; /* default page surface */
-  --brand-fg: var(--brand-accent);
-  --brand-muted: color-mix(in oklab, var(--brand-accent) 45%, white 55%);
-  --brand-border: var(--brand-accent);
+  --brand-fg: var(--brand-body-primary);
+  --brand-muted: color-mix(in oklab, var(--brand-ink) 45%, white 55%);
+  --brand-border: color-mix(in oklab, var(--brand-accent) 70%, black 30%);
+  --brand-border-strong: color-mix(in oklab, var(--brand-accent) 82%, black 18%);
   --brand-surface: var(--brand-primary);
   --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
   --brand-surface-contrast: #FFFFFF;
   --brand-overlay: color-mix(in oklab, var(--brand-primary) 60%, transparent);
   --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 35%, transparent);
+  --surface-heading-color: var(--brand-heading-primary);
+  --surface-body-color: var(--brand-body-primary);
 
   /* Layout and component variables (defaults) */
   --layout-max-width: 90vw;
@@ -125,10 +159,17 @@ img {
     --brand-bg: color-mix(in oklab, #080211 85%, var(--brand-primary) 15%);
     --brand-surface: color-mix(in oklab, #120322 65%, var(--brand-primary) 35%);
     --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 55%, white 45%);
-    --brand-fg: var(--brand-accent);
+    --brand-heading-primary: var(--brand-accent);
+    --brand-heading-secondary: var(--brand-primary-contrast);
+    --brand-body-primary: var(--brand-accent);
+    --brand-body-secondary: var(--brand-primary-contrast);
+    --surface-heading-color: var(--brand-heading-primary);
+    --surface-body-color: var(--brand-body-primary);
+    --brand-fg: var(--brand-body-primary);
     /* Make muted text distinct from main fg in dark mode */
     --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
     --brand-border: var(--brand-accent);
+    --brand-border-strong: color-mix(in oklab, var(--brand-accent) 70%, black 30%);
     --brand-surface-contrast: #FFFFFF;
     --brand-alt: #FFFFFF;
     --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
@@ -142,9 +183,16 @@ html[data-theme="dark"] {
   --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
   --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
   --brand-primary-muted: var(--brand-primary);
-  --brand-fg: var(--brand-accent);
+  --brand-heading-primary: var(--brand-accent);
+  --brand-heading-secondary: var(--brand-primary-contrast);
+  --brand-body-primary: var(--brand-accent);
+  --brand-body-secondary: var(--brand-primary-contrast);
+  --surface-heading-color: var(--brand-heading-primary);
+  --surface-body-color: var(--brand-body-primary);
+  --brand-fg: var(--brand-body-primary);
   --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
   --brand-border: var(--brand-accent);
+  --brand-border-strong: color-mix(in oklab, var(--brand-accent) 70%, black 30%);
   --brand-surface-contrast: #FFFFFF;
   --brand-alt: #FFFFFF;
   --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
@@ -160,15 +208,22 @@ html {
   --brand-accent: #D6AF36;
   --brand-ink: #121212;
   --brand-alt: color-mix(in oklab, var(--brand-primary) 40%, var(--brand-accent) 60%);
+  --brand-heading-primary: color-mix(in oklab, var(--brand-accent) 85%, black 15%);
+  --brand-heading-secondary: #FFFFFF;
+  --brand-body-primary: var(--brand-ink);
+  --brand-body-secondary: color-mix(in oklab, var(--brand-accent) 92%, white 8%);
   --brand-bg: #FFFFFF;
-  --brand-fg: var(--brand-accent);
-  --brand-muted: color-mix(in oklab, var(--brand-accent) 45%, white 55%);
-  --brand-border: var(--brand-accent);
+  --brand-fg: var(--brand-body-primary);
+  --brand-muted: color-mix(in oklab, var(--brand-ink) 45%, white 55%);
+  --brand-border: color-mix(in oklab, var(--brand-accent) 70%, black 30%);
+  --brand-border-strong: color-mix(in oklab, var(--brand-accent) 82%, black 18%);
   --brand-surface: var(--brand-primary);
   --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
   --brand-surface-contrast: #FFFFFF;
   --brand-overlay: color-mix(in oklab, var(--brand-primary) 60%, transparent);
   --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 35%, transparent);
+  --surface-heading-color: var(--brand-heading-primary);
+  --surface-body-color: var(--brand-body-primary);
 
   /* Font variable fallbacks (overridden by next/font classes on <html>) */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
   /* Fallback font variables; next/font will override via classes on <html> */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";
   --font-header: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;

--- a/app/globals.css
+++ b/app/globals.css
@@ -112,33 +112,34 @@ img {
 @media (prefers-color-scheme: dark) {
   :root {
     /* Dark mode overrides */
-    --brand-primary: #B19CD9;
-    --brand-bg: color-mix(in oklab, black 78%, var(--brand-primary) 22%);
-    --brand-surface: color-mix(in oklab, black 64%, var(--brand-primary) 36%);
-    --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 32%, var(--brand-bg) 68%);
+    --brand-primary: #B19CD9; /* lighter purple for dark for contrast */
+    --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
+    --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
+    --brand-primary-muted: var(--brand-primary);
     --brand-fg: var(--brand-accent);
-    --brand-muted: color-mix(in oklab, var(--brand-accent) 58%, #2d1a4c 42%);
-    --brand-border: color-mix(in oklab, var(--brand-accent) 65%, var(--brand-primary) 35%);
-    --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 85%, var(--brand-accent) 15%);
+    /* Make muted text distinct from main fg in dark mode */
+    --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
+    --brand-border: var(--brand-accent);
+    --brand-surface-contrast: #FFFFFF;
     --brand-alt: #FFFFFF;
-    --brand-overlay: color-mix(in oklab, var(--brand-primary) 38%, transparent);
-    --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 22%, transparent);
+    --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
+    --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 60%, transparent);
   }
 }
 
 [data-theme="dark"],
 html[data-theme="dark"] {
   --brand-primary: #B19CD9;
-  --brand-bg: color-mix(in oklab, black 78%, var(--brand-primary) 22%);
-  --brand-surface: color-mix(in oklab, black 64%, var(--brand-primary) 36%);
-  --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 32%, var(--brand-bg) 68%);
+  --brand-bg: color-mix(in oklab, var(--brand-primary) 18%, black);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 26%, black);
+  --brand-primary-muted: var(--brand-primary);
   --brand-fg: var(--brand-accent);
-  --brand-muted: color-mix(in oklab, var(--brand-accent) 58%, #2d1a4c 42%);
-  --brand-border: color-mix(in oklab, var(--brand-accent) 65%, var(--brand-primary) 35%);
-  --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 85%, var(--brand-accent) 15%);
+  --brand-muted: color-mix(in oklab, var(--brand-accent) 60%, var(--brand-ink) 40%);
+  --brand-border: var(--brand-accent);
+  --brand-surface-contrast: #FFFFFF;
   --brand-alt: #FFFFFF;
-  --brand-overlay: color-mix(in oklab, var(--brand-primary) 38%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 22%, transparent);
+  --brand-overlay: color-mix(in oklab, var(--brand-ink) 50%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-ink) 60%, transparent);
 }
 
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -91,10 +91,11 @@ img {
     color-mix(in oklab, white 78%, var(--brand-ink) 22%),
     var(--brand-primary) 38%
   );
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 75%, white 25%);
+  --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
   --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 92%, var(--brand-accent) 8%);
-  --brand-overlay: color-mix(in oklab, var(--brand-primary) 42%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 18%, transparent);
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 52%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 24%, transparent);
 
   /* Layout and component variables (defaults) */
   --layout-max-width: 90vw;
@@ -114,6 +115,7 @@ img {
     --brand-primary: #B19CD9;
     --brand-bg: color-mix(in oklab, black 78%, var(--brand-primary) 22%);
     --brand-surface: color-mix(in oklab, black 64%, var(--brand-primary) 36%);
+    --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 32%, var(--brand-bg) 68%);
     --brand-fg: var(--brand-accent);
     --brand-muted: color-mix(in oklab, var(--brand-accent) 58%, #2d1a4c 42%);
     --brand-border: color-mix(in oklab, var(--brand-accent) 65%, var(--brand-primary) 35%);
@@ -129,6 +131,7 @@ html[data-theme="dark"] {
   --brand-primary: #B19CD9;
   --brand-bg: color-mix(in oklab, black 78%, var(--brand-primary) 22%);
   --brand-surface: color-mix(in oklab, black 64%, var(--brand-primary) 36%);
+  --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 32%, var(--brand-bg) 68%);
   --brand-fg: var(--brand-accent);
   --brand-muted: color-mix(in oklab, var(--brand-accent) 58%, #2d1a4c 42%);
   --brand-border: color-mix(in oklab, var(--brand-accent) 65%, var(--brand-primary) 35%);
@@ -155,10 +158,11 @@ html {
     color-mix(in oklab, white 78%, var(--brand-ink) 22%),
     var(--brand-primary) 38%
   );
-  --brand-surface: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
+  --brand-surface: color-mix(in oklab, var(--brand-primary) 75%, white 25%);
+  --brand-primary-muted: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
   --brand-surface-contrast: color-mix(in oklab, var(--brand-primary-contrast) 92%, var(--brand-accent) 8%);
-  --brand-overlay: color-mix(in oklab, var(--brand-primary) 42%, transparent);
-  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 18%, transparent);
+  --brand-overlay: color-mix(in oklab, var(--brand-primary) 52%, transparent);
+  --brand-overlay-muted: color-mix(in oklab, var(--brand-primary) 24%, transparent);
 
   /* Font variable fallbacks (overridden by next/font classes on <html>) */
   --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/app/livestreams/page.tsx
+++ b/app/livestreams/page.tsx
@@ -129,7 +129,7 @@ export default async function Page() {
   return (
     <div>
       {live && (
-        <h2 className="mb-4 text-center text-3xl font-bold text-[var(--brand-fg)]">Live Now</h2>
+        <h2 className="mb-4 text-center text-3xl font-bold text-[var(--brand-heading-primary)]">Live Now</h2>
       )}
       {featured && <LivestreamPlayer videos={displayVideos} initial={featured} />}
     </div>

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -10,12 +10,12 @@
   .btn-primary {
     /* Use brand tokens */
     @apply btn-brand;
-    background-color: var(--brand-primary);
+    background-color: color-mix(in oklab, var(--brand-primary) 75%, white 25%);
     color: var(--brand-primary-contrast);
-    border: 1px solid var(--brand-primary);
+    border: 1px solid color-mix(in oklab, var(--brand-primary) 82%, white 18%);
   }
   .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 85%, white 15%);
+    background-color: color-mix(in oklab, var(--brand-primary) 88%, white 12%);
   }
   .btn-primary:active {
     transform: translateY(1px);
@@ -27,8 +27,8 @@
     background-color: transparent;
   }
   .btn-ghost:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 10%, var(--brand-surface) 90%);
-    color: var(--brand-primary);
+    background-color: color-mix(in oklab, var(--brand-primary) 18%, var(--brand-bg) 82%);
+    color: color-mix(in oklab, var(--brand-primary) 88%, white 12%);
   }
 
   /* Brand outlined button: transparent fill with visible border */
@@ -39,7 +39,8 @@
     border: 1px solid var(--brand-primary);
   }
   .btn-outline:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 10%, var(--brand-surface) 90%);
+    background-color: color-mix(in oklab, var(--brand-primary) 18%, var(--brand-bg) 82%);
+    border-color: color-mix(in oklab, var(--brand-primary) 88%, white 12%);
   }
   .btn-outline:active {
     transform: translateY(1px);
@@ -51,13 +52,13 @@
     border-radius: 9999px; /* ensure pill corners regardless of any resets */
     color: var(--brand-primary);
     /* More prominent border using accent+primary mix */
-    border: 2px solid color-mix(in oklab, var(--brand-accent) 65%, var(--brand-primary) 35%);
+    border: 2px solid color-mix(in oklab, var(--brand-accent) 48%, var(--brand-primary) 52%);
     /* Faded light background to lift from purple page bg */
-    background-color: color-mix(in oklab, var(--brand-primary) 14%, white 86%);
+    background-color: color-mix(in oklab, var(--brand-primary) 24%, white 76%);
   }
   .btn-outline-cta:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 20%, white 80%);
-    box-shadow: 0 8px 18px -8px color-mix(in oklab, var(--brand-accent) 35%, transparent);
+    background-color: color-mix(in oklab, var(--brand-primary) 32%, white 68%);
+    box-shadow: 0 8px 18px -8px color-mix(in oklab, var(--brand-primary) 40%, transparent);
   }
   .btn-outline-cta:active {
     transform: translateY(1px);

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -23,11 +23,14 @@
 
   /* Elevate button hover on secondary surfaces */
   [class*="brand-surface"] .btn-primary {
-    border-color: var(--brand-surface-contrast);
+    background-color: var(--brand-heading-secondary);
+    color: var(--brand-primary);
+    border-color: var(--brand-heading-secondary);
+    box-shadow: 0 8px 18px -10px color-mix(in oklab, var(--brand-heading-secondary) 35%, transparent);
   }
 
   [class*="brand-surface"] .btn-primary:hover {
-    background-color: var(--brand-surface-contrast);
+    background-color: color-mix(in oklab, var(--brand-heading-secondary) 85%, var(--brand-body-secondary) 15%);
     color: var(--brand-primary);
   }
 
@@ -75,9 +78,10 @@
   }
 
   .card {
-    @apply relative overflow-hidden rounded-lg shadow-md;
+    @apply relative overflow-hidden rounded-lg shadow-md border-2;
     background-color: var(--brand-surface);
-    color: var(--brand-fg);
+    color: var(--brand-body-secondary);
+    border-color: var(--brand-border);
   }
 
   .card .hero-overlay {
@@ -88,8 +92,8 @@
   .assistant-chip {
     @apply inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-wide transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-surface)];
     background-color: color-mix(in oklab, var(--brand-surface) 78%, var(--brand-primary) 22%);
-    color: var(--brand-fg);
-    border-color: color-mix(in oklab, var(--brand-border) 70%, transparent);
+    color: var(--brand-body-secondary);
+    border-color: var(--brand-border);
     box-shadow:
       0 6px 14px -10px color-mix(in oklab, var(--brand-primary) 65%, transparent),
       0 0 0 1px color-mix(in oklab, var(--brand-border) 30%, transparent);

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -3,21 +3,25 @@
 @layer components {
   /* Base brand button: default rounded edges and interactions */
   .btn-brand {
-    @apply rounded-full px-6 py-3 inline-flex items-center justify-center gap-2 font-medium transition-all shadow-md hover:shadow-lg transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] overflow-hidden;
+    @apply rounded-full px-6 py-3 inline-flex items-center justify-center gap-2 font-medium transition-all shadow-md hover:shadow-lg transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] overflow-hidden cursor-pointer;
     font-family: var(--font-button), sans-serif;
   }
 
   .btn-primary {
     /* Use brand tokens */
     @apply btn-brand;
-    background-color: var(--brand-primary-muted);
+    background-color: color-mix(in oklab, var(--brand-primary) 65%, white 35%);
     color: var(--brand-primary-contrast);
     border: 2px solid var(--brand-border-strong);
-    box-shadow: 0 14px 22px -12px color-mix(in oklab, var(--brand-primary) 55%, transparent);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--brand-accent) 30%, transparent),
+      0 14px 22px -12px color-mix(in oklab, var(--brand-primary) 55%, transparent);
   }
   .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-primary-muted) 82%, white 18%);
-    box-shadow: 0 18px 28px -12px color-mix(in oklab, var(--brand-primary) 65%, transparent);
+    background-color: color-mix(in oklab, var(--brand-primary) 55%, white 45%);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--brand-accent) 55%, transparent),
+      0 18px 28px -12px color-mix(in oklab, var(--brand-primary) 65%, transparent);
   }
   .btn-primary:active {
     transform: translateY(1px);
@@ -25,18 +29,18 @@
 
   /* Elevate button hover on secondary surfaces */
   [class*="brand-surface"] .btn-primary {
-    background-color: var(--brand-primary-muted);
+    background-color: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
     color: var(--brand-primary-contrast);
-    border-color: var(--brand-accent);
+    border-color: color-mix(in oklab, var(--brand-accent) 70%, white 30%);
     box-shadow:
-      0 0 0 1px color-mix(in oklab, var(--brand-accent) 45%, transparent),
+      0 0 0 1px color-mix(in oklab, var(--brand-accent) 55%, transparent),
       0 18px 32px -18px color-mix(in oklab, var(--brand-accent) 55%, transparent);
   }
 
   [class*="brand-surface"] .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-primary-muted) 88%, white 12%);
+    background-color: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
     color: var(--brand-primary-contrast);
-    border-color: color-mix(in oklab, var(--brand-accent) 70%, white 30%);
+    border-color: var(--brand-accent);
   }
 
   .btn-ghost {

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -10,12 +10,12 @@
   .btn-primary {
     /* Use brand tokens */
     @apply btn-brand;
-    background-color: color-mix(in oklab, var(--brand-primary) 75%, white 25%);
+    background-color: var(--brand-primary-muted);
     color: var(--brand-primary-contrast);
-    border: 1px solid color-mix(in oklab, var(--brand-primary) 82%, white 18%);
+    border: 1px solid color-mix(in oklab, var(--brand-primary-muted) 62%, white 38%);
   }
   .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 88%, white 12%);
+    background-color: color-mix(in oklab, var(--brand-primary-muted) 78%, white 22%);
   }
   .btn-primary:active {
     transform: translateY(1px);
@@ -23,24 +23,24 @@
 
   .btn-ghost {
     @apply btn-brand border border-transparent;
-    color: var(--brand-primary);
+    color: var(--brand-primary-muted);
     background-color: transparent;
   }
   .btn-ghost:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 18%, var(--brand-bg) 82%);
-    color: color-mix(in oklab, var(--brand-primary) 88%, white 12%);
+    background-color: color-mix(in oklab, var(--brand-primary-muted) 22%, var(--brand-bg) 78%);
+    color: color-mix(in oklab, var(--brand-primary-muted) 78%, white 22%);
   }
 
   /* Brand outlined button: transparent fill with visible border */
   .btn-outline {
     @apply btn-brand;
     background-color: transparent;
-    color: var(--brand-primary);
-    border: 1px solid var(--brand-primary);
+    color: var(--brand-primary-muted);
+    border: 1px solid color-mix(in oklab, var(--brand-primary-muted) 72%, white 28%);
   }
   .btn-outline:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 18%, var(--brand-bg) 82%);
-    border-color: color-mix(in oklab, var(--brand-primary) 88%, white 12%);
+    background-color: color-mix(in oklab, var(--brand-primary-muted) 22%, var(--brand-bg) 78%);
+    border-color: color-mix(in oklab, var(--brand-primary-muted) 82%, white 18%);
   }
   .btn-outline:active {
     transform: translateY(1px);
@@ -50,15 +50,15 @@
   .btn-outline-cta {
     @apply btn-brand font-semibold; /* inherits rounded-full, padding, layout, transitions */
     border-radius: 9999px; /* ensure pill corners regardless of any resets */
-    color: var(--brand-primary);
+    color: var(--brand-primary-muted);
     /* More prominent border using accent+primary mix */
-    border: 2px solid color-mix(in oklab, var(--brand-accent) 48%, var(--brand-primary) 52%);
+    border: 2px solid color-mix(in oklab, var(--brand-accent) 42%, var(--brand-primary-muted) 58%);
     /* Faded light background to lift from purple page bg */
-    background-color: color-mix(in oklab, var(--brand-primary) 24%, white 76%);
+    background-color: color-mix(in oklab, var(--brand-primary-muted) 35%, white 65%);
   }
   .btn-outline-cta:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 32%, white 68%);
-    box-shadow: 0 8px 18px -8px color-mix(in oklab, var(--brand-primary) 40%, transparent);
+    background-color: color-mix(in oklab, var(--brand-primary-muted) 45%, white 55%);
+    box-shadow: 0 8px 18px -8px color-mix(in oklab, var(--brand-primary-muted) 40%, transparent);
   }
   .btn-outline-cta:active {
     transform: translateY(1px);

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -12,10 +12,12 @@
     @apply btn-brand;
     background-color: var(--brand-primary-muted);
     color: var(--brand-primary-contrast);
-    border: 1px solid color-mix(in oklab, var(--brand-primary-muted) 55%, white 45%);
+    border: 2px solid var(--brand-border-strong);
+    box-shadow: 0 14px 22px -12px color-mix(in oklab, var(--brand-primary) 55%, transparent);
   }
   .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-primary-muted) 80%, white 20%);
+    background-color: color-mix(in oklab, var(--brand-primary-muted) 82%, white 18%);
+    box-shadow: 0 18px 28px -12px color-mix(in oklab, var(--brand-primary) 65%, transparent);
   }
   .btn-primary:active {
     transform: translateY(1px);
@@ -23,15 +25,18 @@
 
   /* Elevate button hover on secondary surfaces */
   [class*="brand-surface"] .btn-primary {
-    background-color: var(--brand-heading-secondary);
-    color: var(--brand-primary);
-    border-color: var(--brand-heading-secondary);
-    box-shadow: 0 8px 18px -10px color-mix(in oklab, var(--brand-heading-secondary) 35%, transparent);
+    background-color: var(--brand-primary-muted);
+    color: var(--brand-primary-contrast);
+    border-color: var(--brand-accent);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--brand-accent) 45%, transparent),
+      0 18px 32px -18px color-mix(in oklab, var(--brand-accent) 55%, transparent);
   }
 
   [class*="brand-surface"] .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-heading-secondary) 85%, var(--brand-body-secondary) 15%);
-    color: var(--brand-primary);
+    background-color: color-mix(in oklab, var(--brand-primary-muted) 88%, white 12%);
+    color: var(--brand-primary-contrast);
+    border-color: color-mix(in oklab, var(--brand-accent) 70%, white 30%);
   }
 
   .btn-ghost {

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -76,8 +76,8 @@
 
   .assistant-chip {
     @apply inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-wide transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-surface)];
-    background-color: color-mix(in oklab, var(--brand-alt) 78%, var(--brand-primary) 22%);
-    color: var(--brand-ink);
+    background-color: color-mix(in oklab, var(--brand-surface) 78%, var(--brand-primary) 22%);
+    color: var(--brand-fg);
     border-color: color-mix(in oklab, var(--brand-border) 70%, transparent);
     box-shadow:
       0 6px 14px -10px color-mix(in oklab, var(--brand-primary) 65%, transparent),

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -10,18 +10,19 @@
   .btn-primary {
     /* Use brand tokens */
     @apply btn-brand;
-    background-color: color-mix(in oklab, var(--brand-primary) 65%, white 35%);
+    background-color: var(--brand-primary-muted);
     color: var(--brand-primary-contrast);
     border: 2px solid var(--brand-border-strong);
     box-shadow:
       0 0 0 1px color-mix(in oklab, var(--brand-accent) 30%, transparent),
-      0 14px 22px -12px color-mix(in oklab, var(--brand-primary) 55%, transparent);
+      0 16px 30px -18px color-mix(in oklab, var(--brand-primary) 65%, transparent);
   }
   .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 55%, white 45%);
+    background-color: color-mix(in oklab, var(--brand-primary) 70%, var(--brand-primary-muted) 30%);
+    color: var(--brand-primary-contrast);
     box-shadow:
-      0 0 0 1px color-mix(in oklab, var(--brand-accent) 55%, transparent),
-      0 18px 28px -12px color-mix(in oklab, var(--brand-primary) 65%, transparent);
+      0 0 0 1px color-mix(in oklab, var(--brand-accent) 60%, transparent),
+      0 20px 36px -18px color-mix(in oklab, var(--brand-primary) 70%, transparent);
   }
   .btn-primary:active {
     transform: translateY(1px);
@@ -29,18 +30,18 @@
 
   /* Elevate button hover on secondary surfaces */
   [class*="brand-surface"] .btn-primary {
-    background-color: color-mix(in oklab, var(--brand-primary) 45%, white 55%);
-    color: var(--brand-primary-contrast);
-    border-color: color-mix(in oklab, var(--brand-accent) 70%, white 30%);
+    background-color: var(--brand-surface-contrast);
+    color: var(--brand-primary);
+    border-color: var(--brand-accent);
     box-shadow:
-      0 0 0 1px color-mix(in oklab, var(--brand-accent) 55%, transparent),
-      0 18px 32px -18px color-mix(in oklab, var(--brand-accent) 55%, transparent);
+      0 0 0 1px color-mix(in oklab, var(--brand-accent) 40%, transparent),
+      0 20px 36px -20px color-mix(in oklab, var(--brand-primary) 55%, transparent);
   }
 
   [class*="brand-surface"] .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-primary) 35%, white 65%);
+    background-color: var(--brand-primary-muted);
     color: var(--brand-primary-contrast);
-    border-color: var(--brand-accent);
+    border-color: var(--brand-border-strong);
   }
 
   .btn-ghost {

--- a/app/utilities.css
+++ b/app/utilities.css
@@ -12,13 +12,23 @@
     @apply btn-brand;
     background-color: var(--brand-primary-muted);
     color: var(--brand-primary-contrast);
-    border: 1px solid color-mix(in oklab, var(--brand-primary-muted) 62%, white 38%);
+    border: 1px solid color-mix(in oklab, var(--brand-primary-muted) 55%, white 45%);
   }
   .btn-primary:hover {
-    background-color: color-mix(in oklab, var(--brand-primary-muted) 78%, white 22%);
+    background-color: color-mix(in oklab, var(--brand-primary-muted) 80%, white 20%);
   }
   .btn-primary:active {
     transform: translateY(1px);
+  }
+
+  /* Elevate button hover on secondary surfaces */
+  [class*="brand-surface"] .btn-primary {
+    border-color: var(--brand-surface-contrast);
+  }
+
+  [class*="brand-surface"] .btn-primary:hover {
+    background-color: var(--brand-surface-contrast);
+    color: var(--brand-primary);
   }
 
   .btn-ghost {

--- a/app/visit/page.tsx
+++ b/app/visit/page.tsx
@@ -86,14 +86,14 @@ export default async function Page() {
   return (
     <div className="space-y-16">
       <section className="rounded-3xl border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-primary)_12%,transparent)] p-8 shadow-lg sm:p-12">
-        <div className="space-y-6 text-[var(--brand-surface-contrast)]">
+        <div className="space-y-6 text-[var(--brand-body-primary)]">
           <p className="text-sm uppercase tracking-[0.4em] text-[var(--brand-accent)]">
             Plan a Visit
           </p>
-          <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
+          <h1 className="text-3xl font-semibold leading-tight text-[var(--brand-heading-primary)] sm:text-4xl">
             We saved you a seat at {settings?.title ?? "our church"}.
           </h1>
-          <p className="max-w-3xl text-base text-[color:color-mix(in_oklab,var(--brand-surface-contrast)_75%,white_25%)] sm:text-lg">
+          <p className="max-w-3xl text-base text-[var(--brand-body-primary)] sm:text-lg">
             Discover what to expect before you arrive and feel right at home from the moment you pull into the parking lot.
           </p>
           <div className="flex flex-wrap gap-4 text-sm font-medium text-[var(--brand-accent)]">
@@ -113,7 +113,7 @@ export default async function Page() {
 
       <section className="space-y-6">
         <div className="flex items-center justify-between gap-4">
-          <h2 className="text-2xl font-semibold text-[var(--brand-surface-contrast)]">
+          <h2 className="text-2xl font-semibold text-[var(--brand-heading-primary)]">
             Start Here
           </h2>
           <span className="hidden text-sm text-[var(--brand-accent)] sm:inline">
@@ -131,10 +131,10 @@ export default async function Page() {
                 {String(idx + 1).padStart(2, "0")}
               </span>
               <div>
-                <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">
+                <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">
                   {action.title}
                 </h3>
-                <p className="mt-2 text-sm text-[var(--brand-accent)]">
+                <p className="mt-2 text-sm text-[var(--brand-body-secondary)]">
                   {action.description}
                 </p>
               </div>
@@ -160,28 +160,28 @@ export default async function Page() {
       </section>
 
       <section className="space-y-6">
-        <h2 className="text-2xl font-semibold text-[var(--brand-surface-contrast)]">
+        <h2 className="text-2xl font-semibold text-[var(--brand-heading-primary)]">
           Important Details
         </h2>
         <div className="grid gap-6 lg:grid-cols-3">
           <div className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">
+            <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">
               Service Times
             </h3>
-            <p className="mt-2 text-sm text-[var(--brand-accent)]">
+            <p className="mt-2 text-sm text-[var(--brand-body-secondary)]">
               {serviceTimes || "We update our worship schedule regularly. Check back soon."}
             </p>
           </div>
           <div className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">
+            <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">
               Where to Find Us
             </h3>
             {address ? (
-              <p className="mt-2 text-sm text-[var(--brand-accent)]">
+              <p className="mt-2 text-sm text-[var(--brand-body-secondary)]">
                 {address}
               </p>
             ) : (
-              <p className="mt-2 text-sm text-[var(--brand-accent)]">
+              <p className="mt-2 text-sm text-[var(--brand-body-secondary)]">
                 Our address will be available soon.
               </p>
             )}
@@ -205,10 +205,10 @@ export default async function Page() {
             )}
           </div>
           <div className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">
+            <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">
               Contact Us
             </h3>
-            <ul className="mt-2 space-y-2 text-sm text-[var(--brand-accent)]">
+            <ul className="mt-2 space-y-2 text-sm text-[var(--brand-body-secondary)]">
               {phone && (
                 <li>
                   <a
@@ -250,17 +250,17 @@ export default async function Page() {
               />
             </div>
           )}
-          <div className="space-y-4 text-[var(--brand-surface-contrast)]">
+          <div className="space-y-4 text-[var(--brand-body-secondary)]">
             <p className="text-sm uppercase tracking-[0.35em] text-[var(--brand-accent)]">
               Meet Our Pastor
             </p>
-            <h2 className="text-2xl font-semibold">
+            <h2 className="text-2xl font-semibold text-[var(--brand-heading-secondary)]">
               {leadPastor.name}
             </h2>
-            <p className="text-sm font-medium text-[var(--brand-accent)]">
+            <p className="text-sm font-medium text-[var(--brand-body-secondary)]">
               {leadPastor.role}
             </p>
-            <p className="text-base text-[color:color-mix(in_oklab,var(--brand-surface-contrast)_80%,white_20%)]">
+            <p className="text-base text-[var(--brand-body-secondary)]">
               {welcomeMessage}
             </p>
           </div>
@@ -279,7 +279,7 @@ export default async function Page() {
       <section className="space-y-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-2xl font-semibold text-[var(--brand-surface-contrast)]">
+            <h2 className="text-2xl font-semibold text-[var(--brand-heading-primary)]">
               Frequently Asked Questions
             </h2>
             <p className="text-sm text-[var(--brand-accent)]">
@@ -308,10 +308,10 @@ export default async function Page() {
               key={faq._id}
               className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-lg"
             >
-              <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">
+              <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">
                 {faq.question}
               </h3>
-              <p className="mt-3 text-sm text-[var(--brand-accent)]">
+              <p className="mt-3 text-sm text-[var(--brand-body-secondary)]">
                 {getFaqSnippet(faq.answer) || "Read the full answer on our FAQ page."}
               </p>
               <Link
@@ -332,7 +332,7 @@ export default async function Page() {
             </article>
           ))}
           {faqPreview.length === 0 && (
-            <div className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 text-sm text-[var(--brand-accent)]">
+            <div className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 text-sm text-[var(--brand-body-secondary)]">
               We are gathering answers to the questions guests ask most often. Check back soon for more details.
             </div>
           )}
@@ -342,18 +342,18 @@ export default async function Page() {
       {youthMinistry && (
         <section className="rounded-3xl border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-primary)_10%,transparent)] p-8 shadow-lg sm:p-12">
           <div className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:items-center">
-            <div className="space-y-5 text-[var(--brand-surface-contrast)]">
+            <div className="space-y-5 text-[var(--brand-body-primary)]">
               <p className="text-sm uppercase tracking-[0.35em] text-[var(--brand-accent)]">
                 Ministry Highlight
               </p>
-              <h2 className="text-3xl font-semibold sm:text-4xl">
+              <h2 className="text-3xl font-semibold text-[var(--brand-heading-primary)] sm:text-4xl">
                 {youthMinistry.name}
               </h2>
-              <p className="text-base text-[color:color-mix(in_oklab,var(--brand-surface-contrast)_80%,white_20%)]">
+              <p className="text-base text-[var(--brand-body-primary)]">
                 {youthInvite ||
                   "Our youth team loves creating a vibrant, faith-filled space for students to grow together. We can't wait to meet you!"}
               </p>
-              <p className="text-sm text-[var(--brand-accent)]">
+              <p className="text-sm text-[var(--brand-body-primary)]">
                 {youthMinistry.description}
               </p>
               <Link

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -445,7 +445,7 @@ export default function Assistant() {
           }}
           className="absolute right-2 top-2 grid h-8 w-8 place-items-center rounded-full border text-2xl leading-none cursor-pointer"
           style={{
-            backgroundColor: 'var(--brand-alt)',
+            backgroundColor: 'var(--brand-surface)',
             color: 'var(--brand-ink)',
             borderColor: 'var(--brand-ink)',
           }}
@@ -558,7 +558,7 @@ export default function Assistant() {
               type="text"
               className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-alt)',
+                backgroundColor: 'var(--brand-surface)',
                 color: 'var(--brand-ink)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',
@@ -573,7 +573,7 @@ export default function Assistant() {
               type="text"
               className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-alt)',
+                backgroundColor: 'var(--brand-surface)',
                 color: 'var(--brand-ink)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',
@@ -588,7 +588,7 @@ export default function Assistant() {
               type="email"
               className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-alt)',
+                backgroundColor: 'var(--brand-surface)',
                 color: 'var(--brand-ink)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',
@@ -602,7 +602,7 @@ export default function Assistant() {
             <textarea
               className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-alt)',
+                backgroundColor: 'var(--brand-surface)',
                 color: 'var(--brand-ink)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',
@@ -630,7 +630,7 @@ export default function Assistant() {
               type="text"
               className="flex-1 min-w-0 border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-alt)',
+                backgroundColor: 'var(--brand-surface)',
                 color: 'var(--brand-ink)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -432,8 +432,8 @@ export default function Assistant() {
         className={`absolute bottom-0 right-0 w-80 rounded-lg border pt-8 pr-8 pb-4 pl-4 shadow-lg transition-all duration-700 ease-in-out transform ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
         style={{
           backgroundColor: 'var(--brand-surface)',
-          color: 'var(--brand-ink)',
-          borderColor: 'var(--brand-ink)',
+          color: 'var(--brand-body-secondary)',
+          borderColor: 'var(--brand-border)',
         }}
       >
         <button
@@ -445,9 +445,9 @@ export default function Assistant() {
           }}
           className="absolute right-2 top-2 grid h-8 w-8 place-items-center rounded-full border text-2xl leading-none cursor-pointer"
           style={{
-            backgroundColor: 'var(--brand-surface)',
-            color: 'var(--brand-ink)',
-            borderColor: 'var(--brand-ink)',
+            backgroundColor: 'var(--brand-heading-secondary)',
+            color: 'var(--brand-primary)',
+            borderColor: 'var(--brand-border)',
           }}
         >
           ×
@@ -473,7 +473,10 @@ export default function Assistant() {
                         m.role === 'assistant'
                           ? 'var(--brand-primary)'
                           : 'var(--brand-accent)',
-                      color: 'var(--brand-ink)',
+                      color:
+                        m.role === 'assistant'
+                          ? 'var(--brand-heading-secondary)'
+                          : 'var(--brand-ink)',
                       borderColor: 'var(--brand-border)',
                       overflowWrap: 'anywhere',
                       wordBreak: 'break-word',
@@ -558,8 +561,8 @@ export default function Assistant() {
               type="text"
               className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-surface)',
-                color: 'var(--brand-ink)',
+                backgroundColor: 'var(--brand-heading-secondary)',
+                color: 'var(--brand-body-primary)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',
               } as CSSProperties}
@@ -588,8 +591,8 @@ export default function Assistant() {
               type="email"
               className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-surface)',
-                color: 'var(--brand-ink)',
+                backgroundColor: 'var(--brand-heading-secondary)',
+                color: 'var(--brand-body-primary)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',
               } as CSSProperties}
@@ -602,8 +605,8 @@ export default function Assistant() {
             <textarea
               className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-surface)',
-                color: 'var(--brand-ink)',
+                backgroundColor: 'var(--brand-heading-secondary)',
+                color: 'var(--brand-body-primary)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',
               } as CSSProperties}
@@ -616,9 +619,12 @@ export default function Assistant() {
               type="submit"
               className="rounded px-3 py-1 focus:outline-none focus:ring-2 cursor-pointer"
               style={{
-                backgroundColor: 'var(--brand-primary)',
-                color: 'var(--brand-ink)',
-                '--tw-ring-color': 'var(--brand-primary)',
+                backgroundColor: 'var(--brand-heading-secondary)',
+                color: 'var(--brand-primary)',
+                borderColor: 'var(--brand-border)',
+                borderWidth: 1,
+                borderStyle: 'solid',
+                '--tw-ring-color': 'var(--brand-heading-secondary)',
               } as CSSProperties}
             >
               Send
@@ -630,8 +636,8 @@ export default function Assistant() {
               type="text"
               className="flex-1 min-w-0 border rounded px-2 py-1 focus:outline-none focus:ring-2"
               style={{
-                backgroundColor: 'var(--brand-surface)',
-                color: 'var(--brand-ink)',
+                backgroundColor: 'var(--brand-heading-secondary)',
+                color: 'var(--brand-body-primary)',
                 borderColor: 'var(--brand-border)',
                 '--tw-ring-color': 'var(--brand-primary)',
               } as CSSProperties}
@@ -643,9 +649,12 @@ export default function Assistant() {
               type="submit"
               className="rounded px-3 py-1 focus:outline-none focus:ring-2 cursor-pointer"
               style={{
-                backgroundColor: 'var(--brand-primary)',
-                color: 'var(--brand-ink)',
-                '--tw-ring-color': 'var(--brand-primary)',
+                backgroundColor: 'var(--brand-heading-secondary)',
+                color: 'var(--brand-primary)',
+                borderColor: 'var(--brand-border)',
+                borderWidth: 1,
+                borderStyle: 'solid',
+                '--tw-ring-color': 'var(--brand-heading-secondary)',
               } as CSSProperties}
             >
               Send

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -429,238 +429,172 @@ export default function Assistant() {
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
       <div
-        className={`absolute bottom-0 right-0 w-80 rounded-lg border pt-8 pr-8 pb-4 pl-4 shadow-lg transition-all duration-700 ease-in-out transform ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
-        style={{
-          backgroundColor: 'var(--brand-surface)',
-          color: 'var(--brand-body-secondary)',
-          borderColor: 'var(--brand-border)',
-        }}
+        className={`absolute bottom-0 right-0 w-80 transition-all duration-700 ease-in-out transform ${
+          open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'
+        }`}
       >
-        <button
-          type="button"
-          aria-label="Close assistant"
-          onClick={() => {
-            setOpen(false);
-            resetNudge();
-          }}
-          className="absolute right-2 top-2 grid h-8 w-8 place-items-center rounded-full border text-2xl leading-none cursor-pointer"
-          style={{
-            backgroundColor: 'var(--brand-heading-secondary)',
-            color: 'var(--brand-primary)',
-            borderColor: 'var(--brand-border)',
-          }}
-        >
-          ×
-        </button>
-        <div
-          role="log"
-          aria-label="Chat messages"
-          className="mb-2 max-h-60 overflow-y-auto pr-2"
-          style={{ scrollbarGutter: 'stable' } as CSSProperties}
-          ref={logRef}
-        >
-          {messages.map((m, i) => (
+        <div className="relative flex flex-col gap-4 rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] p-5 shadow-2xl">
+          <button
+            type="button"
+            aria-label="Close assistant"
+            onClick={() => {
+              setOpen(false);
+              resetNudge();
+            }}
+            className="absolute right-3 top-3 grid h-8 w-8 place-items-center rounded-full border border-[var(--brand-border-strong)] bg-[var(--brand-primary-muted)] text-lg font-semibold leading-none text-[var(--brand-primary-contrast)] shadow-sm transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-primary-muted)_88%,white_12%)]"
+          >
+            ×
+          </button>
+          <div className="brand-surface flex flex-col gap-3 rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-4 shadow-inner">
             <div
-              key={i}
-              className={`mb-2 flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              role="log"
+              aria-label="Chat messages"
+              className="mb-2 max-h-60 overflow-y-auto pr-2 text-[var(--brand-body-secondary)]"
+              style={{ scrollbarGutter: 'stable' } as CSSProperties}
+              ref={logRef}
             >
-              <div className={`max-w-[85%] flex flex-col ${m.role === 'assistant' ? 'items-start' : 'items-end'}`}>
-                <div className="relative">
-                  <div
-                    className="relative z-10 rounded-2xl border px-3 py-2 whitespace-pre-wrap break-words"
-                    style={{
-                      backgroundColor:
-                        m.role === 'assistant'
-                          ? 'var(--brand-primary)'
-                          : 'var(--brand-accent)',
-                      color:
-                        m.role === 'assistant'
-                          ? 'var(--brand-heading-secondary)'
-                          : 'var(--brand-ink)',
-                      borderColor: 'var(--brand-border)',
-                      overflowWrap: 'anywhere',
-                      wordBreak: 'break-word',
-                    }}
-                  >
-                    {renderContent(m.content, m.role)}
-                    {m.role === 'assistant' && m.softEscalate && !collectInfo && (
-                      <div className="mt-1 text-sm">
-                        <button
-                          type="button"
-                          className="underline text-[var(--brand-alt)] decoration-[var(--brand-alt)] hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-[var(--brand-alt)] cursor-pointer bg-transparent p-0 font-normal"
-                          onClick={() => {
-                            const pct = Math.max(
-                              0,
-                              Math.min(100, Math.round(((m.confidence ?? 0) as number) * 100))
-                            );
-                            setEscalationReason(
-                              `Assistant confidence ${pct}%. Visitor opted to reach out for a more certain answer.`
-                            );
-                            setCollectInfo(true);
-                            setCollectInfoMode('soft');
-                          }}
-                          aria-label="Open escalation form"
-                        >
-                          Reach Out to a Staff Member
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  <div
-                    className={`absolute h-3 w-3 rotate-45 border-b ${m.role === 'assistant' ? 'border-l left-3' : 'border-r right-3'}`}
-                    style={{
-                      bottom: -3,
-                      backgroundColor:
-                        m.role === 'assistant'
-                          ? 'var(--brand-primary)'
-                          : 'var(--brand-accent)',
-                      borderColor: 'var(--brand-border)',
-                    }}
-                  />
-                </div>
+              {messages.map((m, i) => (
                 <div
-                  className={`mt-3 inline-block rounded border px-3 py-1 text-base font-semibold ${
-                    m.role === 'assistant'
-                      ? 'self-start'
-                      : 'self-end'
-                  }`}
-                  style={{
-                    borderColor: 'var(--brand-border)',
-                    color: 'var(--brand-accent)',
-                  }}
+                  key={i}
+                  className={`mb-2 flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
                 >
-                  {m.role === 'assistant' ? 'Assistant' : 'You'}
+                  <div className={`max-w-[85%] flex flex-col ${m.role === 'assistant' ? 'items-start' : 'items-end'}`}>
+                    <div className="relative">
+                      <div
+                        className={`relative z-10 rounded-2xl border px-3 py-2 text-sm whitespace-pre-wrap break-words ${
+                          m.role === 'assistant'
+                            ? 'brand-surface bg-[var(--brand-surface)] text-[var(--brand-body-secondary)] border-[var(--brand-border-strong)]'
+                            : 'bg-[var(--brand-surface-contrast)] text-[var(--brand-body-primary)] border-[var(--brand-border-strong)]'
+                        }`}
+                        style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}
+                      >
+                        {renderContent(m.content, m.role)}
+                        {m.role === 'assistant' && m.softEscalate && !collectInfo && (
+                          <div className="mt-2 text-xs">
+                            <button
+                              type="button"
+                              className="underline text-[var(--brand-heading-secondary)] decoration-[var(--brand-heading-secondary)] underline-offset-2 hover:opacity-80 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-heading-secondary)]"
+                              onClick={() => {
+                                const pct = Math.max(
+                                  0,
+                                  Math.min(100, Math.round(((m.confidence ?? 0) as number) * 100))
+                                );
+                                setEscalationReason(
+                                  `Assistant confidence ${pct}%. Visitor opted to reach out for a more certain answer.`
+                                );
+                                setCollectInfo(true);
+                                setCollectInfoMode('soft');
+                              }}
+                              aria-label="Open escalation form"
+                            >
+                              Reach Out to a Staff Member
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                      <div
+                        className={`absolute h-3 w-3 rotate-45 border-b ${m.role === 'assistant' ? 'border-l left-3' : 'border-r right-3'}`}
+                        style={{
+                          bottom: -3,
+                          backgroundColor:
+                            m.role === 'assistant'
+                              ? 'var(--brand-surface)'
+                              : 'var(--brand-surface-contrast)',
+                          borderColor: 'var(--brand-border-strong)',
+                        }}
+                      />
+                    </div>
+                  </div>
                 </div>
-              </div>
+              ))}
+              {thinking && (
+                <div className="mb-2 flex justify-start">
+                  <div className="max-w-[85%]">
+                    <div className="relative">
+                      <div className="relative z-10 rounded-2xl border border-[var(--brand-border-strong)] bg-[var(--brand-surface)] px-3 py-2 text-sm text-[var(--brand-body-secondary)]">
+                        Typing…
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
-          ))}
-          {thinking && !collectInfo && (
-            <div className="mb-1" style={{ color: 'var(--brand-muted)' }}>Assistant is thinking…</div>
-          )}
-        </div>
-        {collectInfo ? (
-          <form onSubmit={sendInfo} className="flex flex-col gap-2 border rounded p-2" aria-label="Contact form" style={{ borderColor: 'var(--brand-border)' }}>
-            {collectInfoMode === 'soft' && (
-              <button
-                type="button"
-                onClick={() => { setCollectInfo(false); setCollectInfoMode(null); }}
-                aria-label="Go back to chat"
-                className="self-start -mb-1 underline focus:outline-none focus:ring-1 cursor-pointer hover:opacity-80"
-                style={{
-                  color: 'var(--brand-accent)',
-                  '--tw-ring-color': 'var(--brand-accent)',
-                } as CSSProperties}
+            {collectInfo ? (
+              <form
+                onSubmit={sendInfo}
+                className="flex flex-col gap-3 rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] p-3 text-[var(--brand-body-primary)] shadow-sm"
+                aria-label="Contact form"
               >
-                Back
-              </button>
+                {collectInfoMode === 'soft' && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCollectInfo(false);
+                      setCollectInfoMode(null);
+                    }}
+                    aria-label="Go back to chat"
+                    className="self-start text-xs font-medium uppercase tracking-wide text-[var(--brand-body-primary)] underline decoration-[var(--brand-body-primary)] underline-offset-2 hover:opacity-80"
+                  >
+                    Back to chat
+                  </button>
+                )}
+                <p className="text-sm text-[var(--brand-body-primary)]">
+                  We&apos;d love to follow up. Share the best way to reach you and a short summary of what you need.
+                </p>
+                <input
+                  type="text"
+                  className="w-full rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+                  placeholder="Name"
+                  value={info.name}
+                  onChange={(e) => setInfo({ ...info, name: e.target.value })}
+                  aria-label="Name"
+                  required
+                />
+                <input
+                  type="tel"
+                  className="w-full rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+                  placeholder="Contact Number"
+                  value={info.contact}
+                  onChange={(e) => setInfo({ ...info, contact: e.target.value })}
+                  aria-label="Contact Number"
+                  required
+                />
+                <input
+                  type="email"
+                  className="w-full rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+                  placeholder="Email"
+                  value={info.email}
+                  onChange={(e) => setInfo({ ...info, email: e.target.value })}
+                  aria-label="Email"
+                  required
+                />
+                <textarea
+                  className="w-full rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+                  placeholder="Any extra details"
+                  value={info.details}
+                  onChange={(e) => setInfo({ ...info, details: e.target.value })}
+                  aria-label="Any extra details"
+                />
+                <button type="submit" className="btn-primary w-full cursor-pointer text-base">
+                  Send
+                </button>
+              </form>
+            ) : (
+              <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
+                <input
+                  type="text"
+                  className="flex-1 min-w-0 rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  aria-label="Message"
+                />
+                <button type="submit" className="btn-primary cursor-pointer px-4 py-2 text-base">
+                  Send
+                </button>
+              </form>
             )}
-            <p className="mb-2 text-lg font-semibold" style={{ color: 'var(--brand-accent)' }}>
-              Contact a Staff Member
-            </p>
-            <input
-              type="text"
-              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-heading-secondary)',
-                color: 'var(--brand-body-primary)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
-              placeholder="Name"
-              value={info.name}
-              onChange={(e) => setInfo({ ...info, name: e.target.value })}
-              aria-label="Name"
-              required
-            />
-            <input
-              type="text"
-              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-surface)',
-                color: 'var(--brand-ink)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
-              placeholder="Contact Number"
-              value={info.contact}
-              onChange={(e) => setInfo({ ...info, contact: e.target.value })}
-              aria-label="Contact Number"
-              required
-            />
-            <input
-              type="email"
-              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-heading-secondary)',
-                color: 'var(--brand-body-primary)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
-              placeholder="Email"
-              value={info.email}
-              onChange={(e) => setInfo({ ...info, email: e.target.value })}
-              aria-label="Email"
-              required
-            />
-            <textarea
-              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-heading-secondary)',
-                color: 'var(--brand-body-primary)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
-              placeholder="Any extra details"
-              value={info.details}
-              onChange={(e) => setInfo({ ...info, details: e.target.value })}
-              aria-label="Any extra details"
-            />
-            <button
-              type="submit"
-              className="rounded px-3 py-1 focus:outline-none focus:ring-2 cursor-pointer"
-              style={{
-                backgroundColor: 'var(--brand-heading-secondary)',
-                color: 'var(--brand-primary)',
-                borderColor: 'var(--brand-border)',
-                borderWidth: 1,
-                borderStyle: 'solid',
-                '--tw-ring-color': 'var(--brand-heading-secondary)',
-              } as CSSProperties}
-            >
-              Send
-            </button>
-          </form>
-        ) : (
-          <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
-            <input
-              type="text"
-              className="flex-1 min-w-0 border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-heading-secondary)',
-                color: 'var(--brand-body-primary)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              aria-label="Message"
-            />
-            <button
-              type="submit"
-              className="rounded px-3 py-1 focus:outline-none focus:ring-2 cursor-pointer"
-              style={{
-                backgroundColor: 'var(--brand-heading-secondary)',
-                color: 'var(--brand-primary)',
-                borderColor: 'var(--brand-border)',
-                borderWidth: 1,
-                borderStyle: 'solid',
-                '--tw-ring-color': 'var(--brand-heading-secondary)',
-              } as CSSProperties}
-            >
-              Send
-            </button>
-          </form>
-        )}
+          </div>
+        </div>
       </div>
       <div
         className={`relative group transition-all duration-700 ease-in-out ${

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -429,172 +429,241 @@ export default function Assistant() {
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
       <div
-        className={`absolute bottom-0 right-0 w-80 transition-all duration-700 ease-in-out transform ${
-          open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'
-        }`}
+        className={`absolute bottom-0 right-0 w-80 rounded-lg border pt-8 pr-8 pb-4 pl-4 shadow-lg transition-all duration-700 ease-in-out transform ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
+        style={{
+          backgroundColor: 'var(--brand-surface)',
+          color: 'var(--brand-ink)',
+          borderColor: 'var(--brand-ink)',
+        }}
       >
-        <div className="relative flex flex-col gap-4 rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] p-5 shadow-2xl">
-          <button
-            type="button"
-            aria-label="Close assistant"
-            onClick={() => {
-              setOpen(false);
-              resetNudge();
-            }}
-            className="absolute right-3 top-3 grid h-8 w-8 place-items-center rounded-full border border-[var(--brand-border-strong)] bg-[var(--brand-primary-muted)] text-lg font-semibold leading-none text-[var(--brand-primary-contrast)] shadow-sm transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-primary-muted)_88%,white_12%)]"
+        <button
+          type="button"
+          aria-label="Close assistant"
+          onClick={() => {
+            setOpen(false);
+            resetNudge();
+          }}
+          className="absolute right-2 top-2 grid h-8 w-8 place-items-center rounded-full border text-2xl leading-none cursor-pointer"
+          style={{
+            backgroundColor: 'var(--brand-alt)',
+            color: 'var(--brand-ink)',
+            borderColor: 'var(--brand-ink)',
+          }}
+        >
+          ×
+        </button>
+        <div className="mb-3 rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-bg)] p-3 shadow-inner">
+          <div
+            role="log"
+            aria-label="Chat messages"
+            className="max-h-60 space-y-2 overflow-y-auto pr-2"
+            style={{ scrollbarGutter: 'stable' } as CSSProperties}
+            ref={logRef}
           >
-            ×
-          </button>
-          <div className="brand-surface flex flex-col gap-3 rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-4 shadow-inner">
-            <div
-              role="log"
-              aria-label="Chat messages"
-              className="mb-2 max-h-60 overflow-y-auto pr-2 text-[var(--brand-body-secondary)]"
-              style={{ scrollbarGutter: 'stable' } as CSSProperties}
-              ref={logRef}
-            >
-              {messages.map((m, i) => (
-                <div
-                  key={i}
-                  className={`mb-2 flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
-                >
-                  <div className={`max-w-[85%] flex flex-col ${m.role === 'assistant' ? 'items-start' : 'items-end'}`}>
-                    <div className="relative">
-                      <div
-                        className={`relative z-10 rounded-2xl border px-3 py-2 text-sm whitespace-pre-wrap break-words ${
-                          m.role === 'assistant'
-                            ? 'brand-surface bg-[var(--brand-surface)] text-[var(--brand-body-secondary)] border-[var(--brand-border-strong)]'
-                            : 'bg-[var(--brand-surface-contrast)] text-[var(--brand-body-primary)] border-[var(--brand-border-strong)]'
-                        }`}
-                        style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}
-                      >
-                        {renderContent(m.content, m.role)}
-                        {m.role === 'assistant' && m.softEscalate && !collectInfo && (
-                          <div className="mt-2 text-xs">
-                            <button
-                              type="button"
-                              className="underline text-[var(--brand-heading-secondary)] decoration-[var(--brand-heading-secondary)] underline-offset-2 hover:opacity-80 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-heading-secondary)]"
-                              onClick={() => {
-                                const pct = Math.max(
-                                  0,
-                                  Math.min(100, Math.round(((m.confidence ?? 0) as number) * 100))
-                                );
-                                setEscalationReason(
-                                  `Assistant confidence ${pct}%. Visitor opted to reach out for a more certain answer.`
-                                );
-                                setCollectInfo(true);
-                                setCollectInfoMode('soft');
-                              }}
-                              aria-label="Open escalation form"
-                            >
-                              Reach Out to a Staff Member
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                      <div
-                        className={`absolute h-3 w-3 rotate-45 border-b ${m.role === 'assistant' ? 'border-l left-3' : 'border-r right-3'}`}
-                        style={{
-                          bottom: -3,
-                          backgroundColor:
-                            m.role === 'assistant'
-                              ? 'var(--brand-surface)'
-                              : 'var(--brand-surface-contrast)',
-                          borderColor: 'var(--brand-border-strong)',
-                        }}
-                      />
-                    </div>
-                  </div>
-                </div>
-              ))}
-              {thinking && (
-                <div className="mb-2 flex justify-start">
-                  <div className="max-w-[85%]">
-                    <div className="relative">
-                      <div className="relative z-10 rounded-2xl border border-[var(--brand-border-strong)] bg-[var(--brand-surface)] px-3 py-2 text-sm text-[var(--brand-body-secondary)]">
-                        Typing…
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-            {collectInfo ? (
-              <form
-                onSubmit={sendInfo}
-                className="flex flex-col gap-3 rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] p-3 text-[var(--brand-body-primary)] shadow-sm"
-                aria-label="Contact form"
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
               >
-                {collectInfoMode === 'soft' && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setCollectInfo(false);
-                      setCollectInfoMode(null);
+                <div className={`max-w-[85%] flex flex-col ${m.role === 'assistant' ? 'items-start' : 'items-end'}`}>
+                  <div className="relative">
+                    <div
+                      className="relative z-10 rounded-2xl border px-3 py-2 whitespace-pre-wrap break-words"
+                      style={{
+                        backgroundColor:
+                          m.role === 'assistant'
+                            ? 'var(--brand-primary)'
+                            : 'var(--brand-accent)',
+                        color: 'var(--brand-ink)',
+                        borderColor: 'var(--brand-border)',
+                        overflowWrap: 'anywhere',
+                        wordBreak: 'break-word',
+                      }}
+                    >
+                      {renderContent(m.content, m.role)}
+                      {m.role === 'assistant' && m.softEscalate && !collectInfo && (
+                        <div className="mt-1 text-sm">
+                          <button
+                            type="button"
+                            className="underline text-[var(--brand-alt)] decoration-[var(--brand-alt)] hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-[var(--brand-alt)] cursor-pointer bg-transparent p-0 font-normal"
+                            onClick={() => {
+                              const pct = Math.max(
+                                0,
+                                Math.min(100, Math.round(((m.confidence ?? 0) as number) * 100))
+                              );
+                              setEscalationReason(
+                                `Assistant confidence ${pct}%. Visitor opted to reach out for a more certain answer.`
+                              );
+                              setCollectInfo(true);
+                              setCollectInfoMode('soft');
+                            }}
+                            aria-label="Open escalation form"
+                          >
+                            Reach Out to a Staff Member
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                    <div
+                      className={`absolute h-3 w-3 rotate-45 border-b ${m.role === 'assistant' ? 'border-l left-3' : 'border-r right-3'}`}
+                      style={{
+                        bottom: -3,
+                        backgroundColor:
+                          m.role === 'assistant'
+                            ? 'var(--brand-primary)'
+                            : 'var(--brand-accent)',
+                        borderColor: 'var(--brand-border)',
+                      }}
+                    />
+                  </div>
+                  <div
+                    className={`mt-3 inline-block rounded border px-3 py-1 text-base font-semibold ${
+                      m.role === 'assistant'
+                        ? 'self-start'
+                        : 'self-end'
+                    }`}
+                    style={{
+                      borderColor: 'var(--brand-border)',
+                      color: 'var(--brand-accent)',
                     }}
-                    aria-label="Go back to chat"
-                    className="self-start text-xs font-medium uppercase tracking-wide text-[var(--brand-body-primary)] underline decoration-[var(--brand-body-primary)] underline-offset-2 hover:opacity-80"
                   >
-                    Back to chat
-                  </button>
-                )}
-                <p className="text-sm text-[var(--brand-body-primary)]">
-                  We&apos;d love to follow up. Share the best way to reach you and a short summary of what you need.
-                </p>
-                <input
-                  type="text"
-                  className="w-full rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
-                  placeholder="Name"
-                  value={info.name}
-                  onChange={(e) => setInfo({ ...info, name: e.target.value })}
-                  aria-label="Name"
-                  required
-                />
-                <input
-                  type="tel"
-                  className="w-full rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
-                  placeholder="Contact Number"
-                  value={info.contact}
-                  onChange={(e) => setInfo({ ...info, contact: e.target.value })}
-                  aria-label="Contact Number"
-                  required
-                />
-                <input
-                  type="email"
-                  className="w-full rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
-                  placeholder="Email"
-                  value={info.email}
-                  onChange={(e) => setInfo({ ...info, email: e.target.value })}
-                  aria-label="Email"
-                  required
-                />
-                <textarea
-                  className="w-full rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
-                  placeholder="Any extra details"
-                  value={info.details}
-                  onChange={(e) => setInfo({ ...info, details: e.target.value })}
-                  aria-label="Any extra details"
-                />
-                <button type="submit" className="btn-primary w-full cursor-pointer text-base">
-                  Send
-                </button>
-              </form>
-            ) : (
-              <form onSubmit={sendMessage} className="flex gap-2" aria-label="Chat input">
-                <input
-                  type="text"
-                  className="flex-1 min-w-0 rounded border border-[var(--brand-border)] bg-[var(--brand-bg)] px-3 py-2 text-sm text-[var(--brand-body-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
-                  value={input}
-                  onChange={(e) => setInput(e.target.value)}
-                  aria-label="Message"
-                />
-                <button type="submit" className="btn-primary cursor-pointer px-4 py-2 text-base">
-                  Send
-                </button>
-              </form>
+                    {m.role === 'assistant' ? 'Assistant' : 'You'}
+                  </div>
+                </div>
+              </div>
+            ))}
+            {thinking && !collectInfo && (
+              <div className="text-sm" style={{ color: 'var(--brand-muted)' }}>
+                Assistant is thinking…
+              </div>
             )}
           </div>
         </div>
+        {collectInfo ? (
+          <form
+            onSubmit={sendInfo}
+            className="flex flex-col gap-2 rounded-xl border border-[var(--brand-border)] bg-[var(--brand-bg)] p-3 shadow-sm"
+            aria-label="Contact form"
+          >
+            {collectInfoMode === 'soft' && (
+              <button
+                type="button"
+                onClick={() => { setCollectInfo(false); setCollectInfoMode(null); }}
+                aria-label="Go back to chat"
+                className="self-start -mb-1 underline focus:outline-none focus:ring-1 cursor-pointer hover:opacity-80"
+                style={{
+                  color: 'var(--brand-accent)',
+                  '--tw-ring-color': 'var(--brand-accent)',
+                } as CSSProperties}
+              >
+                Back
+              </button>
+            )}
+            <p className="mb-2 text-lg font-semibold" style={{ color: 'var(--brand-accent)' }}>
+              Contact a Staff Member
+            </p>
+            <input
+              type="text"
+              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
+              style={{
+                backgroundColor: 'var(--brand-alt)',
+                color: 'var(--brand-ink)',
+                borderColor: 'var(--brand-border)',
+                '--tw-ring-color': 'var(--brand-primary)',
+              } as CSSProperties}
+              placeholder="Name"
+              value={info.name}
+              onChange={(e) => setInfo({ ...info, name: e.target.value })}
+              aria-label="Name"
+              required
+            />
+            <input
+              type="text"
+              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
+              style={{
+                backgroundColor: 'var(--brand-alt)',
+                color: 'var(--brand-ink)',
+                borderColor: 'var(--brand-border)',
+                '--tw-ring-color': 'var(--brand-primary)',
+              } as CSSProperties}
+              placeholder="Contact Number"
+              value={info.contact}
+              onChange={(e) => setInfo({ ...info, contact: e.target.value })}
+              aria-label="Contact Number"
+              required
+            />
+            <input
+              type="email"
+              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
+              style={{
+                backgroundColor: 'var(--brand-alt)',
+                color: 'var(--brand-ink)',
+                borderColor: 'var(--brand-border)',
+                '--tw-ring-color': 'var(--brand-primary)',
+              } as CSSProperties}
+              placeholder="Email"
+              value={info.email}
+              onChange={(e) => setInfo({ ...info, email: e.target.value })}
+              aria-label="Email"
+              required
+            />
+            <textarea
+              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
+              style={{
+                backgroundColor: 'var(--brand-alt)',
+                color: 'var(--brand-ink)',
+                borderColor: 'var(--brand-border)',
+                '--tw-ring-color': 'var(--brand-primary)',
+              } as CSSProperties}
+              placeholder="Any extra details"
+              value={info.details}
+              onChange={(e) => setInfo({ ...info, details: e.target.value })}
+              aria-label="Any extra details"
+            />
+            <button
+              type="submit"
+              className="rounded px-3 py-1 focus:outline-none focus:ring-2 cursor-pointer"
+              style={{
+                backgroundColor: 'var(--brand-primary)',
+                color: 'var(--brand-ink)',
+                '--tw-ring-color': 'var(--brand-primary)',
+              } as CSSProperties}
+            >
+              Send
+            </button>
+          </form>
+        ) : (
+          <form
+            onSubmit={sendMessage}
+            className="flex gap-2 rounded-xl border border-[var(--brand-border)] bg-[var(--brand-bg)] p-2 shadow-sm"
+            aria-label="Chat input"
+          >
+            <input
+              type="text"
+              className="flex-1 min-w-0 border rounded px-2 py-1 focus:outline-none focus:ring-2"
+              style={{
+                backgroundColor: 'var(--brand-alt)',
+                color: 'var(--brand-ink)',
+                borderColor: 'var(--brand-border)',
+                '--tw-ring-color': 'var(--brand-primary)',
+              } as CSSProperties}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              aria-label="Message"
+            />
+            <button
+              type="submit"
+              className="rounded px-3 py-1 focus:outline-none focus:ring-2 cursor-pointer"
+              style={{
+                backgroundColor: 'var(--brand-primary)',
+                color: 'var(--brand-ink)',
+                '--tw-ring-color': 'var(--brand-primary)',
+              } as CSSProperties}
+            >
+              Send
+            </button>
+          </form>
+        )}
       </div>
       <div
         className={`relative group transition-all duration-700 ease-in-out ${

--- a/components/Assistant.tsx
+++ b/components/Assistant.tsx
@@ -429,11 +429,11 @@ export default function Assistant() {
       className={`fixed right-6 bottom-6 z-50 transition-all duration-[1000ms] ease-in-out ${entered ? '' : 'pointer-events-none'}`}
     >
       <div
-        className={`absolute bottom-0 right-0 w-80 rounded-lg border pt-8 pr-8 pb-4 pl-4 shadow-lg transition-all duration-700 ease-in-out transform ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
+        className={`brand-surface absolute bottom-0 right-0 w-80 rounded-lg border pt-8 pr-8 pb-4 pl-4 shadow-lg transition-all duration-700 ease-in-out transform ${open ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0 pointer-events-none'}`}
         style={{
           backgroundColor: 'var(--brand-surface)',
-          color: 'var(--brand-ink)',
-          borderColor: 'var(--brand-ink)',
+          color: 'var(--brand-body-secondary)',
+          borderColor: 'var(--brand-border)',
         }}
       >
         <button
@@ -447,7 +447,7 @@ export default function Assistant() {
           style={{
             backgroundColor: 'var(--brand-alt)',
             color: 'var(--brand-ink)',
-            borderColor: 'var(--brand-ink)',
+            borderColor: 'var(--brand-border)',
           }}
         >
           ×
@@ -472,9 +472,12 @@ export default function Assistant() {
                       style={{
                         backgroundColor:
                           m.role === 'assistant'
-                            ? 'var(--brand-primary)'
+                            ? 'var(--brand-surface)'
                             : 'var(--brand-accent)',
-                        color: 'var(--brand-ink)',
+                        color:
+                          m.role === 'assistant'
+                            ? 'var(--brand-heading-secondary)'
+                            : 'var(--brand-ink)',
                         borderColor: 'var(--brand-border)',
                         overflowWrap: 'anywhere',
                         wordBreak: 'break-word',
@@ -510,7 +513,7 @@ export default function Assistant() {
                         bottom: -3,
                         backgroundColor:
                           m.role === 'assistant'
-                            ? 'var(--brand-primary)'
+                            ? 'var(--brand-surface)'
                             : 'var(--brand-accent)',
                         borderColor: 'var(--brand-border)',
                       }}
@@ -564,13 +567,7 @@ export default function Assistant() {
             </p>
             <input
               type="text"
-              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-alt)',
-                color: 'var(--brand-ink)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
+              className="border border-[var(--brand-border)] rounded px-3 py-2 bg-[var(--brand-surface-contrast)] text-[var(--brand-body-primary)] focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
               placeholder="Name"
               value={info.name}
               onChange={(e) => setInfo({ ...info, name: e.target.value })}
@@ -579,13 +576,7 @@ export default function Assistant() {
             />
             <input
               type="text"
-              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-alt)',
-                color: 'var(--brand-ink)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
+              className="border border-[var(--brand-border)] rounded px-3 py-2 bg-[var(--brand-surface-contrast)] text-[var(--brand-body-primary)] focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
               placeholder="Contact Number"
               value={info.contact}
               onChange={(e) => setInfo({ ...info, contact: e.target.value })}
@@ -594,13 +585,7 @@ export default function Assistant() {
             />
             <input
               type="email"
-              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-alt)',
-                color: 'var(--brand-ink)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
+              className="border border-[var(--brand-border)] rounded px-3 py-2 bg-[var(--brand-surface-contrast)] text-[var(--brand-body-primary)] focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
               placeholder="Email"
               value={info.email}
               onChange={(e) => setInfo({ ...info, email: e.target.value })}
@@ -608,13 +593,7 @@ export default function Assistant() {
               required
             />
             <textarea
-              className="border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-alt)',
-                color: 'var(--brand-ink)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
+              className="border border-[var(--brand-border)] rounded px-3 py-2 bg-[var(--brand-surface-contrast)] text-[var(--brand-body-primary)] focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
               placeholder="Any extra details"
               value={info.details}
               onChange={(e) => setInfo({ ...info, details: e.target.value })}
@@ -622,12 +601,7 @@ export default function Assistant() {
             />
             <button
               type="submit"
-              className="rounded px-3 py-1 focus:outline-none focus:ring-2 cursor-pointer"
-              style={{
-                backgroundColor: 'var(--brand-primary)',
-                color: 'var(--brand-ink)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
+              className="btn-primary px-4 py-2 text-sm"
             >
               Send
             </button>
@@ -640,25 +614,14 @@ export default function Assistant() {
           >
             <input
               type="text"
-              className="flex-1 min-w-0 border rounded px-2 py-1 focus:outline-none focus:ring-2"
-              style={{
-                backgroundColor: 'var(--brand-alt)',
-                color: 'var(--brand-ink)',
-                borderColor: 'var(--brand-border)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
+              className="flex-1 min-w-0 rounded border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] px-3 py-2 text-[var(--brand-body-primary)] focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               aria-label="Message"
             />
             <button
               type="submit"
-              className="rounded px-3 py-1 focus:outline-none focus:ring-2 cursor-pointer"
-              style={{
-                backgroundColor: 'var(--brand-primary)',
-                color: 'var(--brand-ink)',
-                '--tw-ring-color': 'var(--brand-primary)',
-              } as CSSProperties}
+              className="btn-primary px-4 py-2 text-sm"
             >
               Send
             </button>

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -102,92 +102,88 @@ export default function ContactForm({ pageId, formId }: ContactFormProps) {
   const isLoading = status === "loading";
 
   return (
-    <div className="mt-8 max-w-md mx-auto">
+    <div className="mx-auto w-full max-w-2xl">
       {status === "success" ? (
-        <p className="text-center animate-fade-in-up" role="status">
+        <p className="text-center text-lg font-semibold text-[var(--brand-heading-primary)] animate-fade-in-up" role="status">
           Thanks for reaching out! We&apos;ll get back to you soon.
         </p>
       ) : (
-        <form
-          onSubmit={handleSubmit}
-          className="space-y-6 animate-fade-in-up"
-        >
-          <div className="relative">
-            <input
-              id="name"
-              type="text"
-              required
-              placeholder="Your name"
-              value={values.name}
-              onChange={handleChange("name")}
-              className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-5 pb-3 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
-            />
-            <label
-              htmlFor="name"
-              className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-muted)] transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-hover:top-1.5 peer-hover:translate-y-0 peer-hover:text-xs peer-hover:bg-transparent peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-accent)] peer-focus:bg-[var(--brand-surface)]"
+        <div className="brand-surface space-y-6 rounded-2xl border-2 border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 shadow-lg animate-fade-in-up">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="relative">
+              <input
+                id="name"
+                type="text"
+                required
+                placeholder="Your name"
+                value={values.name}
+                onChange={handleChange("name")}
+                className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] px-4 pt-5 pb-3 text-[var(--brand-body-primary)] placeholder-transparent focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+              />
+              <label
+                htmlFor="name"
+                className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface-contrast)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-body-secondary)] transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-heading-primary)]"
+              >
+                Name
+              </label>
+            </div>
+            <div className="relative">
+              <input
+                id="email"
+                type="email"
+                required
+                placeholder="Your email"
+                value={values.email}
+                onChange={handleChange("email")}
+                className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] px-4 pt-5 pb-3 text-[var(--brand-body-primary)] placeholder-transparent focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+              />
+              <label
+                htmlFor="email"
+                className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface-contrast)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-body-secondary)] transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-heading-primary)]"
+              >
+                Email
+              </label>
+            </div>
+            <div className="relative">
+              <textarea
+                id="message"
+                required
+                rows={4}
+                placeholder="Your message"
+                value={values.message}
+                onChange={handleChange("message")}
+                className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] px-4 pt-6 pb-4 text-[var(--brand-body-primary)] placeholder-transparent focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+              />
+              <label
+                htmlFor="message"
+                className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface-contrast)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-body-secondary)] transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-heading-primary)]"
+              >
+                Message
+              </label>
+            </div>
+            {status === "error" && errorMessage ? (
+              <p className="text-center text-sm font-semibold text-[var(--brand-heading-primary)]" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="btn-primary pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md cursor-pointer hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-60"
             >
-              Name
-            </label>
-          </div>
-          <div className="relative">
-            <input
-              id="email"
-              type="email"
-              required
-              placeholder="Your email"
-              value={values.email}
-              onChange={handleChange("email")}
-              className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-5 pb-3 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
-            />
-            <label
-              htmlFor="email"
-              className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-muted)] transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-hover:top-1.5 peer-hover:translate-y-0 peer-hover:text-xs peer-hover:bg-transparent peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-accent)] peer-focus:bg-[var(--brand-surface)]"
-            >
-              Email
-            </label>
-          </div>
-          <div className="relative">
-            <textarea
-              id="message"
-              required
-              rows={4}
-              placeholder="Your message"
-              value={values.message}
-              onChange={handleChange("message")}
-              className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-6 pb-4 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
-            />
-            <label
-              htmlFor="message"
-              className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-muted)] transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-hover:top-1.5 peer-hover:translate-y-0 peer-hover:text-xs peer-hover:bg-transparent peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-accent)] peer-focus:bg-[var(--brand-surface)]"
-            >
-              Message
-            </label>
-          </div>
-          {status === "error" && errorMessage ? (
-            <p
-              className="text-sm text-center text-[var(--brand-accent)]"
-              role="alert"
-            >
-              {errorMessage}
-            </p>
-          ) : null}
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="btn-outline-cta pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md cursor-pointer hover:shadow-lg transform transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
-          >
-            <span>{isLoading ? "Sending..." : "Send Message"}</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-              className="h-5 w-5"
-            >
-              <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l5 5a1 1 0 010 1.414l-5 5a1 1 0 11-1.414-1.414L13.586 11H4a1 1 0 110-2h9.586l-3.293-3.293a1 1 0 010-1.414z" clipRule="evenodd" />
-            </svg>
-          </button>
-        </form>
+              <span>{isLoading ? "Sending..." : "Send Message"}</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+                className="h-5 w-5"
+              >
+                <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l5 5a1 1 0 010 1.414l-5 5a1 1 0 11-1.414-1.414L13.586 11H4a1 1 0 110-2h9.586l-3.293-3.293a1 1 0 010-1.414z" clipRule="evenodd" />
+              </svg>
+            </button>
+          </form>
+        </div>
       )}
     </div>
   );

--- a/components/Countdown.tsx
+++ b/components/Countdown.tsx
@@ -24,7 +24,7 @@ export default function Countdown({ target }: Props) {
   const seconds = Math.floor((remaining / 1000) % 60);
 
   return (
-    <div className="text-center text-lg font-semibold text-[var(--brand-fg)]">
+    <div className="text-center text-lg font-semibold text-[var(--brand-heading-primary)]">
       {days > 0 && `${days}d `}
       {String(hours).padStart(2, '0')}:{String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')} until next stream
     </div>

--- a/components/EventCalendar.tsx
+++ b/components/EventCalendar.tsx
@@ -60,26 +60,26 @@ export default function EventCalendar({ events }: { events: CalendarEvent[] }) {
       <div className="flex items-center justify-between">
         <button
           onClick={() => changeMonth(-1)}
-          className="px-2 py-1 text-sm rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] cursor-pointer text-[var(--brand-fg)] hover:bg-[var(--brand-border)] hover:text-[var(--brand-bg)]"
+          className="px-2 py-1 text-sm rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] cursor-pointer text-[var(--brand-heading-secondary)] hover:bg-[var(--brand-heading-secondary)] hover:text-[var(--brand-primary)]"
         >
           Prev
         </button>
-        <h2 className="font-semibold text-[var(--brand-fg)]">
+        <h2 className="font-semibold text-[var(--brand-heading-primary)]">
           {current.toLocaleString("en-US", { month: "long", year: "numeric" })}
         </h2>
         <button
           onClick={() => changeMonth(1)}
-          className="px-2 py-1 text-sm rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] cursor-pointer text-[var(--brand-fg)] hover:bg-[var(--brand-border)] hover:text-[var(--brand-bg)]"
+          className="px-2 py-1 text-sm rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] cursor-pointer text-[var(--brand-heading-secondary)] hover:bg-[var(--brand-heading-secondary)] hover:text-[var(--brand-primary)]"
         >
           Next
         </button>
       </div>
-      <div className="grid grid-cols-7 text-center text-sm font-medium text-[var(--brand-fg)]">
+      <div className="grid grid-cols-7 text-center text-sm font-medium text-[var(--brand-body-primary)]">
         {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
           <div key={d}>{d}</div>
         ))}
       </div>
-      <div className="grid grid-cols-7 gap-px bg-[var(--brand-border)] text-[var(--brand-fg)]">
+      <div className="grid grid-cols-7 gap-px bg-[var(--brand-border)] text-[var(--brand-body-primary)]">
         {weeks.flat().map((d, i) => (
           <div
             key={i}
@@ -147,7 +147,7 @@ export default function EventCalendar({ events }: { events: CalendarEvent[] }) {
         <div className="flex justify-center">
           <button
             onClick={goToToday}
-            className="px-4 py-2 text-base rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] cursor-pointer text-[var(--brand-fg)] hover:bg-[var(--brand-border)] hover:text-[var(--brand-bg)]"
+            className="px-4 py-2 text-base rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] cursor-pointer text-[var(--brand-heading-secondary)] hover:bg-[var(--brand-heading-secondary)] hover:text-[var(--brand-primary)]"
           >
             Today
           </button>

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -38,7 +38,7 @@ export function EventCard({
     return (
       <Link
         href={event.href}
-        className="group card relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-visible:-translate-y-1 focus-visible:-rotate-1 focus-visible:scale-[1.02] focus-visible:shadow-lg transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)] no-underline hover:no-underline focus:no-underline focus-visible:no-underline visited:no-underline active:no-underline"
+        className="group card brand-surface relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-visible:-translate-y-1 focus-visible:-rotate-1 focus-visible:scale-[1.02] focus-visible:shadow-lg transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)] no-underline hover:no-underline focus:no-underline focus-visible:no-underline visited:no-underline active:no-underline"
         style={{ ...style, textDecoration: 'none' }}
       >
         {event.image && (
@@ -52,16 +52,16 @@ export function EventCard({
         )}
         <div className="flex flex-1 flex-col p-4">
           <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{event.title}</h3>
-          <p className={`mt-1 text-sm ${dateClassName ?? 'text-[var(--brand-muted)]'}`}>
+          <p className={`mt-1 text-sm ${dateClassName ?? 'text-[var(--brand-body-secondary)]'}`}>
             {event.date}
             {event.location ? ` • ${event.location}` : ""}
           </p>
           {event.description && (
-            <p className={`mt-2 flex-1 text-sm ${descriptionClassName ?? 'text-[var(--brand-fg)]'}`}>
+            <p className={`mt-2 flex-1 text-sm ${descriptionClassName ?? 'text-[var(--brand-body-secondary)]'}`}>
               {event.description}
             </p>
           )}
-          <span className="relative mt-4 inline-block rounded px-1 py-0.5 text-sm font-medium text-[var(--brand-accent)] transition-colors underline group-hover:text-[var(--brand-primary-contrast)]">
+          <span className="relative mt-4 inline-block rounded px-1 py-0.5 text-sm font-medium text-[var(--brand-heading-secondary)] transition-colors underline decoration-[var(--brand-heading-secondary)] underline-offset-2 group-hover:opacity-90">
             Learn more
           </span>
         </div>
@@ -70,7 +70,7 @@ export function EventCard({
   }
   return (
     <div
-      className="card relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-within:-translate-y-1 focus-within:-rotate-1 focus-within:scale-[1.02] focus-within:shadow-lg"
+      className="card brand-surface relative flex h-full transform flex-col overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] transition duration-300 ease-out hover:-translate-y-1 hover:-rotate-1 hover:scale-[1.02] hover:shadow-lg focus-within:-translate-y-1 focus-within:-rotate-1 focus-within:scale-[1.02] focus-within:shadow-lg"
       style={style}
     >
       {event.image && (
@@ -84,12 +84,12 @@ export function EventCard({
       )}
       <div className="flex flex-1 flex-col p-4">
         <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{event.title}</h3>
-        <p className={`mt-1 text-sm ${dateClassName ?? 'text-[var(--brand-muted)]'}`}>
+        <p className={`mt-1 text-sm ${dateClassName ?? 'text-[var(--brand-body-secondary)]'}`}>
           {event.date}
           {event.location ? ` • ${event.location}` : ""}
         </p>
         {event.description && (
-          <p className={`mt-2 flex-1 text-sm ${descriptionClassName ?? 'text-[var(--brand-fg)]'}`}>
+          <p className={`mt-2 flex-1 text-sm ${descriptionClassName ?? 'text-[var(--brand-body-secondary)]'}`}>
             {event.description}
           </p>
         )}

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -51,7 +51,7 @@ export function EventCard({
           />
         )}
         <div className="flex flex-1 flex-col p-4">
-          <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{event.title}</h3>
+          <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{event.title}</h3>
           <p className={`mt-1 text-sm ${dateClassName ?? 'text-[var(--brand-muted)]'}`}>
             {event.date}
             {event.location ? ` • ${event.location}` : ""}
@@ -83,7 +83,7 @@ export function EventCard({
         />
       )}
       <div className="flex flex-1 flex-col p-4">
-        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{event.title}</h3>
+        <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{event.title}</h3>
         <p className={`mt-1 text-sm ${dateClassName ?? 'text-[var(--brand-muted)]'}`}>
           {event.date}
           {event.location ? ` • ${event.location}` : ""}

--- a/components/EventGallery.tsx
+++ b/components/EventGallery.tsx
@@ -40,7 +40,7 @@ export default function EventGallery({ events }: { events: GalleryEvent[] }) {
               />
             )}
             <div className="p-4">
-              <h3 className="text-base font-semibold text-[var(--brand-fg)]">{ev.title}</h3>
+              <h3 className="text-base font-semibold text-[var(--brand-heading-secondary)]">{ev.title}</h3>
               <p className="mt-1 text-xs text-[var(--brand-muted)]">
                 {ev.date}
                 {ev.location ? ` • ${ev.location}` : ""}

--- a/components/EventList.tsx
+++ b/components/EventList.tsx
@@ -4,7 +4,7 @@ export function EventList({ events, descriptionClassName, dateClassName }: { eve
   if (events.length === 0) {
     return (
       <div className="grid gap-6 grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]">
-        <p className="col-span-full text-sm text-[var(--brand-muted)]">No events found.</p>
+        <p className="col-span-full text-sm text-[var(--brand-body-primary)]">No events found.</p>
       </div>
     );
   }

--- a/components/EventTabs.tsx
+++ b/components/EventTabs.tsx
@@ -28,7 +28,7 @@ export default function EventTabs({ events }: { events: CalendarEvent[] }) {
           className={`px-3 py-1 rounded cursor-pointer ${
             tab === "timeline"
               ? "bg-[var(--brand-accent)] text-[var(--brand-ink)]"
-              : "border border-[var(--brand-border)] bg-[var(--brand-surface)] text-[var(--brand-fg)]"
+              : "border border-[var(--brand-border)] bg-[var(--brand-surface)] text-[var(--brand-heading-secondary)]"
           }`}
           onClick={() => setTab("timeline")}
         >
@@ -38,7 +38,7 @@ export default function EventTabs({ events }: { events: CalendarEvent[] }) {
           className={`px-3 py-1 rounded cursor-pointer ${
             tab === "calendar"
               ? "bg-[var(--brand-accent)] text-[var(--brand-ink)]"
-              : "border border-[var(--brand-border)] bg-[var(--brand-surface)] text-[var(--brand-fg)]"
+              : "border border-[var(--brand-border)] bg-[var(--brand-surface)] text-[var(--brand-heading-secondary)]"
           }`}
           onClick={() => setTab("calendar")}
         >

--- a/components/EventTimeline.tsx
+++ b/components/EventTimeline.tsx
@@ -92,7 +92,7 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
                   className="mb-4 w-full rounded object-cover"
                 />
               )}
-              <h3 className="text-lg font-semibold text-[var(--brand-fg)]">
+              <h3 className="text-lg font-semibold text-[var(--brand-heading-primary)]">
                 {ev.title}
               </h3>
               <p className="text-sm text-[var(--brand-muted)]">
@@ -100,7 +100,7 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
                 {ev.location ? ` • ${ev.location}` : ""}
               </p>
               {ev.description && (
-                <p className="text-base text-[var(--brand-fg)]">
+                <p className="text-base text-[var(--brand-body-primary)]">
                   {ev.description}
                 </p>
               )}
@@ -119,7 +119,7 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
                   className="mb-4 w-full rounded object-cover"
                 />
               )}
-              <h3 className="text-lg font-semibold text-[var(--brand-fg)]">
+              <h3 className="text-lg font-semibold text-[var(--brand-heading-primary)]">
                 {ev.title}
               </h3>
               <p className="text-sm text-[var(--brand-muted)]">
@@ -127,7 +127,7 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
                 {ev.location ? ` • ${ev.location}` : ""}
               </p>
               {ev.description && (
-                <p className="text-base text-[var(--brand-fg)]">
+                <p className="text-base text-[var(--brand-body-primary)]">
                   {ev.description}
                 </p>
               )}

--- a/components/EventTimeline.tsx
+++ b/components/EventTimeline.tsx
@@ -95,7 +95,7 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
               <h3 className="text-lg font-semibold text-[var(--brand-heading-primary)]">
                 {ev.title}
               </h3>
-              <p className="text-sm text-[var(--brand-muted)]">
+              <p className="text-sm text-[var(--brand-body-primary)]">
                 {ev.date}
                 {ev.location ? ` • ${ev.location}` : ""}
               </p>
@@ -122,7 +122,7 @@ export default function EventTimeline({ events }: { events: TimelineEvent[] }) {
               <h3 className="text-lg font-semibold text-[var(--brand-heading-primary)]">
                 {ev.title}
               </h3>
-              <p className="text-sm text-[var(--brand-muted)]">
+              <p className="text-sm text-[var(--brand-body-primary)]">
                 {ev.date}
                 {ev.location ? ` • ${ev.location}` : ""}
               </p>

--- a/components/FaqAccordion.tsx
+++ b/components/FaqAccordion.tsx
@@ -16,26 +16,26 @@ interface FaqAccordionProps {
 const portableTextComponents: PortableTextComponents = {
   block: {
     normal: ({ children }) => (
-      <p className="text-sm leading-relaxed text-[var(--brand-alt)]/90">{children}</p>
+      <p className="text-sm leading-relaxed text-[var(--brand-body-secondary)]">{children}</p>
     ),
     h4: ({ children }) => (
-      <h4 className="text-base font-semibold text-[var(--brand-alt)]">{children}</h4>
+      <h4 className="text-base font-semibold text-[var(--brand-heading-secondary)]">{children}</h4>
     ),
   },
   list: {
     bullet: ({ children }) => (
-      <ul className="ml-4 list-disc space-y-1 text-sm text-[var(--brand-alt)]/90">{children}</ul>
+      <ul className="ml-4 list-disc space-y-1 text-sm text-[var(--brand-body-secondary)]">{children}</ul>
     ),
     number: ({ children }) => (
-      <ol className="ml-4 list-decimal space-y-1 text-sm text-[var(--brand-alt)]/90">{children}</ol>
+      <ol className="ml-4 list-decimal space-y-1 text-sm text-[var(--brand-body-secondary)]">{children}</ol>
     ),
   },
   marks: {
     strong: ({ children }) => (
-      <strong className="font-semibold text-[var(--brand-alt)]">{children}</strong>
+      <strong className="font-semibold text-[var(--brand-heading-secondary)]">{children}</strong>
     ),
     em: ({ children }) => (
-      <em className="italic text-[var(--brand-alt)]/95">{children}</em>
+      <em className="italic text-[var(--brand-body-secondary)]">{children}</em>
     ),
     link: ({
       children,
@@ -47,7 +47,7 @@ const portableTextComponents: PortableTextComponents = {
       return (
         <a
           href={href}
-          className="underline decoration-[var(--brand-alt)] underline-offset-2 hover:opacity-80 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-alt)]"
+          className="underline decoration-[var(--brand-heading-secondary)] underline-offset-2 hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-heading-secondary)]"
           target={isExternal ? "_blank" : undefined}
           rel={isExternal ? "noreferrer" : undefined}
         >
@@ -81,7 +81,7 @@ export default function FaqAccordion({ faqs }: FaqAccordionProps) {
 
   if (faqs.length === 0) {
     return (
-      <div className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 text-center text-[var(--brand-alt)]">
+      <div className="brand-surface rounded-2xl border-2 border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 text-center text-[var(--brand-body-secondary)]">
         We update our frequently asked questions often. Please check back soon.
       </div>
     );
@@ -94,11 +94,11 @@ export default function FaqAccordion({ faqs }: FaqAccordionProps) {
           <div className="flex items-baseline justify-between gap-3">
             <h2
               id={`faq-category-${category}`}
-              className="text-xl font-semibold text-[var(--brand-alt)]"
+              className="text-xl font-semibold text-[var(--brand-heading-primary)]"
             >
               {category}
             </h2>
-            <span className="text-xs uppercase tracking-widest text-[var(--brand-muted)]">
+            <span className="text-xs uppercase tracking-widest text-[var(--brand-body-primary)]">
               {items.length} {items.length === 1 ? "topic" : "topics"}
             </span>
           </div>
@@ -113,27 +113,27 @@ export default function FaqAccordion({ faqs }: FaqAccordionProps) {
               return (
                 <article
                   key={faq._id}
-                  className="rounded-2xl border border-[var(--brand-border)] bg-[var(--brand-surface)] p-4 shadow-sm transition-transform duration-300 hover:translate-y-[-2px] hover:shadow-lg"
+                  className="brand-surface rounded-2xl border-2 border-[var(--brand-border)] bg-[var(--brand-surface)] p-4 shadow-sm transition-transform duration-300 hover:translate-y-[-2px] hover:shadow-lg"
                 >
                   <div className="flex flex-col gap-3">
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between gap-4 text-left"
+                      className="flex w-full items-center justify-between gap-4 text-left text-[var(--brand-heading-secondary)]"
                       onClick={() => toggle(faq._id)}
                       aria-expanded={isOpen}
                       aria-controls={contentId}
                     >
-                      <span className="text-base font-semibold text-[var(--brand-alt)]">
+                      <span className="text-base font-semibold text-[var(--brand-heading-secondary)]">
                         {faq.question}
                       </span>
                       <span
                         aria-hidden="true"
-                        className={`transition-transform duration-300 ${
+                        className={`text-[var(--brand-heading-secondary)] transition-transform duration-300 ${
                           isOpen ? "rotate-180" : "rotate-0"
                         }`}
                       >
                         <svg
-                          className="h-5 w-5 text-[var(--brand-alt)]"
+                          className="h-5 w-5"
                           viewBox="0 0 20 20"
                           fill="currentColor"
                         >
@@ -146,7 +146,7 @@ export default function FaqAccordion({ faqs }: FaqAccordionProps) {
                       </span>
                     </button>
                     <div className="flex flex-wrap items-center justify-between gap-3">
-                      <span className="rounded-full bg-[color:color-mix(in_oklab,var(--brand-primary)_30%,transparent)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[var(--brand-alt)]/90">
+                      <span className="rounded-full bg-[color:color-mix(in_oklab,var(--brand-primary)_30%,transparent)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[var(--brand-body-secondary)]">
                         {category}
                       </span>
                       <FaqAssistantChip prompt={prompt} />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -15,7 +15,7 @@ export default async function Footer() {
       <div className="max-w-site px-4 py-6">
         <div className="grid grid-cols-1 justify-items-center gap-y-8 text-center md:grid-cols-5 md:gap-x-8 md:justify-items-center md:text-center">
           <div>
-            <h4 className="mb-2 font-semibold text-[var(--brand-surface-contrast)]">{title}</h4>
+            <h4 className="mb-2 font-semibold text-[var(--brand-heading-secondary)]">{title}</h4>
             <p>
               <a
                 href={`https://www.google.com/maps?q=${encodeURIComponent(address)}`}
@@ -29,7 +29,7 @@ export default async function Footer() {
           </div>
 
           <div>
-            <h4 className="mb-2 font-semibold text-[var(--brand-surface-contrast)]">Service Times</h4>
+            <h4 className="mb-2 font-semibold text-[var(--brand-heading-secondary)]">Service Times</h4>
             <div className="space-y-0.5 text-[var(--brand-accent)] dark:text-[var(--brand-fg)]">
               {serviceTimes
                 .split(/[,;\n|]+/)
@@ -43,7 +43,7 @@ export default async function Footer() {
 
           <div>
             <div className="mx-auto w-max">
-              <h4 className="mb-2 font-semibold text-[var(--brand-surface-contrast)]">Quick Links</h4>
+              <h4 className="mb-2 font-semibold text-[var(--brand-heading-secondary)]">Quick Links</h4>
               <ul className="grid grid-cols-2 justify-items-center gap-x-6 gap-y-1">
                 <li>
                   <Link className="rounded text-[var(--brand-accent)] no-underline hover:text-[var(--brand-alt)] hover:underline focus-visible:text-[var(--brand-alt)] focus-visible:ring-1 focus-visible:ring-[var(--brand-alt)]" href="/visit">
@@ -79,7 +79,7 @@ export default async function Footer() {
           </div>
 
           <div>
-            <h4 className="mb-2 font-semibold text-[var(--brand-surface-contrast)]">Connect</h4>
+            <h4 className="mb-2 font-semibold text-[var(--brand-heading-secondary)]">Connect</h4>
             <div className="mb-2 flex flex-col items-center space-y-1 text-[var(--brand-accent)] dark:text-[var(--brand-fg)]">
               {phone && (
                 <a
@@ -101,12 +101,12 @@ export default async function Footer() {
           </div>
 
           <div>
-            <h4 className="mb-2 font-semibold text-[var(--brand-surface-contrast)]">Newsletter</h4>
+            <h4 className="mb-2 font-semibold text-[var(--brand-heading-secondary)]">Newsletter</h4>
             <form className="flex w-full flex-col gap-2 sm:flex-row sm:items-center">
               <input
                 type="email"
                 placeholder="Email address"
-                className="flex-1 rounded border border-[var(--brand-border)] bg-[var(--brand-surface)] px-2 py-1 text-[var(--brand-fg)] placeholder-[var(--brand-muted)] focus:border-[var(--brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-primary)]"
+                className="flex-1 rounded border border-[var(--brand-border)] bg-[var(--brand-heading-secondary)] px-2 py-1 text-[var(--brand-body-primary)] placeholder-[var(--brand-muted)] focus:border-[var(--brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-primary)]"
               />
               <button
                 type="submit"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -106,7 +106,7 @@ export default async function Footer() {
               <input
                 type="email"
                 placeholder="Email address"
-                className="flex-1 rounded border border-[var(--brand-border)] bg-[var(--brand-heading-secondary)] px-2 py-1 text-[var(--brand-body-primary)] placeholder-[var(--brand-muted)] focus:border-[var(--brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-primary)]"
+                className="flex-1 rounded border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] px-3 py-2 font-sans text-sm text-[var(--brand-body-primary)] placeholder:text-[var(--brand-body-primary)] placeholder:opacity-70 focus:border-[var(--brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-primary)]"
               />
               <button
                 type="submit"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -110,7 +110,7 @@ export default async function Footer() {
               />
               <button
                 type="submit"
-                className="rounded cursor-pointer border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-3 py-1 text-sm font-medium text-[var(--brand-primary-contrast)] transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--brand-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-bg)]"
+                className="btn-primary px-6 py-2 text-sm font-semibold"
               >
                 Subscribe
               </button>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -110,7 +110,7 @@ export default async function Footer() {
               />
               <button
                 type="submit"
-                className="rounded cursor-pointer border border-[var(--brand-primary)] bg-[var(--brand-alt)] px-3 py-1 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-primary)] hover:text-[var(--brand-primary-contrast)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--brand-accent)] dark:bg-[var(--brand-primary)] dark:text-[var(--brand-ink)] dark:hover:bg-[var(--brand-alt)] dark:hover:text-[var(--brand-primary)]"
+                className="rounded cursor-pointer border border-[var(--brand-primary)] bg-[var(--brand-primary)] px-3 py-1 text-sm font-medium text-[var(--brand-primary-contrast)] transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-primary)_85%,white_15%)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--brand-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-bg)]"
               >
                 Subscribe
               </button>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -26,6 +26,13 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
   const linkClasses = (active: boolean) =>
     `${active ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)]`;
 
+  const dropdownButtonClasses = (active: boolean) =>
+    `${
+      active
+        ? "text-[var(--brand-heading-secondary)]"
+        : "text-[var(--brand-body-secondary)]"
+    } inline-flex items-center gap-1 cursor-pointer focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--brand-heading-secondary)] hover:text-[var(--brand-heading-secondary)] focus:text-[var(--brand-heading-secondary)]`;
+
   return (
     <header className="sticky top-0 z-50 border-b border-[var(--brand-border)] bg-[var(--brand-surface)]">
       <div className="max-w-site relative flex h-16 items-center px-4">
@@ -46,7 +53,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
 
           <div className="relative group">
             <button
-              className={`${pathname.startsWith("/about") ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)] inline-flex items-center gap-1 cursor-pointer focus:outline-none`}
+              className={dropdownButtonClasses(pathname.startsWith("/about"))}
               aria-haspopup="true"
             >
               <span>About</span>
@@ -101,7 +108,7 @@ export default function Header({ initialTitle }: { initialTitle?: string }) {
 
           <div className="relative group">
             <button
-              className={`${pathname.startsWith("/contact") ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)] inline-flex items-center gap-1 cursor-pointer focus:outline-none`}
+              className={dropdownButtonClasses(pathname.startsWith("/contact"))}
               aria-haspopup="true"
             >
               <span>Contact</span>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -82,10 +82,10 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             />
           )}
           <div className="absolute inset-0 bg-[var(--brand-overlay)] z-10" />
-          <div className="relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center text-[var(--brand-body-secondary)]">
-            <div className="rounded-md bg-[color:color-mix(in_oklab,var(--brand-bg)_60%,transparent)] px-4 py-2 shadow-xl md:shadow-2xl">
-              <h1 className="text-4xl font-bold tracking-tight text-[var(--brand-heading-secondary)]">{slide.headline}</h1>
-              {slide.subline && <p className="mt-2 text-lg text-[var(--brand-body-secondary)]">{slide.subline}</p>}
+          <div className="brand-surface relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center">
+            <div className="rounded-xl border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface)_32%,var(--brand-bg)_68%)] px-6 py-4 shadow-xl md:shadow-2xl">
+              <h1 className="text-4xl font-bold tracking-tight">{slide.headline}</h1>
+              {slide.subline && <p className="mt-2 text-lg">{slide.subline}</p>}
             </div>
             {slide.cta && slide.cta.href && slide.cta.label && (
               <Link
@@ -94,13 +94,7 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
                 target="_blank"
                 rel="noopener noreferrer"
                 role="button"
-                className={`mt-8 inline-flex items-center justify-center gap-2 rounded-full px-7 py-3 font-semibold tracking-wide no-underline
-                bg-[var(--brand-accent)] text-[var(--brand-ink)] ring-2 ring-[color:color-mix(in_oklab,var(--brand-ink)_30%,transparent)] shadow-[0_8px_18px_-6px_color-mix(in_oklab,var(--brand-ink)_40%,transparent)]
-                /* Preserve current branch's hover effect: scale and stronger shadow */
-                hover:scale-105 hover:shadow-lg
-                /* Keep main's focus and active states */
-                focus:outline-none focus:ring-4 focus:ring-[var(--brand-alt)] focus:ring-offset-2 focus:ring-offset-[var(--brand-ink)]
-                transition-transform active:scale-95 ${shouldNudge ? 'animate-shake' : ''}`}
+                className={`btn-primary mt-8 text-lg font-semibold uppercase tracking-wide no-underline ${shouldNudge ? 'animate-shake' : ''}`}
               >
                 {slide.cta.label}
               </Link>
@@ -115,7 +109,7 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             type="button"
             aria-label="Previous slide"
             onClick={prev}
-            className="absolute left-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_35%,transparent)] text-3xl leading-none text-[var(--brand-primary)] hover:bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_55%,transparent)] ring-1 ring-[color:color-mix(in_oklab,var(--brand-heading-secondary)_45%,transparent)] shadow-sm cursor-pointer"
+            className="absolute left-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface-contrast)_35%,transparent)] text-3xl leading-none text-[var(--brand-primary)] shadow-sm transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface-contrast)_65%,transparent)]"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="15 18 9 12 15 6" />
@@ -125,7 +119,7 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             type="button"
             aria-label="Next slide"
             onClick={next}
-            className="absolute right-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_35%,transparent)] text-3xl leading-none text-[var(--brand-primary)] hover:bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_55%,transparent)] ring-1 ring-[color:color-mix(in_oklab,var(--brand-heading-secondary)_45%,transparent)] shadow-sm cursor-pointer"
+            className="absolute right-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface-contrast)_35%,transparent)] text-3xl leading-none text-[var(--brand-primary)] shadow-sm transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface-contrast)_65%,transparent)]"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="9 18 15 12 9 6" />
@@ -136,10 +130,10 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
               <button
                 key={i}
                 onClick={() => goTo(i)}
-                className={`h-2 w-2 rounded-full ${
+                className={`h-2 w-2 rounded-full transition-colors ${
                   i === index
-                    ? 'bg-[var(--brand-heading-secondary)]'
-                    : 'bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_40%,transparent)]'
+                    ? 'bg-[var(--brand-accent)]'
+                    : 'bg-[color:color-mix(in_oklab,var(--brand-accent)_40%,transparent)]'
                 }` }
                 aria-label={`Go to slide ${i + 1}`}
               />

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -82,8 +82,8 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             />
           )}
           <div className="relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center">
-            <div className="max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-surface)] p-1 shadow-2xl">
-              <div className="rounded-2xl bg-[var(--brand-bg)] px-6 py-6 text-[var(--brand-body-primary)] md:px-10 md:py-8">
+            <div className="brand-surface max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-surface)] p-1 shadow-2xl">
+              <div className="rounded-2xl bg-[var(--brand-surface-contrast)] px-6 py-6 text-[var(--brand-body-primary)] md:px-10 md:py-8 [--surface-heading-color:var(--brand-heading-primary)] [--surface-body-color:var(--brand-body-primary)]">
                 <h1 className="text-3xl font-bold tracking-tight text-[var(--brand-heading-primary)] md:text-4xl">
                   {slide.headline}
                 </h1>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -82,10 +82,10 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             />
           )}
           <div className="absolute inset-0 bg-[var(--brand-overlay)] z-10" />
-          <div className="relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center text-[var(--brand-fg)]">
+          <div className="relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center text-[var(--brand-body-secondary)]">
             <div className="rounded-md bg-[color:color-mix(in_oklab,var(--brand-bg)_60%,transparent)] px-4 py-2 shadow-xl md:shadow-2xl">
-              <h1 className="text-4xl font-bold tracking-tight">{slide.headline}</h1>
-              {slide.subline && <p className="mt-2 text-lg text-[var(--brand-accent)]">{slide.subline}</p>}
+              <h1 className="text-4xl font-bold tracking-tight text-[var(--brand-heading-secondary)]">{slide.headline}</h1>
+              {slide.subline && <p className="mt-2 text-lg text-[var(--brand-body-secondary)]">{slide.subline}</p>}
             </div>
             {slide.cta && slide.cta.href && slide.cta.label && (
               <Link
@@ -115,7 +115,7 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             type="button"
             aria-label="Previous slide"
             onClick={prev}
-            className="absolute left-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--brand-fg)_40%,transparent)] text-3xl leading-none text-[var(--brand-primary-contrast)] hover:bg-[color:color-mix(in_oklab,var(--brand-fg)_60%,transparent)] ring-1 ring-[color:color-mix(in_oklab,var(--brand-border)_70%,transparent)] shadow-sm cursor-pointer"
+            className="absolute left-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_35%,transparent)] text-3xl leading-none text-[var(--brand-primary)] hover:bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_55%,transparent)] ring-1 ring-[color:color-mix(in_oklab,var(--brand-heading-secondary)_45%,transparent)] shadow-sm cursor-pointer"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="15 18 9 12 15 6" />
@@ -125,7 +125,7 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             type="button"
             aria-label="Next slide"
             onClick={next}
-            className="absolute right-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--brand-fg)_40%,transparent)] text-3xl leading-none text-[var(--brand-primary-contrast)] hover:bg-[color:color-mix(in_oklab,var(--brand-fg)_60%,transparent)] ring-1 ring-[color:color-mix(in_oklab,var(--brand-border)_70%,transparent)] shadow-sm cursor-pointer"
+            className="absolute right-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_35%,transparent)] text-3xl leading-none text-[var(--brand-primary)] hover:bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_55%,transparent)] ring-1 ring-[color:color-mix(in_oklab,var(--brand-heading-secondary)_45%,transparent)] shadow-sm cursor-pointer"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="9 18 15 12 9 6" />
@@ -138,8 +138,8 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
                 onClick={() => goTo(i)}
                 className={`h-2 w-2 rounded-full ${
                   i === index
-                    ? 'bg-[var(--brand-fg)]'
-                    : 'bg-[color:color-mix(in_oklab,var(--brand-fg)_50%,transparent)]'
+                    ? 'bg-[var(--brand-heading-secondary)]'
+                    : 'bg-[color:color-mix(in_oklab,var(--brand-heading-secondary)_40%,transparent)]'
                 }` }
                 aria-label={`Go to slide ${i + 1}`}
               />

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -81,11 +81,12 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
               className="object-cover md:object-contain object-center z-0"
             />
           )}
-          <div className="absolute inset-0 bg-[var(--brand-overlay)] z-10" />
-          <div className="brand-surface relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center">
-            <div className="rounded-xl border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface)_32%,var(--brand-bg)_68%)] px-6 py-4 shadow-xl md:shadow-2xl">
-              <h1 className="text-4xl font-bold tracking-tight">{slide.headline}</h1>
-              {slide.subline && <p className="mt-2 text-lg">{slide.subline}</p>}
+          <div className="relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center">
+            <div className="max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] px-8 py-6 shadow-2xl">
+              <h1 className="text-4xl font-bold tracking-tight text-[var(--brand-heading-primary)]">{slide.headline}</h1>
+              {slide.subline && (
+                <p className="mt-3 text-lg text-[var(--brand-body-primary)]">{slide.subline}</p>
+              )}
             </div>
             {slide.cta && slide.cta.href && slide.cta.label && (
               <Link

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -62,7 +62,7 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
   };
 
   return (
-    <section className="relative isolate overflow-hidden h-[40vh] md:h-[72vh] border border-[var(--brand-border)] border-glow">
+    <section className="relative isolate overflow-hidden h-[40vh] md:h-[72vh] border border-[var(--brand-border)] border-glow bg-[var(--brand-bg)]">
       {slides.map((slide, i) => (
         <div
           key={slide._id}
@@ -82,11 +82,15 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             />
           )}
           <div className="relative z-20 flex h-full w-full flex-col items-center justify-center px-4 text-center">
-            <div className="max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] px-8 py-6 shadow-2xl">
-              <h1 className="text-4xl font-bold tracking-tight text-[var(--brand-heading-primary)]">{slide.headline}</h1>
-              {slide.subline && (
-                <p className="mt-3 text-lg text-[var(--brand-body-primary)]">{slide.subline}</p>
-              )}
+            <div className="max-w-3xl rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-surface)] p-1 shadow-2xl">
+              <div className="rounded-2xl bg-[var(--brand-bg)] px-6 py-6 text-[var(--brand-body-primary)] md:px-10 md:py-8">
+                <h1 className="text-3xl font-bold tracking-tight text-[var(--brand-heading-primary)] md:text-4xl">
+                  {slide.headline}
+                </h1>
+                {slide.subline ? (
+                  <p className="mt-3 text-base text-[var(--brand-body-primary)] md:text-lg">{slide.subline}</p>
+                ) : null}
+              </div>
             </div>
             {slide.cta && slide.cta.href && slide.cta.label && (
               <Link
@@ -95,7 +99,9 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
                 target="_blank"
                 rel="noopener noreferrer"
                 role="button"
-                className={`btn-primary mt-8 text-lg font-semibold uppercase tracking-wide no-underline ${shouldNudge ? 'animate-shake' : ''}`}
+                className={`btn-primary mt-8 text-lg font-semibold uppercase tracking-wide no-underline transition-transform ${
+                  shouldNudge ? 'animate-shake' : ''
+                }`}
               >
                 {slide.cta.label}
               </Link>
@@ -110,7 +116,7 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             type="button"
             aria-label="Previous slide"
             onClick={prev}
-            className="absolute left-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface-contrast)_35%,transparent)] text-3xl leading-none text-[var(--brand-primary)] shadow-sm transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface-contrast)_65%,transparent)]"
+            className="absolute left-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--brand-surface)_40%,transparent)] text-3xl leading-none text-[var(--brand-primary-contrast)] ring-1 ring-[var(--brand-border)] shadow-sm transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface)_60%,transparent)]"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="15 18 9 12 15 6" />
@@ -120,7 +126,7 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
             type="button"
             aria-label="Next slide"
             onClick={next}
-            className="absolute right-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 items-center justify-center rounded-full border border-[var(--brand-border)] bg-[color:color-mix(in_oklab,var(--brand-surface-contrast)_35%,transparent)] text-3xl leading-none text-[var(--brand-primary)] shadow-sm transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface-contrast)_65%,transparent)]"
+            className="absolute right-4 top-1/2 -translate-y-1/2 z-30 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--brand-surface)_40%,transparent)] text-3xl leading-none text-[var(--brand-primary-contrast)] ring-1 ring-[var(--brand-border)] shadow-sm transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface)_60%,transparent)]"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="9 18 15 12 9 6" />
@@ -131,10 +137,10 @@ export default function Hero({ slides, intervalMs = 10000 }: HeroProps) {
               <button
                 key={i}
                 onClick={() => goTo(i)}
-                className={`h-2 w-2 rounded-full transition-colors ${
+                className={`h-2 w-2 rounded-full ${
                   i === index
-                    ? 'bg-[var(--brand-accent)]'
-                    : 'bg-[color:color-mix(in_oklab,var(--brand-accent)_40%,transparent)]'
+                    ? 'bg-[var(--brand-fg)]'
+                    : 'bg-[color:color-mix(in_oklab,var(--brand-fg)_50%,transparent)]'
                 }` }
                 aria-label={`Go to slide ${i + 1}`}
               />

--- a/components/LivestreamPlayer.tsx
+++ b/components/LivestreamPlayer.tsx
@@ -17,8 +17,8 @@ export default function LivestreamPlayer({
 
   return (
     <div>
-      <div className="mb-4 flex items-center gap-2 text-[var(--brand-fg)]">
-        <h1 className="text-2xl font-bold">{current.name}</h1>
+      <div className="mb-4 flex items-center gap-2 text-[var(--brand-body-primary)]">
+        <h1 className="text-2xl font-bold text-[var(--brand-heading-primary)]">{current.name}</h1>
         {current.live?.status === 'streaming' && (
           <span className="rounded bg-[var(--brand-accent)] px-2 py-0.5 text-xs font-semibold uppercase text-[var(--brand-ink)]">
             Live
@@ -35,7 +35,7 @@ export default function LivestreamPlayer({
       </div>
       {videos.length > 0 && (
         <div>
-          <h2 className="text-xl font-semibold text-[var(--brand-fg)]">Recent</h2>
+          <h2 className="text-xl font-semibold text-[var(--brand-heading-primary)]">Recent</h2>
           <div className="relative mt-4">
             <div className="flex gap-4 overflow-x-auto pb-4 snap-x snap-mandatory">
               {videos.map((video) => {

--- a/components/MinistryCard.tsx
+++ b/components/MinistryCard.tsx
@@ -46,7 +46,7 @@ export function MinistryCard({
         )}
         <div className="flex min-w-0 flex-1 p-4">
           <div className="flex w-full flex-col">
-            <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{ministry.name}</h3>
+            <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{ministry.name}</h3>
             <p className="mt-2 text-sm leading-relaxed text-[var(--brand-accent)]">
               {ministry.description}
             </p>

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -21,7 +21,11 @@ interface MobileMenuProps {
 }
 
 function linkClasses(active: boolean) {
-  return `block ${active ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)]`;
+  return `block ${
+    active
+      ? "text-[var(--brand-heading-secondary)]"
+      : "text-[var(--brand-body-secondary)]"
+  } hover:text-[var(--brand-heading-secondary)] focus:text-[var(--brand-heading-secondary)]`;
 }
 
 
@@ -89,7 +93,13 @@ function MobileMenuInner({ primaryNav, trailingNav }: MobileMenuProps, ref: Reac
                 <Disclosure defaultOpen={pathname.startsWith("/about")}>
                   {({ open: aboutOpen }) => (
                     <div>
-                      <Disclosure.Button className={`${pathname.startsWith("/about") ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} w-full inline-flex items-center justify-between hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)]`}>
+                      <Disclosure.Button
+                        className={`${
+                          pathname.startsWith("/about")
+                            ? "text-[var(--brand-heading-secondary)]"
+                            : "text-[var(--brand-body-secondary)]"
+                        } w-full inline-flex items-center justify-between hover:text-[var(--brand-heading-secondary)] focus:text-[var(--brand-heading-secondary)]`}
+                      >
                         <span>About</span>
                         <svg
                           className={`h-4 w-4 transition-transform duration-150 ${aboutOpen ? "rotate-180" : "rotate-0"}`}
@@ -151,7 +161,13 @@ function MobileMenuInner({ primaryNav, trailingNav }: MobileMenuProps, ref: Reac
                 <Disclosure defaultOpen={pathname.startsWith("/contact")}>
                   {({ open: contactOpen }) => (
                     <div>
-                      <Disclosure.Button className={`${pathname.startsWith("/contact") ? "text-[var(--brand-alt)]" : "text-[var(--brand-accent)]"} w-full inline-flex items-center justify-between hover:text-[var(--brand-alt)] focus:text-[var(--brand-alt)]`}>
+                      <Disclosure.Button
+                        className={`${
+                          pathname.startsWith("/contact")
+                            ? "text-[var(--brand-heading-secondary)]"
+                            : "text-[var(--brand-body-secondary)]"
+                        } w-full inline-flex items-center justify-between hover:text-[var(--brand-heading-secondary)] focus:text-[var(--brand-heading-secondary)]`}
+                      >
                         <span>Contact</span>
                         <svg
                           className={`h-4 w-4 transition-transform duration-150 ${contactOpen ? "rotate-180" : "rotate-0"}`}

--- a/components/PrayerRequestForm.tsx
+++ b/components/PrayerRequestForm.tsx
@@ -112,97 +112,96 @@ export default function PrayerRequestForm({
   const isLoading = status === "loading";
 
   return (
-    <div className="mt-8 max-w-md mx-auto">
+    <div className="mx-auto w-full max-w-2xl">
       {status === "success" ? (
-        <p className="text-center animate-fade-in-up" role="status">
+        <p className="text-center text-lg font-semibold text-[var(--brand-heading-primary)] animate-fade-in-up" role="status">
           Thank you for sharing your request. Our team will be praying with you.
         </p>
       ) : (
-        <form onSubmit={handleSubmit} className="space-y-6 animate-fade-in-up">
-          <div className="relative">
-            <input
-              id="prayer-name"
-              type="text"
-              required
-              placeholder="Your name"
-              value={values.name}
-              onChange={handleChange("name")}
-              className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-5 pb-3 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
-            />
-            <label
-              htmlFor="prayer-name"
-              className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-muted)] transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-hover:top-1.5 peer-hover:translate-y-0 peer-hover:text-xs peer-hover:bg-transparent peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-accent)] peer-focus:bg-[var(--brand-surface)]"
-            >
-              Name
-            </label>
-          </div>
-
-          <div className="relative">
-            <input
-              id="prayer-email"
-              type="email"
-              required
-              placeholder="Your email"
-              value={values.email}
-              onChange={handleChange("email")}
-              className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-5 pb-3 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
-            />
-            <label
-              htmlFor="prayer-email"
-              className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-muted)] transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-hover:top-1.5 peer-hover:translate-y-0 peer-hover:text-xs peer-hover:bg-transparent peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-accent)] peer-focus:bg-[var(--brand-surface)]"
-            >
-              Email
-            </label>
-          </div>
-
-          <div className="relative">
-            <textarea
-              id="prayer-request"
-              required
-              rows={5}
-              placeholder="Your prayer request"
-              value={values.request}
-              onChange={handleChange("request")}
-              className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface)] px-4 pt-6 pb-4 placeholder-transparent focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] transition-colors"
-            />
-            <label
-              htmlFor="prayer-request"
-              className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-muted)] transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-hover:top-1.5 peer-hover:translate-y-0 peer-hover:text-xs peer-hover:bg-transparent peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-accent)] peer-focus:bg-[var(--brand-surface)]"
-            >
-              Prayer Request
-            </label>
-          </div>
-
-          {status === "error" && errorMessage ? (
-            <p
-              className="text-sm text-center text-[var(--brand-accent)]"
-              role="alert"
-            >
-              {errorMessage}
-            </p>
-          ) : null}
-
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="btn-outline-cta pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md cursor-pointer hover:shadow-lg transform transition-transform hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 focus:ring-offset-[var(--brand-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
-          >
-            <span>{isLoading ? "Sending..." : "Send Request"}</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-              className="h-5 w-5"
-            >
-              <path
-                fillRule="evenodd"
-                d="M10.293 3.293a1 1 0 011.414 0l5 5a1 1 0 010 1.414l-5 5a1 1 0 11-1.414-1.414L13.586 11H4a1 1 0 110-2h9.586l-3.293-3.293a1 1 0 010-1.414z"
-                clipRule="evenodd"
+        <div className="brand-surface space-y-6 rounded-2xl border-2 border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 shadow-lg animate-fade-in-up">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="relative">
+              <input
+                id="prayer-name"
+                type="text"
+                required
+                placeholder="Your name"
+                value={values.name}
+                onChange={handleChange("name")}
+                className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] px-4 pt-5 pb-3 text-[var(--brand-body-primary)] placeholder-transparent focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
               />
-            </svg>
-          </button>
-        </form>
+              <label
+                htmlFor="prayer-name"
+                className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface-contrast)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-body-secondary)] transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-heading-primary)]"
+              >
+                Name
+              </label>
+            </div>
+
+            <div className="relative">
+              <input
+                id="prayer-email"
+                type="email"
+                required
+                placeholder="Your email"
+                value={values.email}
+                onChange={handleChange("email")}
+                className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] px-4 pt-5 pb-3 text-[var(--brand-body-primary)] placeholder-transparent focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+              />
+              <label
+                htmlFor="prayer-email"
+                className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface-contrast)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-body-secondary)] transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-heading-primary)]"
+              >
+                Email
+              </label>
+            </div>
+
+            <div className="relative">
+              <textarea
+                id="prayer-request"
+                required
+                rows={5}
+                placeholder="Your prayer request"
+                value={values.request}
+                onChange={handleChange("request")}
+                className="peer w-full rounded-md border border-[var(--brand-border)] bg-[var(--brand-surface-contrast)] px-4 pt-6 pb-4 text-[var(--brand-body-primary)] placeholder-transparent focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)]"
+              />
+              <label
+                htmlFor="prayer-request"
+                className="pointer-events-none absolute left-4 top-3 z-[1] bg-[var(--brand-surface-contrast)] px-1 origin-[0] -translate-y-1/2 text-sm text-[var(--brand-body-secondary)] transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-[&:not(:placeholder-shown)]:top-1.5 peer-[&:not(:placeholder-shown)]:translate-y-0 peer-[&:not(:placeholder-shown)]:text-xs peer-focus:top-1.5 peer-focus:translate-y-0 peer-focus:text-xs peer-focus:text-[var(--brand-heading-primary)]"
+              >
+                Prayer Request
+              </label>
+            </div>
+
+            {status === "error" && errorMessage ? (
+              <p className="text-center text-sm font-semibold text-[var(--brand-heading-primary)]" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="btn-primary pulse-border-soft w-full inline-flex items-center justify-center gap-2 px-6 py-4 shadow-md cursor-pointer hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <span>{isLoading ? "Sending..." : "Send Request"}</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+                className="h-5 w-5"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10.293 3.293a1 1 0 011.414 0l5 5a1 1 0 010 1.414l-5 5a1 1 0 11-1.414-1.414L13.586 11H4a1 1 0 110-2h9.586l-3.293-3.293a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </form>
+        </div>
       )}
     </div>
   );

--- a/components/SocialCTA.tsx
+++ b/components/SocialCTA.tsx
@@ -111,12 +111,12 @@ function SocialCard({ href, label, description, Icon }: SocialItem) {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex h-full flex-col items-center justify-center gap-2 rounded-full border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 text-center transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface)_85%,white_15%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] no-underline hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
+      className="group brand-surface flex h-full flex-col items-center justify-center gap-3 rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-surface)] p-6 text-center transition-all hover:-translate-y-1 hover:shadow-2xl hover:bg-[color:color-mix(in_oklab,var(--brand-surface)_90%,white_10%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-surface)] no-underline hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
       aria-label={description ? `${label}. ${description}` : label}
     >
-      <Icon className="h-8 w-8 text-[var(--brand-accent)] transition-all group-hover:scale-105 group-hover:text-[var(--brand-primary-contrast)]" />
-      <h3 className="text-base font-semibold text-[var(--brand-accent)] group-hover:text-[var(--brand-primary-contrast)]">{label}</h3>
-      {description ? <p className="text-sm text-[var(--brand-alt)]">{description}</p> : null}
+      <Icon className="h-8 w-8 text-[var(--brand-heading-secondary)] drop-shadow-sm transition-all group-hover:scale-105" />
+      <h3 className="text-base font-semibold text-[var(--brand-heading-secondary)]">{label}</h3>
+      {description ? <p className="text-sm text-[var(--brand-body-secondary)]">{description}</p> : null}
     </a>
   );
 }
@@ -187,9 +187,9 @@ export default async function SocialCTA() {
           </div>
         )}
         {embedUrl ? (
-          <div className="relative aspect-video w-full overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-bg)] md:col-start-2 md:row-span-2">
+          <div className="relative aspect-video w-full overflow-hidden rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-bg)] shadow-xl md:col-start-2 md:row-span-2">
             {latest && (
-              <div className="absolute left-2 top-2 rounded bg-[var(--brand-primary)]/80 px-2 py-1 text-sm font-semibold text-[var(--brand-primary-contrast)]">
+              <div className="absolute left-3 top-3 rounded-full bg-[var(--brand-primary)]/85 px-3 py-1 text-sm font-semibold text-[var(--brand-primary-contrast)] shadow">
                 {latest.published.toLocaleDateString("en-US", {
                   month: "long",
                   day: "numeric",
@@ -213,7 +213,7 @@ export default async function SocialCTA() {
               href={`https://www.youtube.com/channel/${channelId}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="relative aspect-video w-full overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] flex items-center justify-center group transition-colors hover:bg-[color:color-mix(in_oklab,var(--brand-surface)_85%,white_15%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] no-underline hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)] md:col-start-2 md:row-span-2"
+              className="brand-surface relative aspect-video w-full overflow-hidden rounded-3xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-surface)] flex items-center justify-center group transition-all hover:-translate-y-1 hover:shadow-2xl hover:bg-[color:color-mix(in_oklab,var(--brand-surface)_90%,white_10%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-surface)] no-underline hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)] md:col-start-2 md:row-span-2"
               aria-label="Visit our YouTube channel"
             >
               {settings?.logo && (
@@ -226,11 +226,11 @@ export default async function SocialCTA() {
                 />
               )}
               <div className="relative z-10 flex flex-col items-center gap-3">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-12 w-12 text-[var(--brand-accent)] drop-shadow-sm transition-transform group-hover:scale-105 group-hover:text-[var(--brand-primary-contrast)]" fill="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-12 w-12 text-[var(--brand-heading-secondary)] drop-shadow-sm transition-transform group-hover:scale-105" fill="currentColor">
                   <path d="M23.5 6.2a4 4 0 0 0-2.8-2.8C18.9 3 12 3 12 3s-6.9 0-8.7.4A4 4 0 0 0 .5 6.2 41.3 41.3 0 0 0 0 12a41.3 41.3 0 0 0 .5 5.8 4 4 0 0 0 2.8 2.8C5.1 21 12 21 12 21s6.9 0 8.7-.4a4 4 0 0 0 2.8-2.8A41.3 41.3 0 0 0 24 12a41.3 41.3 0 0 0-.5-5.8zM9.6 15.5V8.5L15.8 12l-6.2 3.5z"/>
                 </svg>
                 <div className="text-center">
-                  <h3 className="text-base font-semibold text-[var(--brand-accent)] group-hover:text-[var(--brand-primary-contrast)]">Watch on YouTube</h3>
+                  <h3 className="text-base font-semibold text-[var(--brand-heading-secondary)]">Watch on YouTube</h3>
                 </div>
               </div>
             </a>

--- a/components/StaffCard.tsx
+++ b/components/StaffCard.tsx
@@ -30,7 +30,7 @@ export function StaffCard({
   }
   return (
     <div
-      className="card brand-surface relative flex h-full flex-col items-center overflow-hidden rounded-lg text-center"
+      className="card relative flex h-full flex-col items-center overflow-hidden rounded-lg text-center"
       style={style}
     >
       {staff.image && (
@@ -43,14 +43,14 @@ export function StaffCard({
         />
       )}
       <div className="p-4">
-        <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{staff.name}</h3>
-        <p className="mt-1 text-sm text-[var(--brand-body-secondary)]">{staff.role}</p>
+        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{staff.name}</h3>
+        <p className="mt-1 text-sm text-[var(--brand-muted)]">{staff.role}</p>
         {staff.email && (
           <a
             href={`mailto:${staff.email}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-2 block text-sm font-medium text-[var(--brand-body-secondary)] underline decoration-[var(--brand-body-secondary)] underline-offset-4 hover:opacity-90"
+            className="mt-2 block text-sm font-medium text-[var(--brand-accent)] hover:underline hover:text-[var(--brand-primary-contrast)]"
           >
             {staff.email}
           </a>

--- a/components/StaffCard.tsx
+++ b/components/StaffCard.tsx
@@ -43,7 +43,7 @@ export function StaffCard({
         />
       )}
       <div className="p-4">
-        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{staff.name}</h3>
+        <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{staff.name}</h3>
         <p className="mt-1 text-sm text-[var(--brand-muted)]">{staff.role}</p>
         {staff.email && (
           <a

--- a/components/StaffCard.tsx
+++ b/components/StaffCard.tsx
@@ -30,7 +30,7 @@ export function StaffCard({
   }
   return (
     <div
-      className="card relative flex h-full flex-col items-center overflow-hidden rounded-lg text-center"
+      className="card brand-surface relative flex h-full flex-col items-center overflow-hidden rounded-lg text-center"
       style={style}
     >
       {staff.image && (
@@ -44,13 +44,13 @@ export function StaffCard({
       )}
       <div className="p-4">
         <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{staff.name}</h3>
-        <p className="mt-1 text-sm text-[var(--brand-muted)]">{staff.role}</p>
+        <p className="mt-1 text-sm text-[var(--brand-body-secondary)]">{staff.role}</p>
         {staff.email && (
           <a
             href={`mailto:${staff.email}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-2 block text-sm font-medium text-[var(--brand-accent)] hover:underline hover:text-[var(--brand-primary-contrast)]"
+            className="mt-2 block text-sm font-medium text-[var(--brand-body-secondary)] underline decoration-[var(--brand-body-secondary)] underline-offset-4 hover:opacity-90"
           >
             {staff.email}
           </a>

--- a/components/VisitorCTA.tsx
+++ b/components/VisitorCTA.tsx
@@ -71,10 +71,10 @@ function ActionCard({ action, delay }: { action: typeof actions[number]; delay: 
       style={{ animationDelay: delay }}
     >
       <div className="flex items-center gap-3">
-        <Icon className="h-8 w-8 text-[var(--brand-accent)] transition-transform group-hover:rotate-6" />
-        <h3 className="text-lg font-semibold text-[var(--brand-surface-contrast)]">{action.title}</h3>
+        <Icon className="h-8 w-8 text-[var(--brand-heading-secondary)] transition-transform group-hover:rotate-6" />
+        <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{action.title}</h3>
       </div>
-      <p className="text-[var(--brand-accent)]">{action.description}</p>
+      <p className="text-[var(--brand-body-secondary)]">{action.description}</p>
     </a>
   );
 }

--- a/components/VisitorCTA.tsx
+++ b/components/VisitorCTA.tsx
@@ -67,11 +67,11 @@ function ActionCard({ action, delay }: { action: typeof actions[number]; delay: 
   return (
     <a
       href={action.href}
-      className="group flex flex-col items-start gap-4 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-surface)] p-6 opacity-0 animate-fade-in-up transform transition duration-300 hover:-translate-y-1 hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] no-underline transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
+      className="group brand-surface flex flex-col items-start gap-4 rounded-2xl border-2 border-[var(--brand-border-strong)] bg-[var(--brand-surface)] p-6 opacity-0 animate-fade-in-up transform transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-surface)] no-underline transition-colors hover:border-[var(--brand-accent)] focus-visible:border-[var(--brand-accent)]"
       style={{ animationDelay: delay }}
     >
       <div className="flex items-center gap-3">
-        <Icon className="h-8 w-8 text-[var(--brand-heading-secondary)] transition-transform group-hover:rotate-6" />
+        <Icon className="h-8 w-8 text-[var(--brand-heading-secondary)] drop-shadow-sm transition-transform group-hover:rotate-6" />
         <h3 className="text-lg font-semibold text-[var(--brand-heading-secondary)]">{action.title}</h3>
       </div>
       <p className="text-[var(--brand-body-secondary)]">{action.description}</p>


### PR DESCRIPTION
## Summary
- realign global theme CSS custom properties around a white light-mode surface and complementary dark-mode palette
- update utility tokens and the assistant UI to consume the refreshed surface and foreground colors
- retheme the footer subscribe button to match the new primary styling

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5666437a0832cba941ecfda2a6793