### PR TITLE
Enhance event detail images with loaders and lightbox

### DIFF
--- a/components/eventDetailSections/EventImage.tsx
+++ b/components/eventDetailSections/EventImage.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import Image, { type ImageProps } from "next/image";
+import { useEffect, useRef, useState } from "react";
+
+type EventImageProps = {
+  /**
+   * Additional classes applied to the clickable wrapper element.
+   */
+  containerClassName?: string;
+  /**
+   * Additional classes applied to the internal image wrapper div.
+   * This should include sizing styles (e.g. height/width) when using `fill`.
+   */
+  wrapperClassName?: string;
+  /**
+   * Accessible label for the button that opens the lightbox. Defaults to a
+   * string derived from the image alt text when not provided.
+   */
+  openButtonLabel?: string;
+} & ImageProps;
+
+export default function EventImage({
+  containerClassName,
+  wrapperClassName,
+  className,
+  openButtonLabel,
+  alt,
+  ...imageProps
+}: EventImageProps) {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLightboxLoaded, setIsLightboxLoaded] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const triggerButtonRef = useRef<HTMLButtonElement | null>(null);
+  const wasOpen = useRef(false);
+
+  const derivedLabel = openButtonLabel || (alt ? `View larger image for ${alt}` : "View larger image");
+
+  const handleLoad = () => {
+    setIsLoaded(true);
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsLightboxLoaded(false);
+      const handleKeydown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          setIsOpen(false);
+        }
+      };
+
+      window.addEventListener("keydown", handleKeydown);
+      const button = closeButtonRef.current;
+      button?.focus({ preventScroll: true });
+      wasOpen.current = true;
+
+      return () => {
+        window.removeEventListener("keydown", handleKeydown);
+      };
+    }
+
+    if (wasOpen.current) {
+      triggerButtonRef.current?.focus({ preventScroll: true });
+      wasOpen.current = false;
+    }
+
+    return undefined;
+  }, [isOpen]);
+
+  return (
+    <>
+      <button
+        ref={triggerButtonRef}
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className={`group relative block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--brand-accent)] ${containerClassName ?? ""}`}
+        aria-label={derivedLabel}
+      >
+        <div className={`relative ${wrapperClassName ?? ""}`}>
+          <Image
+            {...imageProps}
+            alt={alt}
+            className={`${className ?? ""} ${isLoaded ? "opacity-100" : "opacity-0"}`.trim()}
+            onLoad={handleLoad}
+            onLoadingComplete={handleLoad}
+          />
+          {!isLoaded && (
+            <div className="absolute inset-0 flex items-center justify-center bg-[var(--brand-overlay-muted)]">
+              <span
+                className="h-10 w-10 animate-spin rounded-full border-2 border-[color:color-mix(in_oklab,var(--brand-fg)_75%,transparent)] border-t-transparent"
+                role="status"
+                aria-label="Loading image"
+              />
+            </div>
+          )}
+        </div>
+      </button>
+
+      {isOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-[1000] flex items-center justify-center bg-[color:color-mix(in_oklab,var(--brand-ink)_85%,transparent)] p-4"
+          onClick={() => setIsOpen(false)}
+        >
+          <div
+            className="relative flex h-full w-full max-h-[90vh] max-w-5xl flex-col"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex justify-end pb-2">
+              <button
+                ref={closeButtonRef}
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="rounded bg-[var(--brand-accent)] px-3 py-1 text-sm font-medium text-[var(--brand-ink)] transition hover:bg-[color:color-mix(in_oklab,var(--brand-accent)_85%,white_15%)]"
+              >
+                Close
+              </button>
+            </div>
+            <div className="relative flex-1">
+              <Image
+                src={imageProps.src}
+                alt={alt}
+                fill
+                className={`object-contain ${isLightboxLoaded ? "opacity-100" : "opacity-0"}`}
+                sizes="100vw"
+                onLoad={() => setIsLightboxLoaded(true)}
+                onLoadingComplete={() => setIsLightboxLoaded(true)}
+              />
+              {!isLightboxLoaded && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <span
+                    className="h-12 w-12 animate-spin rounded-full border-2 border-[color:color-mix(in_oklab,var(--brand-fg)_75%,transparent)] border-t-transparent"
+                    role="status"
+                    aria-label="Loading image"
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/eventDetailSections/GallerySection.tsx
+++ b/components/eventDetailSections/GallerySection.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import EventImage from "./EventImage";
 
 interface GalleryImage {
   _key: string;
@@ -13,29 +13,33 @@ interface GallerySectionProps {
 
 export default function GallerySection({ layout = 'grid', images }: GallerySectionProps) {
   if (!images || images.length === 0) return null;
-  return layout === 'carousel' ? (
+  return layout === "carousel" ? (
     <div className="flex gap-4 overflow-x-auto py-4">
       {images.map((img) => (
-        <Image
+        <EventImage
           key={img._key}
           src={img.url}
-          alt={img.alt || ''}
+          alt={img.alt || ""}
           width={600}
           height={400}
-          className="h-60 w-auto max-w-full flex-shrink-0 rounded border border-[var(--brand-border)] object-cover"
+          containerClassName="flex-shrink-0"
+          wrapperClassName="h-60 w-auto max-w-full overflow-hidden rounded border border-[var(--brand-border)]"
+          className="h-full w-full object-cover"
         />
       ))}
     </div>
   ) : (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
       {images.map((img) => (
-        <Image
+        <EventImage
           key={img._key}
           src={img.url}
-          alt={img.alt || ''}
+          alt={img.alt || ""}
           width={600}
           height={400}
-          className="h-48 w-full rounded border border-[var(--brand-border)] object-cover"
+          containerClassName="w-full"
+          wrapperClassName="h-48 w-full overflow-hidden rounded border border-[var(--brand-border)]"
+          className="h-full w-full object-cover"
         />
       ))}
     </div>

--- a/components/eventDetailSections/HeroSection.tsx
+++ b/components/eventDetailSections/HeroSection.tsx
@@ -1,5 +1,6 @@
-import Image from 'next/image';
-import { PortableText } from '@portabletext/react';
+import { PortableText } from "@portabletext/react";
+
+import EventImage from "./EventImage";
 
 interface HeroSectionProps {
   title: string;
@@ -22,53 +23,83 @@ export default function HeroSection({
   subscribeUrl,
   date,
 }: HeroSectionProps) {
+  const hasAdditionalContent =
+    !!eventLogo ||
+    !!section.headline ||
+    !!section.subheadline ||
+    !!body ||
+    !!subscribeUrl;
+  const onlyBackgroundImage = !!section.backgroundImage && !hasAdditionalContent;
   const heading = section.headline || title;
+  const heroImageAlt = section.subheadline || section.headline || `${title} background`;
+
   return (
-    <section className="space-y-4">
+    <section className={`space-y-4 ${onlyBackgroundImage ? "text-center" : ""}`}>
       {section.backgroundImage && (
-        <div className="relative h-64 w-full overflow-hidden rounded">
-          <Image
-            src={section.backgroundImage}
-            alt=""
-            fill
-            className="object-cover"
-            sizes="100vw"
-          />
-        </div>
+        <EventImage
+          src={section.backgroundImage}
+          alt={heroImageAlt}
+          fill
+          containerClassName={onlyBackgroundImage ? "mx-auto max-w-4xl" : "w-full"}
+          wrapperClassName={`${onlyBackgroundImage ? "h-72 sm:h-96" : "h-64"} w-full overflow-hidden rounded`}
+          className="object-cover object-center"
+          sizes="100vw"
+          openButtonLabel={heroImageAlt ? `View larger image for ${heroImageAlt}` : undefined}
+        />
       )}
-      <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-4">
-          {eventLogo && (
-            <div className="relative h-20 w-20 sm:h-24 sm:w-24">
-              <Image src={eventLogo.url} alt={eventLogo.alt || ''} fill className="object-contain" />
-            </div>
-          )}
-          <div>
-            <h1 className="text-3xl font-bold text-[var(--brand-accent)]">{heading}</h1>
-            {!subscribeUrl && date && heading && (
-              <p className="text-[var(--brand-fg)]">{date}</p>
+
+      {(heading || eventLogo || body || subscribeUrl || date || section.subheadline) && (
+        <div
+          className={`flex flex-col gap-4 ${
+            onlyBackgroundImage ? "items-center" : "items-start sm:flex-row sm:items-center sm:justify-between"
+          }`}
+        >
+          <div className={`flex items-center gap-4 ${onlyBackgroundImage ? "justify-center" : ""}`}>
+            {eventLogo && (
+              <EventImage
+                src={eventLogo.url}
+                alt={eventLogo.alt || `${title} logo`}
+                fill
+                containerClassName="relative h-20 w-20 sm:h-24 sm:w-24"
+                wrapperClassName="h-full w-full"
+                className="object-contain"
+                sizes="96px"
+                openButtonLabel={eventLogo.alt ? `View larger image for ${eventLogo.alt}` : `${title} logo`}
+              />
+            )}
+            {(heading || date) && (
+              <div className={onlyBackgroundImage ? "text-center" : ""}>
+                {heading && <h1 className="text-3xl font-bold text-[var(--brand-accent)]">{heading}</h1>}
+                {!subscribeUrl && date && heading && (
+                  <p className="text-[var(--brand-fg)]">{date}</p>
+                )}
+              </div>
             )}
           </div>
+          {subscribeUrl && (
+            <div className={`flex items-center gap-4 ${onlyBackgroundImage ? "justify-center" : "sm:text-right"}`}>
+              {date && <p className="text-[var(--brand-fg)]">{date}</p>}
+              <a
+                href={subscribeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded bg-[var(--brand-accent)] px-4 py-2 text-[var(--brand-ink)] hover:bg-[var(--brand-accent)]/90"
+              >
+                Subscribe
+              </a>
+            </div>
+          )}
         </div>
-        {subscribeUrl && (
-          <div className="flex items-center gap-4 sm:text-right">
-            {date && <p className="text-[var(--brand-fg)]">{date}</p>}
-            <a
-              href={subscribeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded bg-[var(--brand-accent)] px-4 py-2 text-[var(--brand-ink)] hover:bg-[var(--brand-accent)]/90"
-            >
-              Subscribe
-            </a>
-          </div>
-        )}
-      </div>
-      {section.subheadline && (
-        <p className="text-lg text-[var(--brand-fg)]">{section.subheadline}</p>
       )}
+
+      {section.subheadline && (
+        <p className={`text-lg text-[var(--brand-fg)] ${onlyBackgroundImage ? "text-center" : ""}`}>
+          {section.subheadline}
+        </p>
+      )}
+
       {body && (
-        <div className="mx-auto max-w-prose" style={{ color: 'var(--brand-fg)' }}>
+        <div className="mx-auto max-w-prose" style={{ color: "var(--brand-fg)" }}>
           <PortableText value={body} />
         </div>
       )}


### PR DESCRIPTION
## Summary
- add a reusable client EventImage component that shows branded loaders, keyboard support, and a lightbox popup for event imagery
- update the hero and gallery sections to use the new component so hero backgrounds, logos, and gallery items center appropriately and open in the popup
- center hero-only background imagery when it is the sole hero content while keeping layout responsive

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4569c75c8832c9ecaf103c43fb1c5