### PR TITLE
Add sitemap and robots metadata routes

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,28 @@
+import type {MetadataRoute} from 'next';
+
+const DEFAULT_SITE_URL = 'https://gptchurch.org';
+
+function getSiteUrl() {
+  const envUrl =
+    process.env.NEXT_PUBLIC_SITE_ORIGIN ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_SITE_BASE_URL;
+
+  const normalized = envUrl?.replace(/\/$/, '') || DEFAULT_SITE_URL;
+  return normalized;
+}
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl();
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,78 @@
+import type {MetadataRoute} from 'next';
+
+const DEFAULT_SITE_URL = 'https://gptchurch.org';
+
+function getSiteUrl() {
+  const envUrl =
+    process.env.NEXT_PUBLIC_SITE_ORIGIN ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_SITE_BASE_URL;
+
+  const normalized = envUrl?.replace(/\/$/, '') || DEFAULT_SITE_URL;
+  return normalized;
+}
+
+const STATIC_PATHS: readonly string[] = [
+  '/',
+  '/about/beliefs',
+  '/about/mission-statement',
+  '/about/staff',
+  '/building-use',
+  '/contact',
+  '/contact/prayer-requests',
+  '/events',
+  '/faq',
+  '/giving',
+  '/livestreams',
+  '/ministries',
+  '/newsletter',
+  '/privacy',
+  '/services',
+  '/terms',
+  '/visit',
+  '/volunteer',
+];
+
+async function getEventEntries(
+  siteUrl: string,
+  lastModified: Date
+): Promise<MetadataRoute.Sitemap> {
+  const hasSanityConfig =
+    Boolean(process.env.SANITY_STUDIO_PROJECT_ID) &&
+    Boolean(process.env.SANITY_STUDIO_DATASET);
+
+  if (!hasSanityConfig) {
+    return [];
+  }
+
+  try {
+    const {eventDetailLinks} = await import('@/lib/queries');
+    const links = await eventDetailLinks();
+    return links
+      .filter((link) => Boolean(link.slug))
+      .map((link) => ({
+        url: `${siteUrl}/events/${link.slug}`,
+        lastModified,
+      }));
+  } catch (error) {
+    try {
+      // eslint-disable-next-line no-console
+      console.error('[sitemap] Failed to load event slugs', error);
+    } catch {}
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const siteUrl = getSiteUrl();
+  const lastModified = new Date();
+
+  const staticEntries: MetadataRoute.Sitemap = STATIC_PATHS.map((path) => ({
+    url: `${siteUrl}${path}`,
+    lastModified,
+  }));
+
+  const eventEntries = await getEventEntries(siteUrl, lastModified);
+
+  return [...staticEntries, ...eventEntries];
+}


### PR DESCRIPTION
## Summary
- add a Next.js sitemap metadata route that enumerates static pages and published event detail URLs
- provide a robots metadata route that advertises the sitemap and derives the host from environment configuration
- guard the sitemap route against missing Sanity configuration so it can respond even without CMS credentials

## Testing
- npm run dev
- curl http://localhost:3000/sitemap.xml
- curl http://localhost:3000/robots.txt

------
https://chatgpt.com/codex/tasks/task_e_68d60ab4df74832cb6c4764b20e07b16